### PR TITLE
Fix automated running of ts_map notebook

### DIFF
--- a/docs/tutorials/run_tutorials.yml
+++ b/docs/tutorials/run_tutorials.yml
@@ -58,7 +58,7 @@ tutorials:
           checksum: eb72400a1279325e9404110f909c7785
 
     ts_map:
-      notebook: ts_map/Parallel_TS_map_computation.ipynb
+      notebook: ts_map/TS_map_fitting.ipynb
       wasabi_files:
         COSI-SMEX/cosipy_tutorials/grb_spectral_fit_local_frame/grb_binned_data.hdf5:
           checksum: fcf7022369b6fb378d67b780fc4b5db8


### PR DESCRIPTION
Recent changes to develop renamed the tutorial notebook associated with ts_map.  This patch updates the run_tutorials.yml database to point to the correct notebook file so that run_tutorials.py can run it.