### PR TITLE
PR 318 Follow up: optional target_coord when earth_occ = None

### DIFF
--- a/cosipy/spacecraftfile/SpacecraftFile.py
+++ b/cosipy/spacecraftfile/SpacecraftFile.py
@@ -600,19 +600,20 @@ class SpacecraftFile():
         # Get max angle based on altitude:
         max_angle = np.pi - np.arcsin(r_earth/(r_earth + altitude))
         max_angle *= (180/np.pi) # angles in degree
-        
-        # Calculate angle between source direction and Earth zenith
-        # for each time stamp:
-        src_angle = target_coord.separation(earth_zenith)
-        
-        # Get pointings that are occulted by Earth:
-        earth_occ_index = src_angle.value >= max_angle
 
         # Define weights and set to 0 if blocked by Earth:
         weight = self.livetime*u.s
 
-        if earth_occ == True:
-            weight[earth_occ_index[:-1]] = 0        
+        if earth_occ:
+            # Calculate angle between source direction and Earth zenith
+            # for each time stamp:
+            src_angle = target_coord.separation(earth_zenith)
+
+            # Get pointings that are occulted by Earth:
+            earth_occ_index = src_angle.value >= max_angle
+
+            # Mask
+            weight[earth_occ_index[:-1]] = 0
         
         # Fill histogram:
         h_ori.fill(x, y, weight = weight)


### PR DESCRIPTION
#318 Made target_coord optional when earth_occ = False. However, the code was still using target_coord even if earth_occ = False, which produced an error since the target_coord default is None. I moved all calls to target_coord to the blocks where earth_occ = True

@zh3nl Can you please take a look and let me know what you think? I'd like to have a second pair of eyes before merging this.