### PR TITLE
Sorting the TimeTags of the unbinned file

### DIFF
--- a/cosipy/data_io/UnBinnedData.py
+++ b/cosipy/data_io/UnBinnedData.py
@@ -423,7 +423,16 @@ class UnBinnedData(DataIO):
                         'Distance':dist,
                         'Chi galactic':chi_gal,
                         'Psi galactic':psi_gal,
-                       'Compton Seq':CO_seq} 
+                       'Compton Seq':CO_seq}
+                
+        #For simulation the timetags are shuffle so we need to sort it by ascending order
+        # Build sorting index
+        idx = np.argsort(cosi_dataset["TimeTags"])
+
+        # Reorder all columns using the same index
+        for key in cosi_dataset:
+            cosi_dataset[key] = unbinned_signal.cosi_dataset[key][idx]        
+        
         self.cosi_dataset = cosi_dataset
 
         # Option to write unbinned data to file (either fits or hdf5):

--- a/cosipy/data_io/UnBinnedData.py
+++ b/cosipy/data_io/UnBinnedData.py
@@ -427,11 +427,12 @@ class UnBinnedData(DataIO):
                 
         #For simulation the timetags are shuffle so we need to sort it by ascending order
         # Build sorting index
+        logger.info("Sorting the dictionary by ascending TimeTags")        
         idx = np.argsort(cosi_dataset["TimeTags"])
 
         # Reorder all columns using the same index
         for key in cosi_dataset:
-            cosi_dataset[key] = unbinned_signal.cosi_dataset[key][idx]        
+            cosi_dataset[key] = cosi_dataset[key][idx]        
         
         self.cosi_dataset = cosi_dataset
 


### PR DESCRIPTION
@hirokiyoneda is using some time binning method for the image deconvolution which requires the TimeTags of the unbinned file to be sorted in ascending order.

Since we are merging multiple tra files during the mimrec extraction the TimeTags are shuffles when we use simulation.

So I added this sorting in the trafile converter method in the DataIO class. 

@ckarwin Could you review it please ? Should be quick to test.  