### PR TITLE
RL Parallel did not run out-of-the-box

### DIFF
--- a/cosipy/image_deconvolution/RLparallelscript.py
+++ b/cosipy/image_deconvolution/RLparallelscript.py
@@ -25,8 +25,6 @@ from cosipy.image_deconvolution import ImageDeconvolution, DataIF_Parallel, Data
 
 # Define MPI variables
 MASTER = 0                      # Indicates master process
-DRM_DIR = Path('/Users/penguin/Documents/Grad School/Research/COSI/COSIpy/docs/tutorials/data')
-DATA_DIR = Path('/Users/penguin/Documents/Grad School/Research/COSI/COSIpy/docs/tutorials/image_deconvolution/511keV/GalacticCDS')
 
 def main():
     args = argparse.ArgumentParser(

--- a/cosipy/image_deconvolution/dataIF_Parallel.py
+++ b/cosipy/image_deconvolution/dataIF_Parallel.py
@@ -26,7 +26,7 @@ def load_response_matrix(comm, start_col, end_col, filename):
     '''
     with h5py.File(filename, "r", driver="mpio", comm=comm) as f1:
         dataset = f1['hist/contents']
-        R = dataset[1:-1, 1:-1, 1:-1, 1:-1, start_col+1:end_col+1]
+        R = dataset[:, :, :, :, start_col:end_col]
 
         hist_group = f1['hist']
         if 'unit' in hist_group.attrs:
@@ -65,7 +65,7 @@ def load_response_matrix_transpose(comm, start_row, end_row, filename):
     '''
     with h5py.File(filename, "r", driver="mpio", comm=comm) as f1:
         dataset = f1['hist/contents']
-        RT = dataset[start_row+1:end_row+1, 1:-1, 1:-1, 1:-1, 1:-1]
+        RT = dataset[start_row:end_row, :, :, :, :]
 
         hist_group = f1['hist']
         if 'unit' in hist_group.attrs:
@@ -139,7 +139,6 @@ class DataIF_Parallel(ImageDeconvolutionDataInterfaceBase):
         print(f'TaskID = {taskid}, Number of tasks = {numtasks}')
 
         # Get number of NuLambda and PsiChi pixels
-        # DC2 PSR has underflow/overflow bins (so -2)
         # Axes are NuLambda, Em, Ei, Phi, PsiChi
         with h5py.File(drm_filename, "r", driver="mpio", comm=comm) as f1:
             dataset = f1['hist/contents']

--- a/cosipy/image_deconvolution/dataIF_Parallel.py
+++ b/cosipy/image_deconvolution/dataIF_Parallel.py
@@ -16,17 +16,21 @@ except ModuleNotFoundError as e:
 
 import h5py
 from histpy import Histogram, Axes, Axis, HealpixAxis
+import histpy
 
 from cosipy.response import FullDetectorResponse
 from cosipy.image_deconvolution import ImageDeconvolutionDataInterfaceBase
 
-def load_response_matrix(comm, start_col, end_col, filename):
+def load_response_matrix(comm, start_col, end_col, track_overflow_flag, filename):
     '''
     Response matrix
     '''
     with h5py.File(filename, "r", driver="mpio", comm=comm) as f1:
         dataset = f1['hist/contents']
-        R = dataset[:, :, :, :, start_col:end_col]
+        if track_overflow_flag:     # Histpy 1.x default
+            R = dataset[1:-1, 1:-1, 1:-1, 1:-1, start_col+1:end_col+1]
+        else:                       # Histpy 2.x default
+            R = dataset[:, :, :, :, start_col:end_col]
 
         hist_group = f1['hist']
         if 'unit' in hist_group.attrs:
@@ -59,13 +63,16 @@ def load_response_matrix(comm, start_col, end_col, filename):
 
     return Histogram(axes, contents = R, unit = unit)
 
-def load_response_matrix_transpose(comm, start_row, end_row, filename):
+def load_response_matrix_transpose(comm, start_row, end_row, track_overflow_flag, filename):
     '''
     Response matrix tranpose
     '''
     with h5py.File(filename, "r", driver="mpio", comm=comm) as f1:
         dataset = f1['hist/contents']
-        RT = dataset[start_row:end_row, :, :, :, :]
+        if track_overflow_flag:      # Histpy 1.x
+            RT = dataset[start_row+1:end_row+1, 1:-1, 1:-1, 1:-1, 1:-1]
+        else:                   # Histpy 2.x
+            RT = dataset[start_row:end_row, :, :, :, :]
 
         hist_group = f1['hist']
         if 'unit' in hist_group.attrs:
@@ -142,8 +149,17 @@ class DataIF_Parallel(ImageDeconvolutionDataInterfaceBase):
         # Axes are NuLambda, Em, Ei, Phi, PsiChi
         with h5py.File(drm_filename, "r", driver="mpio", comm=comm) as f1:
             dataset = f1['hist/contents']
-            nrows = dataset.shape[0]
-            ncols = dataset.shape[4]
+
+            # Check if track_overflow is set to True (histpy 1.x default) or False (histpy 2.x default)
+            axes = Axes.open(f1['hist/axes'])
+            track_overflow_flag = True if (axes[0].nbins + 2 == dataset.shape[0]) else False
+
+            if track_overflow_flag:     # Histpy 1.x default
+                nrows = dataset.shape[0] - 2
+                ncols = dataset.shape[4] - 2
+            else:                       # Histpy 2.x default
+                nrows = dataset.shape[0]
+                ncols = dataset.shape[4]
 
         # Calculate the indices in Rij that the process has to parse. My hunch is that calculating these scalars individually will be faster than the MPI send broadcast overhead.
         self.averow = nrows // numtasks
@@ -166,8 +182,8 @@ class DataIF_Parallel(ImageDeconvolutionDataInterfaceBase):
         self._bkg_models = {bkg_norm_label: bkg.project(['Em', 'Phi', 'PsiChi']).to_dense()}
 
         # Load response and response transpose
-        self._image_response = load_response_matrix(comm, self.start_col, self.end_col, filename=drm_filename)
-        self._image_response_T = load_response_matrix_transpose(comm, self.start_row, self.end_row, filename=drm_filename)
+        self._image_response = load_response_matrix(comm, self.start_col, self.end_col, track_overflow_flag, filename=drm_filename)
+        self._image_response_T = load_response_matrix_transpose(comm, self.start_row, self.end_row, track_overflow_flag, filename=drm_filename)
 
         self.col_size = 1       # TODO: This can change for more sophisticated model space contents
         self.row_size = np.prod(self.event.contents.shape[:-1])

--- a/cosipy/image_deconvolution/dataIF_Parallel.py
+++ b/cosipy/image_deconvolution/dataIF_Parallel.py
@@ -16,7 +16,6 @@ except ModuleNotFoundError as e:
 
 import h5py
 from histpy import Histogram, Axes, Axis, HealpixAxis
-import histpy
 
 from cosipy.response import FullDetectorResponse
 from cosipy.image_deconvolution import ImageDeconvolutionDataInterfaceBase
@@ -69,9 +68,9 @@ def load_response_matrix_transpose(comm, start_row, end_row, track_overflow_flag
     '''
     with h5py.File(filename, "r", driver="mpio", comm=comm) as f1:
         dataset = f1['hist/contents']
-        if track_overflow_flag:      # Histpy 1.x
+        if track_overflow_flag:     # Histpy 1.x
             RT = dataset[start_row+1:end_row+1, 1:-1, 1:-1, 1:-1, 1:-1]
-        else:                   # Histpy 2.x
+        else:                       # Histpy 2.x
             RT = dataset[start_row:end_row, :, :, :, :]
 
         hist_group = f1['hist']

--- a/cosipy/image_deconvolution/dataIF_Parallel.py
+++ b/cosipy/image_deconvolution/dataIF_Parallel.py
@@ -143,8 +143,8 @@ class DataIF_Parallel(ImageDeconvolutionDataInterfaceBase):
         # Axes are NuLambda, Em, Ei, Phi, PsiChi
         with h5py.File(drm_filename, "r", driver="mpio", comm=comm) as f1:
             dataset = f1['hist/contents']
-            nrows = dataset.shape[0] - 2
-            ncols = dataset.shape[4] - 2
+            nrows = dataset.shape[0]
+            ncols = dataset.shape[4]
 
         # Calculate the indices in Rij that the process has to parse. My hunch is that calculating these scalars individually will be faster than the MPI send broadcast overhead.
         self.averow = nrows // numtasks


### PR DESCRIPTION
The recently merged pull request on RL Parallelization v2 #408 did not run out-of-the-box upon cosipy installation. The issue can be traced back to the update from histpy 1.x to 2.x. In the former, the underflow and overflow bins were tracked by default which required some workarounds for the RL dataIF code. As this tracking feature has been set to False by default in histpy 2.x, the workarounds had to be removed. This pull request verifies the code so that it can work with histpy 2.x.

Changes made:
- RLparallelscript.py: Remove *_DIR and update "- 2" in nrows, ncols
- dataIF_Parallel.py: Update response loader function to work with histpy 2.0