### PR TITLE
Pass `cpu_cores` para correctly for MOCTSMap.moc_ts_fit function

### DIFF
--- a/cosipy/ts_map/moc_ts_fit.py
+++ b/cosipy/ts_map/moc_ts_fit.py
@@ -217,7 +217,7 @@ class MOCTSMap(FastTSMap):
         
         print(f"fitting order = {order}")
         print(f"fitting {len(hypothesis_coords_list)} hypothesis coordinates")
-        results = self.parallel_ts_fit(hypothesis_coords = hypothesis_coords_list, energy_channel = energy_channel, spectrum = spectrum, pixel_idx = pixidx)
+        results = self.parallel_ts_fit(hypothesis_coords = hypothesis_coords_list, energy_channel = energy_channel, spectrum = spectrum, pixel_idx = pixidx, cpu_cores = cpu_cores)
         self.ts_array = results[:,1]
 
         # fill up the 0th order moc map


### PR DESCRIPTION
A tiny fix to function `MOCTSMap.moc_ts_fit function` so that the number of CPU cores requested is passed to the parallel fit. Thanks @NicoloParmiggiani for finding this bug!