### PR TITLE
Add fetch_wasabi_file() utility function.

### DIFF
--- a/cosipy/util/__init__.py
+++ b/cosipy/util/__init__.py
@@ -1,0 +1,1 @@
+from .data_fetching import fetch_wasabi_file

--- a/cosipy/util/data_fetching.py
+++ b/cosipy/util/data_fetching.py
@@ -1,0 +1,23 @@
+import subprocess, os
+
+def fetch_wasabi_file(file,
+                      output = None,
+                      override = False,
+                      bucket = 'cosi-pipeline-public',
+                      endpoint = 'https://s3.us-west-1.wasabisys.com',
+                      access_key_id = 'GBAL6XATQZNRV3GFH9Y4',
+                      access_key = 'GToOczY5hGX3sketNO2fUwiq4DJoewzIgvTCHoOv'):
+
+    if output is None:
+        output = file.split('/')[-1]
+
+    if os.path.exists(output) and not override:
+        raise RuntimeError(f"File {output} already exists.")
+        
+    subprocess.run(['aws', 's3api', 'get-object',
+                    '--bucket', bucket,
+                    '--key', file,
+                    '--endpoint-url', endpoint,
+                    output], 
+                   env = os.environ.copy() | {'AWS_ACCESS_KEY_ID':access_key_id,
+                                              'AWS_SECRET_ACCESS_KEY':access_key})

--- a/tests/util/test_data_fetching.py
+++ b/tests/util/test_data_fetching.py
@@ -1,0 +1,8 @@
+from cosipy.util import fetch_wasabi_file
+
+fetch_wasabi_file('test_file.txt', override = True)
+
+f = open('test_file.txt')
+
+assert f.read() == 'Small file used for testing purposes.\n'
+


### PR DESCRIPTION
 Includes a unit test.

Usage:
```
from cosipy.util import fetch_wasabi_file

fetch_wasabi_file('test_file.txt', override = True)
```

`test_file.txt` is an actual file I added to the public wasabi folder in order to test this with a small file.