### PR TITLE
Earth occultation in the image deconvolution for DC2 + ScAtt binning

### DIFF
--- a/cosipy/image_deconvolution/coordsys_conversion_matrix.py
+++ b/cosipy/image_deconvolution/coordsys_conversion_matrix.py
@@ -84,10 +84,7 @@ class CoordsysConversionMatrix(Histogram):
                                                                              quiet = True,
                                                                              save = False)
 
-#                time_diff = filtered_orientation.get_time_delta()
-
                 dwell_time_map = filtered_orientation.get_dwell_map(response = full_detector_response.filename,
-#                                                                    dts = time_diff,
                                                                     src_path = pixel_movement,
                                                                     save = False)
 
@@ -96,11 +93,14 @@ class CoordsysConversionMatrix(Histogram):
 
             ccm_thispix_sparse = sparse.COO.from_numpy( ccm_thispix.reshape((1, axis_model_map.nbins, axis_local_map.nbins)) )
 
+            # TODO: add the earth occultation masking here once the orientation includes information about the altitude and the zenith direction.
+            # something like: ccm_thispix_sparse = mask_earth_occulation(ccm_thispix_sparse, filtered_orientation)
+
             contents.append(ccm_thispix_sparse)
 
         contents = sparse.concatenate(contents)
         
-        # earth occultation
+        # earth occultation (tentetive for DC2)
         if not earth_horizon_angle is None:
             logger.warning(f"The zenith angle of the earth horizon is assumed to be {earth_horizon_angle.to('deg').value} deg. Note that currently we assume that the satellite points to the zenith.")
 
@@ -217,11 +217,14 @@ class CoordsysConversionMatrix(Histogram):
 
             ccm_thispix_sparse = sparse.COO.from_numpy( ccm_thispix.reshape((1, axis_model_map.nbins, axis_local_map.nbins)) )
 
+            # TODO: add the earth occultation masking here once the orientation includes information about the altitude and the zenith direction.
+            # something like: ccm_thispix_sparse = mask_earth_occulation(ccm_thispix_sparse, altitude, zenith_direction)
+
             contents.append(ccm_thispix_sparse)
 
         contents = sparse.concatenate(contents)
         
-        # earth occultation
+        # earth occultation (tentetive for DC2)
         if not earth_horizon_angle is None:
             logger.warning(f"The zenith angle of the earth horizon is assumed to be {earth_horizon_angle.to('deg').value} deg. Note that currently we assume that the satellite points to the zenith.")
 
@@ -265,4 +268,5 @@ class CoordsysConversionMatrix(Histogram):
 
         return new
 
+# TODO
 #   def calc_exposure_map(self, full_detector_response): #once the response file format is fixed, I will implement this function

--- a/docs/tutorials/image_deconvolution/511keV/ScAttBinning/511keV-DC2-ScAtt-DataReduction.ipynb
+++ b/docs/tutorials/image_deconvolution/511keV/ScAttBinning/511keV-DC2-ScAtt-DataReduction.ipynb
@@ -880,7 +880,9 @@
     "\n",
     "nside_model = nside_local\n",
     "\n",
