### PR TITLE
Update response filename in SpectralFit.py

### DIFF
--- a/docs/tutorials/spectral_fits/continuum_fit/SpectralFit.ipynb
+++ b/docs/tutorials/spectral_fits/continuum_fit/SpectralFit.ipynb
@@ -414,10 +414,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file_list = ['bkg_binned_data_full.hdf5','grb_binned_data.hdf5','grb_bkg_binned_data.hdf5','FlatContinuumIsotropic.LowRes.binnedimaging.imagingresponse.area.nside8.cosipy.h5']\n",
+    "file_list = ['bkg_binned_data_full.hdf5','grb_binned_data.hdf5','grb_bkg_binned_data.hdf5','FlatContinuumIsotropic.LowRes.binnedimaging.imagingresponse.area.nside8.cosipy.h5.zip']\n",
     "\n",
     "for each in file_list:\n",
     "    os.system(\"AWS_ACCESS_KEY_ID=GBAL6XATQZNRV3GFH9Y4 AWS_SECRET_ACCESS_KEY=GToOczY5hGX3sketNO2fUwiq4DJoewzIgvTCHoOv aws s3api get-object  --bucket cosi-pipeline-public --key ComptonSphere/mini-DC2/%s --endpoint-url=https://s3.us-west-1.wasabisys.com %s\" %(each,each))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4c4ab40-c6a1-4885-8216-fb631dab99e7",
+   "metadata": {},
+   "source": [
+    "**Note: `FlatContinuumIsotropic.LowRes.binnedimaging.imagingresponse.area.nside8.cosipy.h5.zip` will need to be unzipped before running the rest of the notebook.**"
    ]
   },
   {


### PR DESCRIPTION
Changing the response filename to be downloaded from wasabi to address issue #104. 
The file on wasabi is zipped, so the user needs to unzip the file manually before running the rest of the notebook