### PR TITLE
Handle null effective area for a given bin when computing the effective area.

### DIFF
--- a/cosipy/response/DetectorResponse.py
+++ b/cosipy/response/DetectorResponse.py
@@ -1,3 +1,8 @@
+import logging
+logger = logging.getLogger(__name__)
+
+import numpy as np
+
 from copy import deepcopy
 
 from histpy import Histogram, Axes, Axis
@@ -107,6 +112,12 @@ class DetectorResponse(Histogram):
         norm[0] = 1*norm.unit if norm[0] == 0 else norm[0]
         norm[-1] = 1*norm.unit if norm[-1] == 0 else norm[-1]
 
+        # Avoid another 0/0 is the effective area is null for some bins
+        if np.any(norm == 0):
+            norm[norm == 0] = 1*norm.unit
+
+            logger.warn("Null effective area, cannot properly compute dispersion matrix.")
+        
         # "Broadcast" such that it has the compatible dimensions with the 2D matrix
         norm = spec.expand_dims(norm, 'Ei')
         


### PR DESCRIPTION
The energy dispersion matrix equals the detector response matrix divided by the effective area. If the effective area is 0 for a given energy bin then the dispersion doesn't make much sense, since the detector says there is no chance to detect that energy to start with. This however raises an error due to 0/0 operation, which I now handle as a special case.

Now it will result in something like this, with 0's where the effective area is 0.

<img width="651" alt="Screen Shot 2023-02-01 at 2 14 37 PM" src="https://user-images.githubusercontent.com/34419239/216140735-bd5b4d24-207a-4e2f-842a-246f304df170.png">
