### PR TITLE
Update source_injector to use new get_scatt_map signature

### DIFF
--- a/cosipy/source_injector/source_injector.py
+++ b/cosipy/source_injector/source_injector.py
@@ -123,7 +123,7 @@ class SourceInjector():
 
             with FullDetectorResponse.open(self.response_path) as response:
                 
-                scatt_map = orientation.get_scatt_map(coordinate, response.nside*2, coordsys = 'galactic', earth_occ = True)
+                scatt_map = orientation.get_scatt_map(response.nside*2,  target_coord = coordinate, coordsys = 'galactic', earth_occ = True)
                 
                 psr = response.get_point_source_response(coord=coordinate, scatt_map=scatt_map)
                 


### PR DESCRIPTION
The get_scatt_map signature recently changes in #318. This only affected develop and not v0.3.x since I didn't want to change the API of the released version. While #318 updated the existing calls to the method, this particular instance was only recently added to v0.3.x. When I merged v0.3.x into develop to keep it in sync, this made the tests fail. This should fix it.