### PR TITLE
Minor typos

### DIFF
--- a/cosipy/response/RspConverter.py
+++ b/cosipy/response/RspConverter.py
@@ -291,7 +291,7 @@ class RspConverter():
                     break
 
                 case 'StopStream': # end of data for dense .rsp -- should never appear
-                    raise RunTimeError("StopStream encountered before StartStream")
+                    raise RuntimeError("StopStream encountered before StartStream")
 
                 case _: # any other field
                     hdr["headers"][key] = " ".join(line[1:])
@@ -419,7 +419,7 @@ class RspConverter():
                 e_hi = np.maximum(emin, e_hi)
 
                 if self.alpha == 1:
-                    nperchannel_norm = np.log(e_hi/e_low) / np.log(emax/emin)
+                    nperchannel_norm = np.log(e_hi/e_lo) / np.log(emax/emin)
                 else:
                     a = 1 - self.alpha
                     nperchannel_norm = (e_hi**a - e_lo**a) / (emax**a - emin**a)

--- a/cosipy/threeml/COSILike.py
+++ b/cosipy/threeml/COSILike.py
@@ -264,7 +264,7 @@ class COSILike(PluginPrototype):
         
         # Recompute the expectation if any parameter in the model changed
         if self._model is None:
-            log.error("You need to set the model first")
+            logger.error("You need to set the model first")
        
         # Set model:
         self.set_model(self._model)


### PR DESCRIPTION
While reading/linting cosipy I found 3 minor typos:

* COSILike using "log.error" instead of "logger.error"
* RspConverter raising "RunTimeError" instead of "RuntimeError"
* RspConverter._get_eff_area using "e_low" instead of "e_lo" in the powerlaw case

This PR fixes them.