### PR TITLE
Fixed bugs in doc strings

### DIFF
--- a/cosipy/data_io/ReadTraTest.py
+++ b/cosipy/data_io/ReadTraTest.py
@@ -25,8 +25,6 @@ class ReadTraTest(UnBinnedData):
         
         """Reads in MEGAlib .tra (or .tra.gz) file.
        
-        Extended Summary
-        ----------------
         This method uses MEGAlib to read events from the tra file. 
         This is used to compare to the new event reader, which is 
         independent of MEGAlib. 
@@ -41,17 +39,17 @@ class ReadTraTest(UnBinnedData):
         -------
         cosi_dataset : dict
             Returns COSI dataset as a dictionary of the form:
-            cosi_dataset = {'Full filename':self.data_file,
-                        'Energies':erg,
-                        'TimeTags':tt,
-                        'Xpointings':np.array([lonX,latX]).T,
-                        'Ypointings':np.array([lonY,latY]).T,
-                        'Zpointings':np.array([lonZ,latZ]).T,
-                        'Phi':phi,
-                        'Chi local':chi_loc,
-                        'Psi local':psi_loc,
-                        'Distance':dist,
-                        'Chi galactic':chi_gal,
+            cosi_dataset = {'Full filename':self.data_file,\
+                        'Energies':erg,\
+                        'TimeTags':tt,\
+                        'Xpointings':np.array([lonX,latX]).T,\
+                        'Ypointings':np.array([lonY,latY]).T,\
+                        'Zpointings':np.array([lonZ,latZ]).T,\
+                        'Phi':phi,\
+                        'Chi local':chi_loc,\
+                        'Psi local':psi_loc,\
+                        'Distance':dist,\
+                        'Chi galactic':chi_gal,\
                         'Psi galactic':psi_gal}
         
         Note

--- a/cosipy/data_io/UnBinnedData.py
+++ b/cosipy/data_io/UnBinnedData.py
@@ -63,27 +63,27 @@ class UnBinnedData(DataIO):
         cosi_dataset, dict
             The returned dictionary contains the COSI dataset, which
             has the form:
-            cosi_dataset = {'Energies':erg,
-                        'TimeTags':tt,
-                        'Xpointings':np.array([lonX,latX]).T,
-                        'Ypointings':np.array([lonY,latY]).T,
-                        'Zpointings':np.array([lonZ,latZ]).T,
-                        'Phi':phi,
-                        'Chi local':chi_loc,
-                        'Psi local':psi_loc,
-                        'Distance':dist,
-                        'Chi galactic':chi_gal,
-                        'Psi galactic':psi_gal} 
-            Arrays contain unbinned photon data.
+            cosi_dataset = {'Energies':erg,\
+                        'TimeTags':tt,\
+                        'Xpointings':np.array([lonX,latX]).T,\
+                        'Ypointings':np.array([lonY,latY]).T,\
+                        'Zpointings':np.array([lonZ,latZ]).T,\
+                        'Phi':phi,\
+                        'Chi local':chi_loc,\
+                        'Psi local':psi_loc,\
+                        'Distance':dist,\
+                        'Chi galactic':chi_gal,\
+                        'Psi galactic':psi_gal}\
+            Arrays contain unbinned photon data. 
         
         Notes
         -----
-            The current code is only able to handle data with Compton 
-            events. It will need to be modified to handle single-site 
-            and pair events. 
+        The current code is only able to handle data with Compton 
+        events. It will need to be modified to handle single-site 
+        and pair events. 
 
-            This method sets the instance attribute, cosi_dataset, 
-            but it does not explicitly return this.  
+        This method sets the instance attribute, cosi_dataset, 
+        but it does not explicitly return this.  
         """
    
         start_time = time.time()
@@ -376,8 +376,6 @@ class UnBinnedData(DataIO):
 
         """Get pointing information from ori file.
         
-        Extended Summary
-        ---------------
         Initializes interpolated functions for lonx, latx, lonz, latz 
         in radians.
         
@@ -555,8 +553,8 @@ class UnBinnedData(DataIO):
 
         """Constructs dictionary from input hdf5 file
         
-        Parameter
-        ---------
+        Parameters
+        ----------
         input_hdf5 : str
             Name of input hdf5 file. 
 

--- a/cosipy/spacecraftfile/SpacecraftFile.py
+++ b/cosipy/spacecraftfile/SpacecraftFile.py
@@ -419,7 +419,7 @@ class SpacecraftFile():
         """
         Bin the spacecraft attitude history into a 4D histogram that contains the accumulated time the axes of the spacecraft where looking at a given direction. 
 
-        Paremeters
+        Parameters
         ----------
         nside : int
             The nside of the scatt map.


### PR DESCRIPTION
I found some bugs in the dataIO doc strings, which have now been fixed. After making these changes I was able to successfully compile the docs locally. I checked docs/_build/html/index.html in my browser, and everything seems to be rendering ok in the API section. 

I put this as a draft for the moment because I would like somebody else to test if the API sections are rendering ok on their end. In the meantime I'm going through all my doc strings to see if they need any additional refinements. 

This PR will resolve issue #148 