### PR TITLE
Update SpecFromDat

### DIFF
--- a/cosipy/threeml/custom_functions.py
+++ b/cosipy/threeml/custom_functions.py
@@ -110,11 +110,10 @@ class SpecFromDat(Function1D, metaclass=FunctionMeta):
                 desc : Normalization
                 initial value : 1.0
                 is_normalization : True
-                transformation : log10
-                min : 1e-30
-                max : 1e3
-                delta : 0.1
-                units: ph/cm2/s
+                min: 0.0 
+                max: 1e6
+                delta: 1.0
+                units:
         properties:
             dat:
                 desc: the data file to load


### PR DESCRIPTION
Remove log10 transformation and clarify units of K in SpecFromDat:

- Removed the log10 transformation on parameter K to avoid confusion and unphysical values. K is now varied in linear space with min=0.0.

- Set parameter bounds to a linear range (0.0–1e6).

- Updated units of K for clarity and consistency with astromodels conventions. K now directly inherits the y-axis units from the input spectrum, making it a differential flux normalization factor rather than an integrated flux.

Fixes issue #363 