### PR TITLE
now showing plots in dataIO tutorial

### DIFF
--- a/docs/tutorials/DataIO/DataIO_example.ipynb
+++ b/docs/tutorials/DataIO/DataIO_example.ipynb
@@ -553,7 +553,7 @@
     }
    ],
    "source": [
-    "analysis.get_raw_spectrum()"
+    "analysis.get_raw_spectrum(show_plots=True)"
    ]
   },
   {
@@ -581,7 +581,7 @@
    ],
    "source": [
     "# LC in plot below is normalized to initial time. \n",
-    "analysis.get_raw_lightcurve()"
+    "analysis.get_raw_lightcurve(show_plots=True)"
    ]
   },
   {
@@ -678,7 +678,7 @@
    ],
    "source": [
     "analysis = BinnedData(\"inputs.yaml\")\n",
-    "analysis.get_binned_data(unbinned_data=\"unbinned_data.hdf5\", output_name=\"binned_data\", make_binning_plots=True)"
+    "analysis.get_binned_data(unbinned_data=\"unbinned_data.hdf5\", output_name=\"binned_data\", make_binning_plots=True, show_plots=True)"
    ]
   },
   {
@@ -804,8 +804,8 @@
     }
    ],
    "source": [
-    "analysis.get_raw_spectrum(binned_data=\"binned_data.hdf5\", output_name=\"crab_spec\")\n",
-    "analysis.get_raw_lightcurve(binned_data=\"binned_data.hdf5\", output_name=\"crab_lc\")"
+    "analysis.get_raw_spectrum(binned_data=\"binned_data.hdf5\", output_name=\"crab_spec\", show_plots=True)\n",
+    "analysis.get_raw_lightcurve(binned_data=\"binned_data.hdf5\", output_name=\"crab_lc\", show_plots=True)"
    ]
   },
   {
@@ -928,8 +928,8 @@
     }
    ],
    "source": [
-    "analysis.get_raw_spectrum(binned_data=\"combined_binned_data.hdf5\", output_name=\"crab_spec_3x\")\n",
-    "analysis.get_raw_lightcurve(binned_data=\"combined_binned_data.hdf5\", output_name=\"crab_lc_3x\")"
+    "analysis.get_raw_spectrum(binned_data=\"combined_binned_data.hdf5\", output_name=\"crab_spec_3x\", show_plots=True)\n",
+    "analysis.get_raw_lightcurve(binned_data=\"combined_binned_data.hdf5\", output_name=\"crab_lc_3x\", show_plots=True)"
    ]
   },
   {
@@ -1162,8 +1162,8 @@
     }
    ],
    "source": [
-    "analysis.get_raw_spectrum(binned_data=\"selected_combined_binned_data.hdf5\", output_name=\"selected_crab_spec_3x\")\n",
-    "analysis.get_raw_lightcurve(binned_data=\"selected_combined_binned_data.hdf5\", output_name=\"selected_crab_lc_3x\")"
+    "analysis.get_raw_spectrum(binned_data=\"selected_combined_binned_data.hdf5\", output_name=\"selected_crab_spec_3x\", show_plots=True)\n",
+    "analysis.get_raw_lightcurve(binned_data=\"selected_combined_binned_data.hdf5\", output_name=\"selected_crab_lc_3x\", show_plots=True)"
    ]
   },
   {
@@ -1397,15 +1397,15 @@
    ],
    "source": [
     "analysis = BinnedData(\"inputs.yaml\")\n",
-    "analysis.get_binned_data(unbinned_data=\"unbinned_data.hdf5\",event_range=[0,1e6],make_binning_plots=True)"
+    "analysis.get_binned_data(unbinned_data=\"unbinned_data.hdf5\",event_range=[0,1e6],make_binning_plots=True, show_plots=True)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:cosi_nomegalib]",
+   "display_name": "Python [conda env:COSIPY_new]",
    "language": "python",
-   "name": "conda-env-cosi_nomegalib-py"
+   "name": "conda-env-COSIPY_new-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1417,7 +1417,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR is a short term solution to issue #338. The code was modified since we initial created the dataIO tutorial, and a `show_plots=True` argument must now be passed to some of the functions in order for the plots to be shown. I added this to the tutorial as needed. 

I think we can keep issue #338 open even after this PR is merged. The dataIO API can be refined in the longer term to make things more intuitive (see the discussion in #338 for more details).  