### PR TITLE
propose fix for issue 317

### DIFF
--- a/cosipy/spacecraftfile/SpacecraftFile.py
+++ b/cosipy/spacecraftfile/SpacecraftFile.py
@@ -541,7 +541,7 @@ class SpacecraftFile():
         return self.dwell_map
 
     def get_scatt_map(self,
-                       target_coord,
+                       target_coord=None,
                        nside,
                        scheme = 'ring',
                        coordsys = 'galactic',
@@ -576,6 +576,10 @@ class SpacecraftFile():
             The spacecraft attitude map.
         """
         
+        # Check if target_coord is needed
+        if earth_occ and target_coord is None:
+            raise ValueError("target_coord is needed when earth_occ = True")
+
         # Get orientations
         timestamps = self.get_time()
         attitudes = self.get_attitude()


### PR DESCRIPTION
Proposed fix for issue 317:

1. Introduced a default value of None for target_coord, essentially making the argument optional
2. Include a conditional check within the function that checks whether earth_occ is True. If so, a target_coord value must be provided, or else a value error will be raised. 