### PR TITLE
Removed a path to a non-existent file in 511 keV notebooks

### DIFF
--- a/docs/tutorials/image_deconvolution/511keV/GalacticCDS/511keV-Galactic-ImageDeconvolution.ipynb
+++ b/docs/tutorials/image_deconvolution/511keV/GalacticCDS/511keV-Galactic-ImageDeconvolution.ipynb
@@ -13,10 +13,9 @@
     "\n",
     "This notebook introduces COSI's image deconvolution with the Compton data space (CDS) in the Galactic coordinate system. An example of the image analysis will be presented using the 511keV thin disk 3-month simulation data created for DC2.\n",
     "\n",
-    "We have two options on the coordinate system to describe the Compton scattering direction (\n",
-    ") in the image deconvolution, namely Galactic coordinates or detector coordinates. Using Galactic coordinates is intuitive, and the spectral fitting adopts this convention. However, image deconvolution in Galactic coordinates take significant computation time since the detector response needs to be converted into Galactic coordinates for each sky pixel. To reduce the burden on the end-user, a pre-computed converted response is provided in DC2 and DC3 for several main sources (511 keV, Al-26, Ti-44, continuum). These pre-computed responses assume that we analyze 3-month data without extracting time intervals, and the pixel resolution of the model map is already fixed. While there is less flexibility in binning/modeling, it is relatively fast to perform the image deconvolution since the most computationally heavy part, the coordinate conversion of the response, can be skipped.\n",
+    "We have two options on the coordinate system to describe the Compton scattering direction ($\\psi\\chi$) in the image deconvolution, namely Galactic coordinates or detector coordinates. Using Galactic coordinates is intuitive, and the spectral fitting adopts this convention. However, image deconvolution in Galactic coordinates take significant computation time since the detector response needs to be converted into Galactic coordinates for each sky pixel. To reduce the burden on the end-user, a pre-computed converted response is provided in DC2 and DC3 for several main sources (511 keV, Al-26, Ti-44, continuum). These pre-computed responses assume that we analyze 3-month data without extracting time intervals, and the pixel resolution of the model map is already fixed. While there is less flexibility in binning/modeling, it is relatively fast to perform the image deconvolution since the most computationally heavy part, the coordinate conversion of the response, can be skipped.\n",
     "\n",
-    "You can also check out the related notebook [511keV-ScAtt-DataReduction.ipynb](https://github.com/cositools/cosipy/blob/main/docs/tutorials/image_deconvolution/511keV/ScAttBinning/511keV-ScAtt-DataReduction.ipynb)for imaging in detector coordinates."
+    "You can also check out the related notebook [511keV-ScAtt-DataReduction.ipynb](https://github.com/cositools/cosipy/blob/main/docs/tutorials/image_deconvolution/511keV/ScAttBinning/511keV-ScAtt-DataReduction.ipynb) for imaging in detector coordinates."
    ]
   },
   {
@@ -417,22 +416,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "fada24bc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "path_data = \"/Users/ckierans/Software/COSItools/COSItools/cosipy/docs/tutorials/image_deconvolution/511keV/GalacticCDS/\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "35f251d6-871d-4138-8709-e411d3a295a5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "path_data = \"/path/to/data/\""
+    "path_data = \"/path/to/data/\"\n",
+    "# exmaple\n",
+    "# path_data = \"/Users/ckierans/Software/COSItools/COSItools/cosipy/docs/tutorials/image_deconvolution/511keV/GalacticCDS/\""
    ]
   },
   {

--- a/docs/tutorials/image_deconvolution/511keV/ScAttBinning/511keV-ScAtt-DataReduction.ipynb
+++ b/docs/tutorials/image_deconvolution/511keV/ScAttBinning/511keV-ScAtt-DataReduction.ipynb
@@ -26,7 +26,6 @@
     "For the 511 keV image analysis, the following notebooks are based on the scatt binning method\n",
     "- [ScAttBinning/511keV-ScAtt-DataReduction.ipynb](https://github.com/cositools/cosipy/blob/main/docs/tutorials/image_deconvolution/511keV/ScAttBinning/511keV-ScAtt-DataReduction.ipynb)\n",
     "- [ScAttBinning/511keV-ScAtt-ImageDeconvolution.ipynb](https://github.com/cositools/cosipy/blob/main/docs/tutorials/image_deconvolution/511keV/ScAttBinning/511keV-ScAtt-ImageDeconvolution.ipynb)\n",
-    "- [ScAttBinning/511keV-ScAtt-Upsampling.ipynb](https://github.com/cositools/cosipy/blob/main/docs/tutorials/image_deconvolution/511keV/ScAttBinning/511keV-ScAtt-Upsampling.ipynb)\n",
     "\n",
     "Note: data that is binned in this notebook is not suitable for analysis performed in Galactic coordinates, such as the spectral fitting or Galactic coordinate imaging.\n",
     "\n",
@@ -433,17 +432,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "path_data = \"/path/to/data/\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "eeffe9e7-a439-4037-8bf9-813bfc151801",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "path_data = \"/Users/ckierans/Software/COSItools/COSItools/cosipy/docs/tutorials/image_deconvolution/511keV/ScAttBinning/\""
+    "path_data = \"/path/to/data/\"\n",
+    "# example\n",
+    "# path_data = \"/Users/ckierans/Software/COSItools/COSItools/cosipy/docs/tutorials/image_deconvolution/511keV/ScAttBinning/\""
    ]
   },
   {


### PR DESCRIPTION
Thanks for PR #309. I've checked it and found it excellent. @ckierans, thank you for checking it and correcting the language.
In this PR, I want to modify these notebooks slightly since I found some minor things.

- I removed a path to ScAttBinning/511keV-ScAtt-Upsampling.ipynb in some cell. The file referred to no longer exists.
- very minor typos (missing space)

These are just small changes. I'm sorry for opening this PR at the last minute of the DC3 deadline, but I hope they can be merged quickly. 