### PR TITLE
Update galdiff_continuum.ipynb

### DIFF
--- a/docs/tutorials/spectral_fits/galactic_diffuse_continuum/galdiff_continuum.ipynb
+++ b/docs/tutorials/spectral_fits/galactic_diffuse_continuum/galdiff_continuum.ipynb
@@ -1611,7 +1611,7 @@
     "The best-fit normalizations are: <br>\n",
     "galprop map: 0.7721 +/- 0.0008 <br>\n",
     "background: 1.00771 +/- 0.00029 <br>\n",
-    "Thus, we recover the background to within <1%,although the galprop normalization is lower than the input by ~23%. The discrepancy is plausibly related to the course spatial binning of the response, which has an nside=8, corresponding to an area of 7.3 x 7.3 square degrees. The intensity is currently being calculated at each fixed position, and then multiplied by the solid angle, likely leading to an overestimate. Possible remedies for this include either using a higher resolution response, or modifying the function to average over a solid angle corresponding to the resolution of the response. Note that the predicted counts agree to within ~6%. Below we plot some of the results, and compare to the inputs. \n",
+    "Thus, we recover the background to within <1%,although the galprop normalization is lower than the input by ~23%. The discrepancy is likely due to the coarse energy binning. The predicted counts agree to within ~6%. Below we plot some of the results, and compare to the inputs. \n",
     "\n",
     "## Make plots"
    ]


### PR DESCRIPTION
Updated the description of the fit results to say that it's likely due to the coarse energy binning.