### PR TITLE
Update __init__.py

### DIFF
--- a/cosipy/__init__.py
+++ b/cosipy/__init__.py
@@ -18,3 +18,7 @@ from .source_injector import SourceInjector
 
 from .background_estimation import LineBackgroundEstimation
 from .background_estimation import ContinuumEstimation
+
+from .polarization import conventions
+from .polarization import polarization_angle
+from .polarization import polarization_asad


### PR DESCRIPTION
Polarization class is not being initialized in top level init script. I noticed this b/c the polarization docs have a different format than the other docs. 