### PR TITLE
fixed bug in FullDetectorResponse

### DIFF
--- a/cosipy/response/FullDetectorResponse.py
+++ b/cosipy/response/FullDetectorResponse.py
@@ -257,7 +257,7 @@ class FullDetectorResponse(HealpixBase):
             labels = ("Ei", "NuLambda", "Pol", "Em", "Phi", "PsiChi", "SigmaTau", "Dist")
         elif np.array_equal(axes_names, ['"Initial energy [keV]"', '"#nu [deg]" "#lambda [deg]"', '"Measured energy [keV]"', '"#phi [deg]"', '"#psi [deg]" "#chi [deg]"', '"#sigma [deg]" "#tau [deg]"', '"Distance [cm]"']):
             has_polarization = False
-            labels = ("Ei", "NuLambda", "Pol", "Em", "Phi", "PsiChi", "SigmaTau", "Dist")
+            labels = ("Ei", "NuLambda", "Em", "Phi", "PsiChi", "SigmaTau", "Dist")
         else:
             raise InputError("Unknown response format")
         
@@ -290,8 +290,6 @@ class FullDetectorResponse(HealpixBase):
                 raise RuntimeError("FISBEL binning not currently supported")
             else:
                 edges += (axis_edges,)
-
-        #print(edges)
         
         if sparse :
             axes = Axes(edges, labels=labels)


### PR DESCRIPTION
There is a small bug in FullDetectorResponse. When the code defines the labels for a response file without polarization, it still includes a polarization label. This causes a mismatch between the labels and edges, which throws and error. I caught this when testing the spectral fit for DC3 511 response. Removing the `"Pol"` label fixed the problem.  