### PR TITLE
Add __enter__ / __exit__   to the  ExtendedSourceResponse

### DIFF
--- a/cosipy/response/ExtendedSourceResponse.py
+++ b/cosipy/response/ExtendedSourceResponse.py
@@ -125,3 +125,17 @@ class ExtendedSourceResponse(Histogram):
             allsky_image_model = get_integrated_extended_model(source, image_axis = self.axes[0], energy_axis = self.axes[1]) 
         
         return self.get_expectation(allsky_image_model)
+
+    def __enter__(self):
+        """
+        Start a context manager
+        """
+
+        return self
+
+    def __exit__(self, type, value, traceback):
+        """
+        Exit a context manager
+        """
+
+        self.close()

--- a/cosipy/response/ExtendedSourceResponse.py
+++ b/cosipy/response/ExtendedSourceResponse.py
@@ -125,7 +125,15 @@ class ExtendedSourceResponse(Histogram):
             allsky_image_model = get_integrated_extended_model(source, image_axis = self.axes[0], energy_axis = self.axes[1]) 
         
         return self.get_expectation(allsky_image_model)
+        
+    def close(self):
+        """
+        Close the HDF5 file containing the response
+        """
 
+        self._file.close()
+
+    
     def __enter__(self):
         """
         Start a context manager


### PR DESCRIPTION
So that we can open the `ExtendedSourceResponse` with the `with` statement, similar to the regular response.

```
with ExtendedSourceResponse.open(response_path) as f :
    f ....
      ...
```
