### PR TITLE
Using Orientation_file class in COSILike

### DIFF
--- a/cosipy/threeml/COSILike.py
+++ b/cosipy/threeml/COSILike.py
@@ -5,7 +5,8 @@ from threeML.exceptions.custom_exceptions import FitFailed
 from astromodels import Parameter
 
 from cosipy.response.FullDetectorResponse import FullDetectorResponse
-from scoords import SpacecraftFrame
+from cosipy.coordinates.orientation import Orientation_file
+from scoords import SpacecraftFrame, Attitude
 
 from mhealpy import HealpixMap
 
@@ -175,17 +176,18 @@ class COSILike(PluginPrototype):
                                     coordsys = SpacecraftFrame())
 
         # Get timestamps and attitude values
-        timestamps, attitudes = zip(*self._sc_orientation)
-            
-        for attitude,duration in zip(attitudes[:-1], np.diff(timestamps)):
+        timestamps = self._sc_orientation.get_time()
+        attitudes = self._sc_orientation.get_attitude().as_matrix()
 
-            local_coord = coord.transform_to(SpacecraftFrame(attitude = attitude))
+        for attitude,duration in zip(attitudes[:-1], np.diff(timestamps.unix)):
+
+            local_coord = coord.transform_to(SpacecraftFrame(attitude = Attitude.from_matrix(attitude)))
 
             # Here we add duration in between timestamps using interpolations
             pixels, weights = dwell_time_map.get_interp_weights(local_coord)
 
             for p,w in zip(pixels, weights):
-                dwell_time_map[p] += w*duration.to(u.s)
+                dwell_time_map[p] += w*(duration*u.s)
                 
         return dwell_time_map
  


### PR DESCRIPTION
Small changes in COSILike.py to read in an Orientation_file class instead of arrays