### PR TITLE
Fix path for continuum background estimation tutorial

### DIFF
--- a/docs/tutorials/background_estimation/continuum_estimation/BG_estimation_example.ipynb
+++ b/docs/tutorials/background_estimation/continuum_estimation/BG_estimation_example.ipynb
@@ -285,7 +285,7 @@
    "metadata": {},
    "source": [
     "The notebook requires the following files:\n",
-    "1) DC3_final_530km_3_month_with_slew_15sbins_GalacticEarth.ori\n",
+    "1) DC3_final_530km_3_month_with_slew_15sbins_GalacticEarth_SAA.ori\n",
     "2) SMEXv12.Continuum.HEALPixO3_10bins_log_flat.binnedimaging.imagingresponse.nonsparse_nside8.area.good_chunks_unzip.earthocc.h5\n",
     "3) crab_bkg_binned_data_galactic.hdf5\n",
     "4) inputs_crab.yaml\n",

--- a/docs/tutorials/background_estimation/continuum_estimation/BG_estimation_example.ipynb
+++ b/docs/tutorials/background_estimation/continuum_estimation/BG_estimation_example.ipynb
@@ -302,8 +302,8 @@
    },
    "outputs": [],
    "source": [
-    "# 20280301_3_month_modifies.ori\n",
-    "fetch_wasabi_file('COSI-SMEX/DC3/Data/Orientation/DC3_final_530km_3_month_with_slew_15sbins_GalacticEarth.ori')"
+    "# DC3_final_530km_3_month_with_slew_15sbins_GalacticEarth_SAA.ori\n",
+    "fetch_wasabi_file('COSI-SMEX/DC3/Data/Orientation/DC3_final_530km_3_month_with_slew_15sbins_GalacticEarth_SAA.ori')"
    ]
   },
   {
@@ -315,7 +315,7 @@
    "source": [
     "# Detector response file\n",
     "# Make sure to unzip file after downloading!\n",
-    "fetch_wasabi_file('COSI-SMEX/DC2/Responses/SMEXv12.Continuum.HEALPixO3_10bins_log_flat.binnedimaging.imagingresponse.nonsparse_nside8.area.good_chunks_unzip.earthocc.h5.zip')"
+    "fetch_wasabi_file('COSI-SMEX/DC2/Responses/SMEXv12.Continuum.HEALPixO3_10bins_log_flat.binnedimaging.imagingresponse.nonsparse_nside8.area.good_chunks_unzip.earthocc.zip')"
    ]
   },
   {
@@ -380,7 +380,7 @@
     "data_path = \"your/path\"\n",
     "\n",
     "# Orientatin file:\n",
-    "ori_file = os.path.join(\".\",\"DC3_final_530km_3_month_with_slew_15sbins_GalacticEarth.ori\")\n",
+    "ori_file = os.path.join(\".\",\"DC3_final_530km_3_month_with_slew_15sbins_GalacticEarth_SAA.ori\")\n",
     "\n",
     "# Spacecraft orientation:\n",
     "sc_orientation = SpacecraftFile.parse_from_file(ori_file)\n",


### PR DESCRIPTION
- Update ori file to the one with the new format with orbital information and uptime
- Fix response path. .h5.zip -> .zip