### PR TITLE
Adding the input file name as an option in the tra file reader function

### DIFF
--- a/cosipy/data_io/UnBinnedData.py
+++ b/cosipy/data_io/UnBinnedData.py
@@ -36,7 +36,7 @@ class UnBinnedData(DataIO):
         Parameters
         ----------
 	    input_name : str, optional
-            Prefix of input file (default is None, in which case the 
+            Path of input file (default is None, in which case the 
 	        input file name is taken from the yaml file).
         output_name : str, optional
             Prefix of output file (default is None, in which case no 

--- a/cosipy/data_io/UnBinnedData.py
+++ b/cosipy/data_io/UnBinnedData.py
@@ -1,6 +1,4 @@
 # Imports:
-from abc import ABC
-
 import numpy as np
 from astropy.table import Table
 from astropy.io import fits
@@ -9,8 +7,7 @@ import h5py
 import time
 import cosipy
 from cosipy.data_io import DataIO
-from cosipy.interfaces.data_interface import TimeTagEventData, EventDataWithEnergy
-from cosipy.spacecraftfile import SpacecraftHistory
+from cosipy.spacecraftfile import SpacecraftFile
 import gzip
 import astropy.coordinates as astro_co
 import astropy.units as u
@@ -25,7 +22,6 @@ import subprocess
 import gc
 import os
 import time
-
 logger = logging.getLogger(__name__)
 
 
@@ -98,7 +94,6 @@ class UnBinnedData(DataIO):
             self.data_file = input_name
             
         start_time = time.time()
-
         # Initialise empty lists:
             
         # Total photon energy
@@ -450,7 +445,7 @@ class UnBinnedData(DataIO):
         """
 
         # Get ori info:
-        ori = SpacecraftHistory.open(self.ori_file)
+        ori = SpacecraftFile.parse_from_file(self.ori_file)
         time_tags = ori._load_time
         x_pointings = ori.x_pointings
         z_pointings = ori.z_pointings
@@ -851,7 +846,7 @@ class UnBinnedData(DataIO):
             self.cosi_dataset = self.get_dict(unbinned_data)
 
         # Get ori info:
-        ori = SpacecraftHistory.open(self.ori_file)
+        ori = SpacecraftFile.parse_from_file(self.ori_file)
         
         # Get bad time intervals:
         bti = self.find_bad_intervals(ori._time, ori.livetime)
@@ -870,5 +865,3 @@ class UnBinnedData(DataIO):
             self.write_unbinned_output(output_name)
 
         return
-
-

--- a/cosipy/data_io/UnBinnedData.py
+++ b/cosipy/data_io/UnBinnedData.py
@@ -94,6 +94,7 @@ class UnBinnedData(DataIO):
             self.data_file = input_name
             
         start_time = time.time()
+				
         # Initialise empty lists:
             
         # Total photon energy

--- a/cosipy/data_io/UnBinnedData.py
+++ b/cosipy/data_io/UnBinnedData.py
@@ -1,4 +1,6 @@
 # Imports:
+from abc import ABC
+
 import numpy as np
 from astropy.table import Table
 from astropy.io import fits
@@ -7,7 +9,8 @@ import h5py
 import time
 import cosipy
 from cosipy.data_io import DataIO
-from cosipy.spacecraftfile import SpacecraftFile
+from cosipy.interfaces.data_interface import TimeTagEventData, EventDataWithEnergy
+from cosipy.spacecraftfile import SpacecraftHistory
 import gzip
 import astropy.coordinates as astro_co
 import astropy.units as u
@@ -22,19 +25,23 @@ import subprocess
 import gc
 import os
 import time
+
 logger = logging.getLogger(__name__)
 
 
 class UnBinnedData(DataIO):
     """Handles unbinned data."""
 
-    def read_tra(self, output_name=None, run_test=False, use_ori=False,
+    def read_tra(self,input_name=None,output_name=None, run_test=False, use_ori=False,
             event_min=None, event_max=None):
         
         """Reads MEGAlib .tra (or .tra.gz) file and creates cosi datset.
         
         Parameters
         ----------
+	input_name : str, optional
+            Prefix of input file (default is None, in which case the 
+	    input file name is taken from the yaml file).
         output_name : str, optional
             Prefix of output file (default is None, in which case no 
             output is written). 
@@ -87,7 +94,9 @@ class UnBinnedData(DataIO):
         This method sets the instance attribute, cosi_dataset, 
         but it does not explicitly return this.  
         """
-   
+        if input_name != None:
+            self.data_file = input_name
+            
         start_time = time.time()
 
         # Initialise empty lists:
@@ -441,7 +450,7 @@ class UnBinnedData(DataIO):
         """
 
         # Get ori info:
-        ori = SpacecraftFile.parse_from_file(self.ori_file)
+        ori = SpacecraftHistory.open(self.ori_file)
         time_tags = ori._load_time
         x_pointings = ori.x_pointings
         z_pointings = ori.z_pointings
@@ -842,7 +851,7 @@ class UnBinnedData(DataIO):
             self.cosi_dataset = self.get_dict(unbinned_data)
 
         # Get ori info:
-        ori = SpacecraftFile.parse_from_file(self.ori_file)
+        ori = SpacecraftHistory.open(self.ori_file)
         
         # Get bad time intervals:
         bti = self.find_bad_intervals(ori._time, ori.livetime)
@@ -861,3 +870,5 @@ class UnBinnedData(DataIO):
             self.write_unbinned_output(output_name)
 
         return
+
+

--- a/cosipy/data_io/UnBinnedData.py
+++ b/cosipy/data_io/UnBinnedData.py
@@ -28,16 +28,16 @@ logger = logging.getLogger(__name__)
 class UnBinnedData(DataIO):
     """Handles unbinned data."""
 
-    def read_tra(self,input_name=None,output_name=None, run_test=False, use_ori=False,
+    def read_tra(self, input_name=None, output_name=None, run_test=False, use_ori=False,
             event_min=None, event_max=None):
         
         """Reads MEGAlib .tra (or .tra.gz) file and creates cosi datset.
         
         Parameters
         ----------
-	input_name : str, optional
+	    input_name : str, optional
             Prefix of input file (default is None, in which case the 
-	    input file name is taken from the yaml file).
+	        input file name is taken from the yaml file).
         output_name : str, optional
             Prefix of output file (default is None, in which case no 
             output is written). 


### PR DESCRIPTION
I added an option to pass directly the input file name to the tra file reader instead of using only the one define in the yaml file.

This is more convenient when you have a list of files to read and you don't want to change the yaml file each time. 