-    "coordsys_conv_matrix = CoordsysConversionMatrix.spacecraft_attitude_binning_ccm(full_detector_response, exposure_table, nside_model = nside_model, use_averaged_pointing = True)"
+    "coordsys_conv_matrix = CoordsysConversionMatrix.spacecraft_attitude_binning_ccm(full_detector_response, exposure_table, nside_model = nside_model, use_averaged_pointing = True)\n",
+    "# if you want to consider the earth occultation for DC2:\n",
+    "#coordsys_conv_matrix = CoordsysConversionMatrix.spacecraft_attitude_binning_ccm(full_detector_response, exposure_table, nside_model = nside_model, use_averaged_pointing = True, earth_horizon_angle = 113.0 * u.deg)"
    ]
   },
   {

--- a/docs/tutorials/image_deconvolution/511keV/ScAttBinning/511keV-DC2-ScAtt-Upsampling.ipynb
+++ b/docs/tutorials/image_deconvolution/511keV/ScAttBinning/511keV-DC2-ScAtt-Upsampling.ipynb
@@ -670,7 +670,9 @@
    "source": [
     "%%time\n",
     "\n",
-    "coordsys_conv_matrix = CoordsysConversionMatrix.spacecraft_attitude_binning_ccm(full_detector_response, exposure_table, nside_model = nside_model, use_averaged_pointing = True)"
+    "coordsys_conv_matrix = CoordsysConversionMatrix.spacecraft_attitude_binning_ccm(full_detector_response, exposure_table, nside_model = nside_model, use_averaged_pointing = True)\n",
+    "# if you want to consider the earth occultation for DC2:\n",
+    "#coordsys_conv_matrix = CoordsysConversionMatrix.spacecraft_attitude_binning_ccm(full_detector_response, exposure_table, nside_model = nside_model, use_averaged_pointing = True, earth_horizon_angle = 113.0 * u.deg)"
    ]
   },
   {

--- a/docs/tutorials/image_deconvolution/511keV/ScAttBinning/mk_ccm_upsampling.py
+++ b/docs/tutorials/image_deconvolution/511keV/ScAttBinning/mk_ccm_upsampling.py
@@ -1,5 +1,6 @@
 from cosipy.response import FullDetectorResponse
 from cosipy.image_deconvolution import SpacecraftAttitudeExposureTable, CoordsysConversionMatrix
+import astropy.units as u
 
 full_detector_response_filename = "/Users/yoneda/Work/Exp/COSI/cosipy-2/data_challenge/DC2/prework/data/Responses/SMEXv12.511keV.HEALPixO4.binnedimaging.imagingresponse.nonsparse_nside16.area.h5" # Please replace this with your file path
 full_detector_response = FullDetectorResponse.open(full_detector_response_filename)
@@ -7,4 +8,6 @@ full_detector_response = FullDetectorResponse.open(full_detector_response_filena
 exposure_table = SpacecraftAttitudeExposureTable.from_fits("exposure_table_nside32.fits")
 
 coordsys_conv_matrix = CoordsysConversionMatrix.spacecraft_attitude_binning_ccm(full_detector_response, exposure_table, nside_model = 32, use_averaged_pointing = True)
+# if you want to consider the earth occultation effect:
+#coordsys_conv_matrix = CoordsysConversionMatrix.spacecraft_attitude_binning_ccm(full_detector_response, exposure_table, nside_model = 32, use_averaged_pointing = True, earth_horizon_angle = 113.0 * u.deg)
 coordsys_conv_matrix.write("ccm_nside32.hdf5", overwrite = True)

--- a/docs/tutorials/image_deconvolution/Crab/ScAttBinning/Crab-DC2-ScAtt-DataReduction.ipynb
+++ b/docs/tutorials/image_deconvolution/Crab/ScAttBinning/Crab-DC2-ScAtt-DataReduction.ipynb
@@ -875,7 +875,9 @@
    "source": [
     "%%time\n",
     "\n",
-    "coordsys_conv_matrix = CoordsysConversionMatrix.spacecraft_attitude_binning_ccm(full_detector_response, exposure_table, use_averaged_pointing = True)"
+    "coordsys_conv_matrix = CoordsysConversionMatrix.spacecraft_attitude_binning_ccm(full_detector_response, exposure_table, use_averaged_pointing = True)\n",
+    "# if you want to consider the earth occultation for DC2:\n",
+    "#coordsys_conv_matrix = CoordsysConversionMatrix.spacecraft_attitude_binning_ccm(full_detector_response, exposure_table, use_averaged_pointing = True, earth_horizon_angle = 113.0 * u.deg)"
    ]
   },
   {

--- a/docs/tutorials/image_deconvolution/Crab/ScAttBinning/Crab-DC2-ScAtt-Upsampling.ipynb
+++ b/docs/tutorials/image_deconvolution/Crab/ScAttBinning/Crab-DC2-ScAtt-Upsampling.ipynb
@@ -694,7 +694,9 @@
    "source": [
     "%%time\n",
     "\n",
-    "coordsys_conv_matrix = CoordsysConversionMatrix.spacecraft_attitude_binning_ccm(full_detector_response, exposure_table, nside_model = nside_model, use_averaged_pointing = True)"
+    "coordsys_conv_matrix = CoordsysConversionMatrix.spacecraft_attitude_binning_ccm(full_detector_response, exposure_table, nside_model = nside_model, use_averaged_pointing = True)\n",
+    "# if you want to consider the earth occultation for DC2:\n",
+    "#coordsys_conv_matrix = CoordsysConversionMatrix.spacecraft_attitude_binning_ccm(full_detector_response, exposure_table, nside_model = nside_model, use_averaged_pointing = True, earth_horizon_angle = 113.0 * u.deg)"
    ]
   },
   {


### PR DESCRIPTION
I added a functionality to consider the earth occultation in the coordinate conversion matrix.
The earth occultation can be included in the analysis of the image deconvolution with the scatt binning + local coordinate.

**I want to emphasize that it is limited to the case that the satellite always points to the zenith. So, it is valid for the DC2 but not for general situations. Thus, this is just an example to think about how to include the earth occultation in the analysis.**

I compared the reconstructed spectrum of 3-month Crab data with/without considering the earth occultation effect.
The reconstructed flux becomes more consistent with the injected model, especially in the higher energy band where gamma rays can pass through the bottom BGO shield more easily. For example, the difference changes from -26% to 0.3% at the highest energy band.

![image](https://github.com/cositools/cosipy/assets/131361855/26fefd36-cf7a-4406-b72a-e053ecff3c86)
![image](https://github.com/cositools/cosipy/assets/131361855/63722da4-bdae-4c6d-a012-ab210b35476a)
