### PR TITLE
Fixing SPARSE attributes error in FullDetectorResponse

### DIFF
--- a/cosipy/response/FullDetectorResponse.py
+++ b/cosipy/response/FullDetectorResponse.py
@@ -94,7 +94,10 @@ class FullDetectorResponse(HealpixBase):
 
         new._unit = u.Unit(new._drm.attrs['UNIT'])
         
-        new._sparse = new._drm.attrs['SPARSE']
+        try:
+             new._sparse = new._drm.attrs['SPARSE']
+        except KeyError:
+             new._sparse = True
 
         # Axes
         axes = []


### PR DESCRIPTION
Quick fix figured out by Eliza to resolve the "SPARSE" attribute error in DetectorResponse.ipyb. This is adding a try except for a KeyError.