### PR TITLE
Added total_flux method in AllSkyImageModel

### DIFF
--- a/cosipy/image_deconvolution/allskyimage.py
+++ b/cosipy/image_deconvolution/allskyimage.py
@@ -171,3 +171,9 @@ class AllSkyImageModel(ModelBase):
             allskyimage_new[:,i] = hp.smoothing(self[:,i].value, fwhm = fwhm.to('rad').value) * self.unit
 
         return allskyimage_new
+
+    def total_flux(self):
+        """
+        Calculate the total flux at each energy bin.
+        """
+        return np.sum(self, axis = 0) * self.axes['lb'].pixarea()

--- a/tests/image_deconvolution/test_model.py
+++ b/tests/image_deconvolution/test_model.py
@@ -1,6 +1,7 @@
 import pytest
 import astropy.units as u
 import numpy as np
+import healpy as hp
 from astromodels import Gaussian, Gaussian_on_sphere, ExtendedSource
 from histpy import Histogram
 
@@ -24,6 +25,9 @@ def test_allskyimage():
 
     model.set_values_from_parameters(parameter)
 
+    # check total_flux
+    assert len(model.total_flux()) == 1 and np.isclose(model.total_flux()[0], hp.nside2pixarea(1) * hp.nside2npix(1) * u.Unit("s-1 cm-2"))
+    
     # instatiation from parameter
     parameter = {"nside": 1,
                  "energy_edges": {"value": [100.,  200.],
@@ -33,7 +37,7 @@ def test_allskyimage():
                  "unit": "cm-2 s-1 sr-1"}
 
     model = AllSkyImageModel.instantiate_from_parameters(parameter)
-    
+
     # smoothing
     model.smoothing(fwhm = 10.0 * u.deg)
     model.smoothing(sigma = 10.0 * u.deg)


### PR DESCRIPTION
The total flux of the image can be calculated using a new method, like:
```
image = AllSkyImageModel(nside = 1, energy_edges = np.array([509.0, 513.0]) * u.keV)
image[:] = 1.0 * u.Unit('cm-2 s-1 sr-1')

image.total_flux() #-> <Quantity [12.56637061] 1 / (s cm2)>
```