### PR TITLE
Fix coordinate frame issues with SpacecraftFile, COSILike, and ts_map

### DIFF
--- a/cosipy/response/FullDetectorResponse.py
+++ b/cosipy/response/FullDetectorResponse.py
@@ -433,7 +433,7 @@ class FullDetectorResponse(HealpixBase):
         -------
         :py:class:`PointSourceResponse` or tuple of same
             Inertial-frame point-source response for each source
-            coordinate; tuple if more than one coordinate provided
+            coordinate
 
         """
 
@@ -571,8 +571,8 @@ class FullDetectorResponse(HealpixBase):
                 # map each local-frame PsiChi pixel dir to its nearest HEALPix
                 # pixel. TODO: this could be interpolated to map each dir to
                 # multiple pixels + weights
-                loc_psichi_pixels = sf_psichi_axis.find_bin(theta = loc_psichi_colat,
-                                                            phi   = loc_psichi_lon)
+                loc_psichi_pixels = psr_axes['PsiChi'].find_bin(theta = loc_psichi_colat,
+                                                                phi   = loc_psichi_lon)
 
                 if has_pol:
 

--- a/cosipy/response/GalacticResponse.py
+++ b/cosipy/response/GalacticResponse.py
@@ -69,11 +69,6 @@ class GalacticResponse(HealpixBase):
 
         new._contents = new._file['hist/contents']
 
-        # NB: old galactic response files were stored as histograms
-        # with overflow tracking on.  Make sure we handle that
-        # when reading them!
-        new._has_overflow = (new._contents.shape != new._axes.shape)
-
         # dummy effective area correction; "counts" in Histogram
         # have already had the effective area correction applied.
         new._eff_area = np.ones(new._axes["Ei"].nbins,

--- a/cosipy/spacecraftfile/SpacecraftFile.py
+++ b/cosipy/spacecraftfile/SpacecraftFile.py
@@ -523,6 +523,7 @@ class SpacecraftFile():
         useSkyCoord = isinstance(target_coord, SkyCoord)
 
         if useSkyCoord:
+            target_coord = target_coord.transform_to(self.frame)
             target_coord = target_coord.cartesian.xyz.value
 
         src_path_cartesian = np.dot(self._attitude.rot.inv().as_matrix(),

--- a/cosipy/threeml/COSILike.py
+++ b/cosipy/threeml/COSILike.py
@@ -106,13 +106,6 @@ class COSILike(PluginPrototype):
         self._data = prepare_binned(data, cds_order)
         self._bkg  = prepare_binned(bkg, cds_order)
 
-        # Precomputed image response for extended
-        # sources
-        if precomputed_psr_file is not None:
-            logger.info("... loading the pre-computed image response ...")
-            self.image_response = ExtendedSourceResponse.open(precomputed_psr_file)
-            logger.info("--> done")
-
         try:
             data_frame = data.axes["PsiChi"].coordsys.name
             bkg_frame  = bkg.axes["PsiChi"].coordsys.name

--- a/cosipy/threeml/COSILike.py
+++ b/cosipy/threeml/COSILike.py
@@ -1,7 +1,10 @@
 import numpy as np
 
-from threeML import PluginPrototype
+import astropy.units as u
+
 from astromodels import Parameter
+
+from threeML import PluginPrototype
 
 from cosipy.response import (
     FullDetectorResponse,
@@ -12,8 +15,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 class COSILike(PluginPrototype):
-    """
-    COSI 3ML plugin.
+    """COSI 3ML plugin.
 
     Parameters
     ----------
@@ -36,11 +38,11 @@ class COSILike(PluginPrototype):
     nuisance_param : astromodels.core.parameter.Parameter, optional
         Background parameter
     coordsys : str, optional
-        Coordinate system ('galactic' or 'spacecraftframe') to perform
-        fit in, which should match coordinate system of data and
-        background. This only needs to be specified if the binned data
-        and background do not have a coordinate system attached to
-        them
+        Coordinate system (name of an inertial frame, such as
+        'galactic', or 'spacecraftframe') to perform fit in, which
+        should match coordinate system of data and background. This
+        only needs to be specified if the binned data and background
+        do not have a coordinate system attached to them
     precomputed_psr_file : str, optional
         Full path to precomputed point source response in Galactic
         coordinates
@@ -48,13 +50,34 @@ class COSILike(PluginPrototype):
         Option to include Earth occultation in fit (default is True).
 
     """
-    def __init__(self, name, dr, data, bkg, sc_orientation, 
+    def __init__(self, name, dr, data, bkg, sc_orientation,
                  nuisance_param = None,
                  coordsys = None,
                  precomputed_psr_file = None,
                  earth_occ=True,
                  **kwargs):
-        
+
+        def prepare_binned(data, cds_order):
+            """Given a Histogram describing binned data/model, convert it to a
+            bare array.  Make sure it is dense, lacks units, and
+            contains only CDS axes in the order specified.
+
+            """
+
+            # we *must* project before densifying, as some
+            # data sets are too big to densify otherwise
+            if tuple(data.axes.labels) != tuple(cds_order):
+                data = data.project(cds_order)
+
+            data = data.todense() if data.is_sparse else data
+
+            data = data.contents
+
+            if isinstance(data, u.Quantity):
+                data = data.value
+
+            return data
+
         # create the hash for the nuisance parameters. We have none for now.
         self._nuisance_parameters = {}
 
@@ -63,29 +86,32 @@ class COSILike(PluginPrototype):
 
         # User inputs needed to compute the likelihood
         self._name = name
-
+        self._dr = FullDetectorResponse.open(dr)
         self._sc_orientation = sc_orientation
         self.earth_occ = earth_occ
 
-        # Full detector response for point sources
-        self._dr = FullDetectorResponse.open(dr)
-        
+        # Option to use precomputed point source response.
+        # Note: this still needs to be implemented in a
+        # consistent way for point srcs and extended srcs.
+        self.precomputed_psr_file = precomputed_psr_file
+        if self.precomputed_psr_file is not None:
+            logger.info("... loading the pre-computed image response ...")
+            self.image_response = ExtendedSourceResponse.open(self.precomputed_psr_file)
+            logger.info("--> done")
+
+        cds_order = tuple(self._dr.axes.labels[-3:])
+        if not all(ax in ("Em", "Phi", "PsiChi") for ax in cds_order):
+            raise ValueError("Response CDS axes must be Em/Phi/PsiChi")
+
+        self._data = prepare_binned(data, cds_order)
+        self._bkg  = prepare_binned(bkg, cds_order)
+
         # Precomputed image response for extended
         # sources
         if precomputed_psr_file is not None:
             logger.info("... loading the pre-computed image response ...")
             self.image_response = ExtendedSourceResponse.open(precomputed_psr_file)
             logger.info("--> done")
-
-        if data.is_sparse:
-            self._data = data.contents.todense()
-        else:
-            self._data = data.contents.value
-            
-        if bkg.is_sparse:
-            self._bkg = bkg.contents.todense()
-        else:
-            self._bkg = bkg.contents.value
 
         try:
             data_frame = data.axes["PsiChi"].coordsys.name
@@ -96,7 +122,7 @@ class COSILike(PluginPrototype):
                 self._coordsys = data_frame
         except:
             if coordsys is None:
-                raise RuntimeError("There is no coordinate system attached to the binned data. One must be provided by specifiying coordsys='galactic' or 'spacecraftframe'.")
+                raise RuntimeError("There is no coordinate system attached to the binned data. One must be provided by specifying either 'spacecraftframe' or an inertial frame for the coordsys argument.")
             else:
                 self._coordsys = coordsys
 
@@ -110,7 +136,7 @@ class COSILike(PluginPrototype):
             self._nuisance_parameters[self._bkg_par.name] = self._bkg_par
         else:
             raise RuntimeError("Nuisance parameter must be astromodels.core.parameter.Parameter object")
-        
+
         # Temporary fix to only print log-likelihood warning once max per fit
         self._printed_warning = False
 
@@ -127,7 +153,7 @@ class COSILike(PluginPrototype):
         JointLikelihood object.
 
         """
-        
+
         point_sources = model.point_sources
         extended_sources = model.extended_sources
 
@@ -137,21 +163,21 @@ class COSILike(PluginPrototype):
         # used only for point sources internally
         self._source_location = {}
         self._psr = {}
-        
+
         for name in point_sources:
             self._source_location[name] = None
             self._psr[name] = None
             self._expected_counts[name] = None
-            
+
         for name in extended_sources:
              self._expected_counts[name] = None
-        
+
         self._model = model
-        
+
     def compute_expectation(self, model):
         """
         Compute the total expected counts of the model
-        
+
         Parameters
         ----------
         model : astromodels.core.model.Model
@@ -162,21 +188,30 @@ class COSILike(PluginPrototype):
         signal : total expected counts
         """
 
+        def get_point_source_coords(source):
+            """
+            Extract the sky position of a point source.  Get the coordinate
+            values in a generic way so that we aren't dependent on
+            whether the position was stored in galactic or ICRS.
+            """
+            pos = source.position
+            return tuple(p.value for p in pos.parameters.values())
+
         signal = None
 
         # Get expectation for extended sources
         for name, source in model.extended_sources.items():
             # Set spectrum
             # Note: the spectral parameters are updated internally by 3ML
-            # during the likelihood scan. 
+            # during the likelihood scan.
 
             # Get expectation using precomputed psr in Galactic coordinates
             total_expectation = \
                 self.image_response.get_expectation_from_astromodel(source)
-            
+
             # Save expected counts for each source,
             # in order to enable easy plotting after likelihood scan
-            self._expected_counts[name] = total_expectation.copy()
+            self._expected_counts[name] = total_expectation
 
             # extract expectation from source as raw numpy array
             if total_expectation.is_sparse:
@@ -185,43 +220,43 @@ class COSILike(PluginPrototype):
                 total_expectation = total_expectation.contents.value
             else:
                 total_expectation = total_expectation.contents
-                            
+
             # Add source to signal
             if signal is None:
-                signal = total_expectation
+                signal = total_expectation.copy()
             else:
                 signal += total_expectation
-                
+
         # Get expectation for point sources
         for name, source in model.point_sources.items():
+            src_coords = get_point_source_coords(source)
 
-            # source location changed
-            if source.position.sky_coord != self._source_location[name]:
+            if src_coords != self._source_location[name]: # source loc changed
                 logger.info(f"... Re-calculating the point source response of {name} ...")
+
+                self._source_location[name] = src_coords
+
                 coord = source.position.sky_coord
-                self._source_location[name] = coord.copy()
-                
+
                 if self._coordsys == 'spacecraftframe':
                     dwell_time_map = self._get_dwell_time_map(coord)
                     self._psr[name] = self._dr.get_point_source_response(exposure_map=dwell_time_map)
-                elif self._coordsys == 'galactic':
+                else:
+                    coord = coord.transform_to(self._coordsys)
                     scatt_map = self._get_scatt_map(coord)
                     self._psr[name] = self._dr.get_point_source_response(coord=coord, scatt_map=scatt_map)
-                else:
-                    raise RuntimeError("Unknown coordinate system")
-                
+
                 logger.info(f"--> done (source name : {name})")
-                
+
             # Convolve with spectrum
             # See also the Detector Response and Source Injector tutorials
             spectrum = source.spectrum.main.shape
             total_expectation = self._psr[name].get_expectation(spectrum)
-            total_expectation.project(('Em', 'Phi', 'PsiChi'))
-            
+
             # Save expected counts for each source,
             # in order to enable easy plotting after likelihood scan
-            self._expected_counts[name] = total_expectation.copy()
-            
+            self._expected_counts[name] = total_expectation
+
             # extract expectation from source as raw numpy array
             if total_expectation.is_sparse:
                 total_expectation = total_expectation.contents.todense()
@@ -229,20 +264,20 @@ class COSILike(PluginPrototype):
                 total_expectation = total_expectation.contents.value
             else:
                 total_expectation = total_expectation.contents
-                
+
             # Add source to signal
             if signal is None:
-                signal = total_expectation
+                signal = total_expectation.copy()
             else:
                 signal += total_expectation
 
         return signal
-        
-                
+
+
     def get_log_like(self):
         """
         Calculate the log-likelihood.
-        
+
         Returns
         ----------
         log_like : float
@@ -252,31 +287,31 @@ class COSILike(PluginPrototype):
         if self._model is None:
             raise ValueError("Must set model before computing likelihood!")
 
-        signal = self.compute_expectation(self._model)
-        
+        expectation = self.compute_expectation(self._model)
+
         if self._fit_nuisance_params:
             # Compute expectation including free background parameter
             nv = self._nuisance_parameters[self._bkg_par.name].value
-            expectation = signal + nv * self._bkg
+            expectation += nv * self._bkg
         else:
             # Compute expectation without background parameter
-            expectation = signal + self._bkg
+            expectation += self._bkg
 
         # avoid -infinite log-likelihood (occurs when expected counts
         # = 0 but data != 0)
         expectation += 1e-12
-        
+
         if not self._printed_warning:
             # This 1e-12 should be defined as a parameter in the near
             # future (HY)
             logger.warning("Adding 1e-12 to each bin of the expectation to avoid log-likelihood = -inf.")
             self._printed_warning = True
-                
+
         # Compute the log-likelihood:
         log_like = np.nansum(self._data * np.log(expectation) - expectation)
-        
+
         return log_like
-    
+
     def inner_fit(self):
         """
         Required for 3ML fit.
@@ -286,38 +321,38 @@ class COSILike(PluginPrototype):
         in fact, it is called on every iteration, so the nuisance
         params are treated as "just another parameter" to optimize.
         """
-        
+
         return self.get_log_like()
-    
+
     def _get_dwell_time_map(self, coord):
         """
         Get the dwell time map of the source in the inertial (spacecraft)
         frame.
-        
+
         Parameters
         ----------
         coord : astropy.coordinates.SkyCoord
             Coordinates of the target source
-        
+
         Returns
         -------
         dwell_time_map : mhealpy.containers.healpix_map.HealpixMap
             Dwell time map
 
         """
-        
+
         src_path = self._sc_orientation.get_target_in_sc_frame(coord)
         dwell_time_map = \
             self._sc_orientation.get_dwell_map(base = self._dr,
                                                src_path = src_path)
-        
+
         return dwell_time_map
-    
+
     def _get_scatt_map(self, coord):
         """
         Get the spacecraft attitude map of the source in the inertial
         (spacecraft) frame.
-        
+
         Parameters
         ----------
         coord : astropy.coordinates.SkyCoord
@@ -328,24 +363,24 @@ class COSILike(PluginPrototype):
         scatt_map : cosipy.spacecraftfile.scatt_map.SpacecraftAttitudeMap
 
         """
-        
+
         scatt_map = \
             self._sc_orientation.get_scatt_map(nside = self._dr.nside * 2,
                                                target_coord = coord,
                                                earth_occ = self.earth_occ)
-        
+
         return scatt_map
-    
+
     def set_inner_minimization(self, flag: bool):
         """
         Turn on the minimization of the internal COSI (nuisance) parameters.
-        
+
         Parameters
         ----------
         flag : bool
             Turns on and off the minimization of the internal parameters
         """
-        
+
         self._fit_nuisance_params: bool = bool(flag)
 
         for parameter in self._nuisance_parameters:

--- a/cosipy/ts_map/fast_ts_fit.py
+++ b/cosipy/ts_map/fast_ts_fit.py
@@ -311,7 +311,15 @@ class FastTSMap():
         data_cds_array, bkg_model_cds_array, psr_cache = \
             self._prepare_inputs(energy_channel, spectrum, max_cache_size)
 
-        hypothesis_coords = self._get_hypothesis_coords(nside)
+        if self._cds_frame == Frame.LOCAL:
+            # compute possible source dirs in same frame
+            # we will use to translate them to local-frame paths
+            hyp_frame = self._orientation.frame
+        else: # galactic frame
+            hyp_frame = "galactic"
+
+        hypothesis_coords = self._get_hypothesis_coords(nside,
+                                                        coordsys=hyp_frame)
 
         results = [
             self._fit_one_direction(source,

--- a/cosipy/ts_map/moc_ts_fit.py
+++ b/cosipy/ts_map/moc_ts_fit.py
@@ -7,7 +7,7 @@ import mhealpy as hp
 
 import matplotlib.pyplot as plt
 
-from .fast_ts_fit import FastTSMap
+from .fast_ts_fit import FastTSMap, Frame
 
 import logging
 logger = logging.getLogger(__name__)
@@ -216,7 +216,15 @@ class MOCTSMap(FastTSMap):
 
         while nside <= max_nside:
 
-            src_locs = self._get_hypothesis_coords(nside, pixels)
+            if self._cds_frame == Frame.LOCAL:
+                # compute possible source dirs in same frame
+                # we will use to translate them to local-frame paths
+                hyp_frame = self._orientation.frame
+            else: # galactic frame
+                hyp_frame = "galactic"
+
+            src_locs = self._get_hypothesis_coords(nside, pixels,
+                                                   coordsys=hyp_frame)
 
             results = [
                 self._fit_one_direction(source,

--- a/docs/tutorials/spectral_fits/extended_source_fit/diffuse_511_spectral_fit.ipynb
+++ b/docs/tutorials/spectral_fits/extended_source_fit/diffuse_511_spectral_fit.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d3dc3a08",
    "metadata": {},
    "source": [
     "# Diffuse 511 Spectral Fit in Galactic Coordinates\n",
@@ -40,7 +39,6 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "af0ff1b1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +66,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6114d2b",
    "metadata": {},
    "source": [
     "## Get the data\n",
@@ -78,7 +75,6 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "afbf58d3",
    "metadata": {
     "scrolled": true
    },
@@ -101,7 +97,6 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "59af8882",
    "metadata": {
     "scrolled": true
    },
@@ -124,7 +119,6 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "f45eab34",
    "metadata": {
     "scrolled": true
    },
@@ -147,7 +141,6 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "14e3a3aa",
    "metadata": {},
    "outputs": [
     {
@@ -168,7 +161,6 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "aeb24c91",
    "metadata": {},
    "outputs": [
     {
@@ -189,7 +181,6 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "3581bc1a",
    "metadata": {
     "tags": []
    },
@@ -219,7 +210,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "327cee87",
    "metadata": {},
    "source": [
     "## Create the combined data\n",
@@ -231,7 +221,6 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "ed644f4b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +234,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4493ec0",
    "metadata": {
     "tags": []
    },
@@ -258,7 +246,6 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "a87fdde1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +257,6 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "cf2fb152",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +268,6 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "115ed66f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +278,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a35bc8e",
    "metadata": {},
    "source": [
     "## Read in the binned data\n",
@@ -303,7 +287,6 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "4c13f074",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +305,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72570ad5",
    "metadata": {
     "tags": []
    },
@@ -337,7 +319,6 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "e40a5d33",
    "metadata": {
     "tags": []
    },
@@ -596,7 +577,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4867b10",
    "metadata": {},
    "source": [
     "Let's make some plots to look at the extended source:"
@@ -605,7 +585,6 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "a5d3d39c",
    "metadata": {},
    "outputs": [
     {
@@ -630,7 +609,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c0f468a",
    "metadata": {},
    "source": [
     "An extended source in astromodels corresponds to a skymap, which is normalized so that the sum over the entire sky, multiplied by the pixel area, equals 1. The pixel values in the skymap serve as weights, which we can use to scale the input spectrum, in order to get the model counts for any location on the sky. This is all handled internally within cosipy, but for demonstration purposes, let's take a look at the skymap:"
@@ -639,7 +617,6 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "f7e3e3b5",
    "metadata": {},
    "outputs": [
     {
@@ -666,7 +643,6 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "fdac4f0b",
    "metadata": {},
    "outputs": [
     {
@@ -703,7 +679,6 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "60311b24",
    "metadata": {},
    "outputs": [
     {
@@ -728,7 +703,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fb18ce05",
    "metadata": {},
    "source": [
     "## Setup the COSI 3ML plugin and perform the likelihood fit\n",
@@ -738,7 +712,6 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "21da19ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -750,7 +723,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f1e47f1c",
    "metadata": {},
    "source": [
     "Setup the COSI 3ML plugin:"
@@ -759,15 +731,14 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "837541f1",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1min 47s, sys: 10.6 s, total: 1min 57s\n",
-      "Wall time: 1min 58s\n"
+      "CPU times: user 1min 49s, sys: 11.7 s, total: 2min 1s\n",
+      "Wall time: 2min 2s\n"
      ]
     }
    ],
@@ -797,7 +768,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a18c3b1",
    "metadata": {
     "collapsed": true,
     "jupyter": {
@@ -812,7 +782,6 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "90a2449e",
    "metadata": {
     "scrolled": true,
     "tags": []
@@ -821,11 +790,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">15:10:17 </span><span style=\"color: #00ffaf; text-decoration-color: #00ffaf\">INFO    </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> set the minimizer to minuit                                              </span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">joint_likelihood.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py#994\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">994</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">10:12:48 </span><span style=\"color: #00ffaf; text-decoration-color: #00ffaf\">INFO    </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> set the minimizer to minuit                                              </span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">joint_likelihood.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py#994\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">994</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[38;5;46m15:10:17\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;49mINFO    \u001b[0m \u001b[1;38;5;251m set the minimizer to minuit                                             \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=127778;file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py\u001b\\\u001b[2mjoint_likelihood.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=898211;file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py#994\u001b\\\u001b[2m994\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001b[38;5;46m10:12:48\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;49mINFO    \u001b[0m \u001b[1;38;5;251m set the minimizer to minuit                                             \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=838902;file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py\u001b\\\u001b[2mjoint_likelihood.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=347377;file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py#994\u001b\\\u001b[2m994\u001b[0m\u001b]8;;\u001b\\\n"
       ]
      },
      "metadata": {},
@@ -841,12 +810,12 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">15:10:22 </span><span style=\"color: #af5fd7; text-decoration-color: #af5fd7\">WARNING </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> get_number_of_data_points not implemented, values for statistical        </span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">plugin_prototype.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py#119\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">119</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">10:12:53 </span><span style=\"color: #af5fd7; text-decoration-color: #af5fd7\">WARNING </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> get_number_of_data_points not implemented, values for statistical        </span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">plugin_prototype.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py#119\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">119</span></a>\n",
        "<span style=\"color: #00ff00; text-decoration-color: #00ff00\">         </span>         <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\">measurements such as AIC or BIC are unreliable                            </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                       </span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[38;5;46m15:10:22\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;134mWARNING \u001b[0m \u001b[1;38;5;251m get_number_of_data_points not implemented, values for statistical       \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=614847;file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py\u001b\\\u001b[2mplugin_prototype.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=843583;file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py#119\u001b\\\u001b[2m119\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[38;5;46m10:12:53\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;134mWARNING \u001b[0m \u001b[1;38;5;251m get_number_of_data_points not implemented, values for statistical       \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=229588;file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py\u001b\\\u001b[2mplugin_prototype.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=354907;file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py#119\u001b\\\u001b[2m119\u001b[0m\u001b]8;;\u001b\\\n",
        "\u001b[38;5;46m         \u001b[0m         \u001b[1;38;5;251mmeasurements such as AIC or BIC are unreliable                           \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b[2m                       \u001b[0m\n"
       ]
      },
@@ -857,8 +826,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 41.8 s, sys: 13 ms, total: 41.9 s\n",
-      "Wall time: 5.26 s\n"
+      "CPU times: user 38.6 s, sys: 182 ms, total: 38.8 s\n",
+      "Wall time: 4.9 s\n"
      ]
     }
    ],
@@ -874,7 +843,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cfd292e5",
    "metadata": {
     "collapsed": true,
     "jupyter": {
@@ -890,7 +858,6 @@
   {
    "cell_type": "code",
    "execution_count": 21,
-   "id": "8ad15fcd",
    "metadata": {
     "tags": []
    },
@@ -985,7 +952,7 @@
     {
      "data": {
       "text/html": [
-       "<div><table id=\"table140662664934704\">\n",
+       "<div><table id=\"table22402441236784\">\n",
        "<tr><td>1.00</td><td>-0.40</td></tr>\n",
        "<tr><td>-0.40</td><td>1.00</td></tr>\n",
        "</table></div>"
@@ -1190,7 +1157,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "03bb6a88",
    "metadata": {},
    "source": [
     "Now let's make some plots. <br>\n",
@@ -1200,7 +1166,6 @@
   {
    "cell_type": "code",
    "execution_count": 22,
-   "id": "9f845a89",
    "metadata": {},
    "outputs": [
     {
@@ -1231,7 +1196,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19d5e7ff",
    "metadata": {},
    "source": [
     "Now let's compare the predicted counts to the injected counts:"
@@ -1240,7 +1204,6 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "92d6c1d5",
    "metadata": {
     "tags": []
    },
@@ -1290,7 +1253,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8c6f8b7",
    "metadata": {},
    "source": [
     "Let's also compare the projection onto Psichi:"
@@ -1299,7 +1261,6 @@
   {
    "cell_type": "code",
    "execution_count": 24,
-   "id": "ecb9bca0",
    "metadata": {},
    "outputs": [
     {
@@ -1335,7 +1296,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd9f6c3d",
    "metadata": {},
    "source": [
     "Here is a summary of the results:\n",
@@ -1351,7 +1311,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20d322f1",
    "metadata": {},
    "source": [
     "## **********************************************************\n",
@@ -1360,7 +1319,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6da299ce",
    "metadata": {},
    "source": [
     "Define the point source. <br>\n",
@@ -1370,7 +1328,6 @@
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "dc85da2d",
    "metadata": {},
    "outputs": [
     {
@@ -1447,7 +1404,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d1334d15",
    "metadata": {},
    "source": [
     "Redefine the first source.<br> \n",
@@ -1457,7 +1413,6 @@
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "083aebb2",
    "metadata": {},
    "outputs": [
     {
@@ -1716,7 +1671,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6409c85",
    "metadata": {},
    "source": [
     "Setup the COSI 3ML plugin using two sources in the model:"
@@ -1725,15 +1679,14 @@
   {
    "cell_type": "code",
    "execution_count": 27,
-   "id": "11394acc",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1min 47s, sys: 12.7 s, total: 1min 59s\n",
-      "Wall time: 2min\n"
+      "CPU times: user 1min 52s, sys: 12 s, total: 2min 4s\n",
+      "Wall time: 2min 5s\n"
      ]
     }
    ],
@@ -1763,7 +1716,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8e3ebced",
    "metadata": {},
    "source": [
     "Display the model:"
@@ -1772,7 +1724,6 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "6fc90305",
    "metadata": {},
    "outputs": [
     {
@@ -1909,7 +1860,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f2fd3f4",
    "metadata": {},
    "source": [
     "Perform the likelihood fit:"
@@ -1918,7 +1868,6 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "106b5f41",
    "metadata": {
     "scrolled": true,
     "tags": []
@@ -1927,11 +1876,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">15:12:26 </span><span style=\"color: #00ffaf; text-decoration-color: #00ffaf\">INFO    </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> set the minimizer to minuit                                              </span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">joint_likelihood.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py#994\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">994</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">10:15:03 </span><span style=\"color: #00ffaf; text-decoration-color: #00ffaf\">INFO    </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> set the minimizer to minuit                                              </span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">joint_likelihood.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py#994\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">994</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[38;5;46m15:12:26\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;49mINFO    \u001b[0m \u001b[1;38;5;251m set the minimizer to minuit                                             \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=661602;file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py\u001b\\\u001b[2mjoint_likelihood.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=241456;file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py#994\u001b\\\u001b[2m994\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001b[38;5;46m10:15:03\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;49mINFO    \u001b[0m \u001b[1;38;5;251m set the minimizer to minuit                                             \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=485087;file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py\u001b\\\u001b[2mjoint_likelihood.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=780675;file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py#994\u001b\\\u001b[2m994\u001b[0m\u001b]8;;\u001b\\\n"
       ]
      },
      "metadata": {},
@@ -1947,12 +1896,12 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">15:12:42 </span><span style=\"color: #af5fd7; text-decoration-color: #af5fd7\">WARNING </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> get_number_of_data_points not implemented, values for statistical        </span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">plugin_prototype.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py#119\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">119</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">10:15:18 </span><span style=\"color: #af5fd7; text-decoration-color: #af5fd7\">WARNING </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> get_number_of_data_points not implemented, values for statistical        </span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">plugin_prototype.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py#119\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">119</span></a>\n",
        "<span style=\"color: #00ff00; text-decoration-color: #00ff00\">         </span>         <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\">measurements such as AIC or BIC are unreliable                            </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                       </span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[38;5;46m15:12:42\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;134mWARNING \u001b[0m \u001b[1;38;5;251m get_number_of_data_points not implemented, values for statistical       \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=553179;file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py\u001b\\\u001b[2mplugin_prototype.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=71426;file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py#119\u001b\\\u001b[2m119\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[38;5;46m10:15:18\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;134mWARNING \u001b[0m \u001b[1;38;5;251m get_number_of_data_points not implemented, values for statistical       \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=210183;file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py\u001b\\\u001b[2mplugin_prototype.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=410787;file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py#119\u001b\\\u001b[2m119\u001b[0m\u001b]8;;\u001b\\\n",
        "\u001b[38;5;46m         \u001b[0m         \u001b[1;38;5;251mmeasurements such as AIC or BIC are unreliable                           \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b[2m                       \u001b[0m\n"
       ]
      },
@@ -2055,7 +2004,7 @@
     {
      "data": {
       "text/html": [
-       "<div><table id=\"table140662575831120\">\n",
+       "<div><table id=\"table22388549719904\">\n",
        "<tr><td>1.00</td><td>-0.95</td><td>-0.18</td></tr>\n",
        "<tr><td>-0.95</td><td>1.00</td><td>0.05</td></tr>\n",
        "<tr><td>-0.18</td><td>0.05</td><td>1.00</td></tr>\n",
@@ -2200,8 +2149,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1min 28s, sys: 700 ms, total: 1min 29s\n",
-      "Wall time: 16 s\n"
+      "CPU times: user 1min 18s, sys: 672 ms, total: 1min 19s\n",
+      "Wall time: 14.7 s\n"
      ]
     }
    ],
@@ -2216,7 +2165,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f4b050f",
    "metadata": {},
    "source": [
     "We see that the normalization of the point source has gone to zero, and we essentially get the same results as the first fit. This is not entirely surprising, considering that the two components have a high degree of degeneracy, and the point source is subdominant. \n",
@@ -2226,7 +2174,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e983de4",
    "metadata": {},
    "source": [
     "## *****************************************\n",
@@ -2235,7 +2182,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b50b0a63",
    "metadata": {},
    "source": [
     "## Read in the binned data\n",
@@ -2245,7 +2191,6 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "4b5c4ea0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2260,7 +2205,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d806eec8",
    "metadata": {},
    "source": [
     "## Define source\n",
@@ -2270,7 +2214,6 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "6f06701e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2318,7 +2261,6 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "a3bed0d3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2344,7 +2286,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e298ccaa",
    "metadata": {},
    "source": [
     "For the Asymm_Gaussian_on_sphere model, note that e is the eccentricity of the Gaussian ellipse, defined such that the scale height b of the disk is given by $b = a \\sqrt{(1-e^2)}$"
@@ -2353,16 +2294,13 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "229770ad",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Define Spatio-spectral models\n",
     "\n",
     "# Bulge\n",
-    "c = SkyCoord(l=0*u.deg, b=0*u.deg, frame='galactic')\n",
-    "c_icrs = c.transform_to('icrs')\n",
-    "ModelCentralPoint = PointSource('centralPoint', ra = c_icrs.ra.deg, dec = c_icrs.dec.deg, spectral_shape=SpecCentralPoint)\n",
+    "ModelCentralPoint = PointSource('centralPoint', l = 0, b = 0, spectral_shape=SpecCentralPoint)\n",
     "ModelNarrowBulge = ExtendedSource('narrowBulge',spectral_shape=SpecNarrowBulge,spatial_shape=MapNarrowBulge)\n",
     "ModelBroadBulge = ExtendedSource('broadBulge',spectral_shape=SpecBroadBulge,spatial_shape=MapBroadBulge)\n",
     "\n",
@@ -2373,7 +2311,6 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "3613f683",
    "metadata": {},
    "outputs": [
     {
@@ -2676,7 +2613,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06fdccf1",
    "metadata": {},
    "source": [
     "Make some plots to look at these new extended sources:"
@@ -2685,7 +2621,6 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "5e046a06",
    "metadata": {},
    "outputs": [
     {
@@ -2717,7 +2652,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d0e2653",
    "metadata": {},
    "source": [
     "The orthopositronium spectral component appears as the low-energy tail of the 511 keV line."
@@ -2726,7 +2660,6 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "9c25d07b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2755,7 +2688,6 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "3866405b",
    "metadata": {},
    "outputs": [
     {
@@ -2815,7 +2747,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d2014b6",
    "metadata": {},
    "source": [
     "## Instantiate the COSI 3ML plugin and perform the likelihood fit\n",
@@ -2825,7 +2756,6 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "1c3caa29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2839,7 +2769,6 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "91c210b6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2854,7 +2783,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9899c7a4",
    "metadata": {},
    "source": [
     "We should re-run the following cell every time we set up a new fit:"
@@ -2863,15 +2791,14 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "3f24160f",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1min 44s, sys: 36.1 s, total: 2min 20s\n",
-      "Wall time: 2min 22s\n"
+      "CPU times: user 1min 46s, sys: 15.7 s, total: 2min 1s\n",
+      "Wall time: 2min 2s\n"
      ]
     }
    ],
@@ -2892,7 +2819,6 @@
   {
    "cell_type": "code",
    "execution_count": 41,
-   "id": "a64a965f",
    "metadata": {},
    "outputs": [
     {
@@ -3148,15 +3074,15 @@
        "      <td>keV-1 s-1 cm-2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>centralPoint.position.ra</th>\n",
-       "      <td>266.404988</td>\n",
+       "      <th>centralPoint.position.l</th>\n",
+       "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>360.0</td>\n",
        "      <td>deg</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>centralPoint.position.dec</th>\n",
-       "      <td>-28.936178</td>\n",
+       "      <th>centralPoint.position.b</th>\n",
+       "      <td>0.0</td>\n",
        "      <td>-90.0</td>\n",
        "      <td>90.0</td>\n",
        "      <td>deg</td>\n",
@@ -3257,34 +3183,34 @@
        "Fixed parameters (27):\n",
        "---------------------\n",
        "\n",
-       "                                               value min_value  max_value  \\\n",
-       "disk.Asymm_Gaussian_on_sphere.lon0               0.0       0.0      360.0   \n",
-       "disk.Asymm_Gaussian_on_sphere.lat0               0.0     -90.0       90.0   \n",
-       "disk.Asymm_Gaussian_on_sphere.a                 90.0       0.0       90.0   \n",
-       "disk.Asymm_Gaussian_on_sphere.theta              0.0     -90.0       90.0   \n",
-       "disk.spectrum.main.composite.mu_1              511.0      None       None   \n",
-       "disk.spectrum.main.composite.sigma_1            1.27       0.0       None   \n",
-       "disk.spectrum.main.composite.K_2              0.0045       0.0  1000000.0   \n",
-       "broadBulge.Gaussian_on_sphere.lon0               0.0       0.0      360.0   \n",
-       "broadBulge.Gaussian_on_sphere.lat0               0.0     -90.0       90.0   \n",
-       "broadBulge.Gaussian_on_sphere.sigma              8.7       0.0       20.0   \n",
-       "broadBulge.spectrum.main.composite.F_1       0.00073       0.0        1.0   \n",
-       "broadBulge.spectrum.main.composite.mu_1        511.0      None       None   \n",
-       "broadBulge...sigma_1                            0.85       0.0       None   \n",
-       "broadBulge.spectrum.main.composite.K_2        0.0027       0.0  1000000.0   \n",
-       "narrowBulge.Gaussian_on_sphere.lon0           359.75       0.0      360.0   \n",
-       "narrowBulge.Gaussian_on_sphere.lat0            -1.25     -90.0       90.0   \n",
-       "narrowBulge.Gaussian_on_sphere.sigma             2.5       0.0       20.0   \n",
-       "narrowBulge.spectrum.main.composite.F_1      0.00028       0.0        1.0   \n",
-       "narrowBulge.spectrum.main.composite.mu_1       511.0      None       None   \n",
-       "narrowBulge...sigma_1                           0.85       0.0       None   \n",
-       "narrowBulge.spectrum.main.composite.K_2       0.0011       0.0  1000000.0   \n",
-       "centralPoint.position.ra                  266.404988       0.0      360.0   \n",
-       "centralPoint.position.dec                 -28.936178     -90.0       90.0   \n",
-       "centralPoint.spectrum.main.composite.F_1     0.00012       0.0        1.0   \n",
-       "centralPoint...mu_1                            511.0      None       None   \n",
-       "centralPoint...sigma_1                          0.85       0.0       None   \n",
-       "centralPoint.spectrum.main.composite.K_2     0.00046       0.0  1000000.0   \n",
+       "                                            value min_value  max_value  \\\n",
+       "disk.Asymm_Gaussian_on_sphere.lon0            0.0       0.0      360.0   \n",
+       "disk.Asymm_Gaussian_on_sphere.lat0            0.0     -90.0       90.0   \n",
+       "disk.Asymm_Gaussian_on_sphere.a              90.0       0.0       90.0   \n",
+       "disk.Asymm_Gaussian_on_sphere.theta           0.0     -90.0       90.0   \n",
+       "disk.spectrum.main.composite.mu_1           511.0      None       None   \n",
+       "disk.spectrum.main.composite.sigma_1         1.27       0.0       None   \n",
+       "disk.spectrum.main.composite.K_2           0.0045       0.0  1000000.0   \n",
+       "broadBulge.Gaussian_on_sphere.lon0            0.0       0.0      360.0   \n",
+       "broadBulge.Gaussian_on_sphere.lat0            0.0     -90.0       90.0   \n",
+       "broadBulge.Gaussian_on_sphere.sigma           8.7       0.0       20.0   \n",
+       "broadBulge.spectrum.main.composite.F_1    0.00073       0.0        1.0   \n",
+       "broadBulge.spectrum.main.composite.mu_1     511.0      None       None   \n",
+       "broadBulge...sigma_1                         0.85       0.0       None   \n",
+       "broadBulge.spectrum.main.composite.K_2     0.0027       0.0  1000000.0   \n",
+       "narrowBulge.Gaussian_on_sphere.lon0        359.75       0.0      360.0   \n",
+       "narrowBulge.Gaussian_on_sphere.lat0         -1.25     -90.0       90.0   \n",
+       "narrowBulge.Gaussian_on_sphere.sigma          2.5       0.0       20.0   \n",
+       "narrowBulge.spectrum.main.composite.F_1   0.00028       0.0        1.0   \n",
+       "narrowBulge.spectrum.main.composite.mu_1    511.0      None       None   \n",
+       "narrowBulge...sigma_1                        0.85       0.0       None   \n",
+       "narrowBulge.spectrum.main.composite.K_2    0.0011       0.0  1000000.0   \n",
+       "centralPoint.position.l                       0.0       0.0      360.0   \n",
+       "centralPoint.position.b                       0.0     -90.0       90.0   \n",
+       "centralPoint.spectrum.main.composite.F_1  0.00012       0.0        1.0   \n",
+       "centralPoint...mu_1                         511.0      None       None   \n",
+       "centralPoint...sigma_1                       0.85       0.0       None   \n",
+       "centralPoint.spectrum.main.composite.K_2  0.00046       0.0  1000000.0   \n",
        "\n",
        "                                                    unit  \n",
        "disk.Asymm_Gaussian_on_sphere.lon0                   deg  \n",
@@ -3308,8 +3234,8 @@
        "narrowBulge.spectrum.main.composite.mu_1             keV  \n",
        "narrowBulge...sigma_1                                keV  \n",
        "narrowBulge.spectrum.main.composite.K_2   keV-1 s-1 cm-2  \n",
-       "centralPoint.position.ra                             deg  \n",
-       "centralPoint.position.dec                            deg  \n",
+       "centralPoint.position.l                              deg  \n",
+       "centralPoint.position.b                              deg  \n",
        "centralPoint.spectrum.main.composite.F_1        s-1 cm-2  \n",
        "centralPoint...mu_1                                  keV  \n",
        "centralPoint...sigma_1                               keV  \n",
@@ -3352,7 +3278,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "05d1a3e3",
    "metadata": {},
    "source": [
     "Before we perform the fit, let's first change the 3ML console logging level, in order to mimimize the amount of console output."
@@ -3361,7 +3286,6 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "77794760",
    "metadata": {
     "scrolled": true
    },
@@ -3369,11 +3293,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">15:16:14 </span><span style=\"color: #00ffaf; text-decoration-color: #00ffaf\">INFO    </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> set the minimizer to minuit                                              </span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">joint_likelihood.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py#994\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">994</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">10:18:17 </span><span style=\"color: #00ffaf; text-decoration-color: #00ffaf\">INFO    </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> set the minimizer to minuit                                              </span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">joint_likelihood.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py#994\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">994</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[38;5;46m15:16:14\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;49mINFO    \u001b[0m \u001b[1;38;5;251m set the minimizer to minuit                                             \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=924377;file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py\u001b\\\u001b[2mjoint_likelihood.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=585270;file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py#994\u001b\\\u001b[2m994\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001b[38;5;46m10:18:17\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;49mINFO    \u001b[0m \u001b[1;38;5;251m set the minimizer to minuit                                             \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=193722;file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py\u001b\\\u001b[2mjoint_likelihood.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=17370;file:///project/cassini/cosi/threeML_git/threeML/classicMLE/joint_likelihood.py#994\u001b\\\u001b[2m994\u001b[0m\u001b]8;;\u001b\\\n"
       ]
      },
      "metadata": {},
@@ -3389,12 +3313,12 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">15:16:49 </span><span style=\"color: #af5fd7; text-decoration-color: #af5fd7\">WARNING </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> get_number_of_data_points not implemented, values for statistical        </span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">plugin_prototype.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py#119\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">119</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">10:18:46 </span><span style=\"color: #af5fd7; text-decoration-color: #af5fd7\">WARNING </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> get_number_of_data_points not implemented, values for statistical        </span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">plugin_prototype.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py#119\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">119</span></a>\n",
        "<span style=\"color: #00ff00; text-decoration-color: #00ff00\">         </span>         <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\">measurements such as AIC or BIC are unreliable                            </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                       </span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[38;5;46m15:16:49\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;134mWARNING \u001b[0m \u001b[1;38;5;251m get_number_of_data_points not implemented, values for statistical       \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=409704;file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py\u001b\\\u001b[2mplugin_prototype.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=10962;file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py#119\u001b\\\u001b[2m119\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[38;5;46m10:18:46\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;134mWARNING \u001b[0m \u001b[1;38;5;251m get_number_of_data_points not implemented, values for statistical       \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=755965;file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py\u001b\\\u001b[2mplugin_prototype.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=430264;file:///project/cassini/cosi/threeML_git/threeML/plugin_prototype.py#119\u001b\\\u001b[2m119\u001b[0m\u001b]8;;\u001b\\\n",
        "\u001b[38;5;46m         \u001b[0m         \u001b[1;38;5;251mmeasurements such as AIC or BIC are unreliable                           \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b[2m                       \u001b[0m\n"
       ]
      },
@@ -3405,8 +3329,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3min 44s, sys: 994 ms, total: 3min 45s\n",
-      "Wall time: 34.5 s\n"
+      "CPU times: user 3min 12s, sys: 888 ms, total: 3min 13s\n",
+      "Wall time: 29.2 s\n"
      ]
     }
    ],
@@ -3420,7 +3344,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e56bc7e3",
    "metadata": {},
    "source": [
     "## Results"
@@ -3429,7 +3352,6 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "9cd0b813",
    "metadata": {
     "scrolled": true
    },
@@ -3482,17 +3404,17 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>disk.Asymm_Gaussian_on_sphere.e</th>\n",
-       "      <td>(9.9985 +/- 0.0005) x 10^-1</td>\n",
+       "      <td>(9.9973 +/- 0.0007) x 10^-1</td>\n",
        "      <td></td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>disk.spectrum.main.composite.F_1</th>\n",
-       "      <td>(1.645 +/- 0.011) x 10^-3</td>\n",
+       "      <td>(1.631 +/- 0.011) x 10^-3</td>\n",
        "      <td>1 / (s cm2)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>background_cosi</th>\n",
-       "      <td>(9.908 +/- 0.032) x 10^-1</td>\n",
+       "      <td>1.0019 +/- 0.0031</td>\n",
        "      <td></td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -3502,9 +3424,9 @@
       "text/plain": [
        "                                                       result         unit\n",
        "parameter                                                                 \n",
-       "disk.Asymm_Gaussian_on_sphere.e   (9.9985 +/- 0.0005) x 10^-1             \n",
-       "disk.spectrum.main.composite.F_1    (1.645 +/- 0.011) x 10^-3  1 / (s cm2)\n",
-       "background_cosi                     (9.908 +/- 0.032) x 10^-1             "
+       "disk.Asymm_Gaussian_on_sphere.e   (9.9973 +/- 0.0007) x 10^-1             \n",
+       "disk.spectrum.main.composite.F_1    (1.631 +/- 0.011) x 10^-3  1 / (s cm2)\n",
+       "background_cosi                             1.0019 +/- 0.0031             "
       ]
      },
      "metadata": {},
@@ -3530,16 +3452,16 @@
     {
      "data": {
       "text/html": [
-       "<div><table id=\"table140662574802960\">\n",
-       "<tr><td>1.00</td><td>-0.32</td><td>0.09</td></tr>\n",
-       "<tr><td>-0.32</td><td>1.00</td><td>-0.60</td></tr>\n",
-       "<tr><td>0.09</td><td>-0.60</td><td>1.00</td></tr>\n",
+       "<div><table id=\"table22388548622512\">\n",
+       "<tr><td>1.00</td><td>-0.15</td><td>0.10</td></tr>\n",
+       "<tr><td>-0.15</td><td>1.00</td><td>-0.60</td></tr>\n",
+       "<tr><td>0.10</td><td>-0.60</td><td>1.00</td></tr>\n",
        "</table></div>"
       ],
       "text/plain": [
-       " 1.00 -0.32  0.09\n",
-       "-0.32  1.00 -0.60\n",
-       " 0.09 -0.60  1.00"
+       " 1.00 -0.15  0.10\n",
+       "-0.15  1.00 -0.60\n",
+       " 0.10 -0.60  1.00"
       ]
      },
      "metadata": {},
@@ -3589,11 +3511,11 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>cosi</th>\n",
-       "      <td>-166795.926926</td>\n",
+       "      <td>-167812.495469</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>total</th>\n",
-       "      <td>-166795.926926</td>\n",
+       "      <td>-167812.495469</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -3601,8 +3523,8 @@
       ],
       "text/plain": [
        "       -log(likelihood)\n",
-       "cosi     -166795.926926\n",
-       "total    -166795.926926"
+       "cosi     -167812.495469\n",
+       "total    -167812.495469"
       ]
      },
      "metadata": {},
@@ -3652,11 +3574,11 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>AIC</th>\n",
-       "      <td>-333593.853852</td>\n",
+       "      <td>-335626.990938</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>BIC</th>\n",
-       "      <td>-333591.853852</td>\n",
+       "      <td>-335624.990938</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -3664,8 +3586,8 @@
       ],
       "text/plain": [
        "     statistical measures\n",
-       "AIC        -333593.853852\n",
-       "BIC        -333591.853852"
+       "AIC        -335626.990938\n",
+       "BIC        -335624.990938"
       ]
      },
      "metadata": {},
@@ -3681,12 +3603,11 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "2268995d",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmgAAAHRCAYAAADewkVpAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAxbJJREFUeJzs3Xd4VNX2N/DvlMykTnrvoYQQAhN6ESGigJQA0ovCDykWEMWXYrn2gnoRUa6IoiAgl4B6adIUCV2KEISEhJqQ3jOTOvW8f0zmZIa0KSd9fZ7H507OnL3PnlwIK3vvtTaPYRgGhBBCCCGk1eC39AAIIYQQQogxCtAIIYQQQloZCtAIIYQQQloZCtAIIYQQQloZCtAIIYQQQloZCtAIIYQQQloZCtAIIYQQQloZCtAIIYQQQloZCtAIIYQQQloZCtAIIaQOcrkcL730EkJCQiAUCsHj8ZCQkID4+HjweDy88847LT3EdiUkJAQhISFW98Pj8TB8+HCr+yGkpVGARgjhDI/Hq/WfWCxGSEgI5s6di5s3bzbreObNmwcej4fU1FSz265cuRJfffUVoqKi8Nprr+Htt9+Gj49PvfcPHz4cPB7P7Oe888474PF4iI+PN7stIaT9Erb0AAgh7c/bb7/NvpbJZLh48SK2bduGX375BWfOnIFUKm25wZno4MGD6Nq1Kw4cOGB0XSKR4ObNm/Dw8GihkRFCOgIK0AghnKtr+W/p0qXYsGEDvvjiC2zdurXZx2SurKwsPProo7Wu29vbo1u3bi0wIkJIR0JLnISQZjFy5EgAQH5+fp3v//e//0VMTAxcXFxga2uLiIgIfPDBB1AoFLXuPX36NMaPH4+AgACIxWL4+Phg4MCBePfdd9l7eDwefvzxRwBAaGgou+Ta2D4n/VIlwzA4efIk206/r+nhPWipqang8Xg4efIk+9yH29QnJCSEHXNMTIxRW0PZ2dl48cUXERISApFIBE9PTzz11FP4+++/G+z/Yfox5ebmYv78+fD29oaDgwMGDx6M06dPAwDKy8uxYsUKBAcHQywWIzIyEnv27KmzP4VCgTVr1iAqKgr29vaQSCQYOnQodu/eXef9DMNgw4YNiIyMhK2tLfz9/bFkyRLIZLIGx23Onw1C2guaQSOENIs//vgDANC3b99a782fPx9btmxBQEAAJk+eDBcXF/z111/417/+hePHj+P333+HUKj7cXXkyBGMHTsWEokEsbGx8Pf3R1FREW7evImvv/6aXV59++23sXfvXly7dg3Lli2Di4sLALD/W5958+Zh+PDhePfddxEcHIx58+YBQL2BnYuLC95++21s3boVaWlpRsu7jQWDL7/8Mvbu3YuTJ09i7ty5dd5///59PPLII8jKysJjjz2GmTNnIj09HXv27MFvv/2GX375BePGjWvwOYZKSkowZMgQODk5YebMmSgqKsKuXbswatQonD9/HosXL0ZRURHGjRsHlUqF//73v5g+fToCAwMxcOBAth+lUolRo0bh5MmT6NatG1588UVUVFTg559/xvTp05GQkICPPvqo1uf98ssv4evri0WLFsHGxgb79u3DhQsXoFQqIRKJao3XnD8bhLQrDCGEcAQAA4B5++232f9eeeUV5pFHHmF4PB4zbtw4Ri6XG7XZsmULA4CZNGkSU1FRYfTe22+/zQBgvvjiC/baU089xQBgEhISaj0/Pz/f6Ou5c+cyAJj79+9b9FmGDRtW6/qJEyfYz2ho2LBhjCU/UvWf8cSJE3W+P3LkSAYA88EHHxhdP3v2LCMQCBg3NzemtLTUpGfp//9ZvHgxo9Fo2Ovbtm1jADCurq7MuHHjmMrKSva9U6dOMQCYiRMnGvX10UcfMQCYJ598klGpVOz13NxcJjg4mAHAnD171mi8AJhOnToxhYWF7PXKykpm4MCBDAAmODjY6Bnm/tnQf8a6/n8jpK2hAI0Qwhl9AFDXf927d2d++umnWm2kUikjFAqZ4uLiWu+p1WrG3d2d6devH3tNH6ClpKQ0Op62HqClp6czAJigoCBGqVTWen/OnDkMAObHH3806VkAGHt7+1pBslqtZoRCIQOAuXv3bq12ISEhTEhIiNG1zp07Mzwej7l582at+zdv3swAYP7v//6PvbZgwQIGAPPDDz/Uul//PX04QDP3z4b+M1KARtoDmhcmhHCOYRj2dXl5ORITE7F69WrMnj0biYmJ+PDDDwEAFRUVuHbtGjw8PPDFF1/U2ZdYLDYqzzF79mz8+uuvGDBgAKZPn46YmBgMGTIEAQEBTfqZWsLVq1cBAEOHDoWNjU2t9x977DHs2LEDV69exTPPPGNSn127doWTk5PRNYFAAG9vb5SXlyMsLKxWG39/f1y4cIH9urS0FHfu3IG/v3+dCROPPfaY0fgB4MqVKwCAYcOG1br/kUcegUAgMLpmyZ8NQtoTCtAIIU3KwcEB/fv3x6+//oqAgAB8+umneO655xAYGIji4mIwDIP8/HyjDf4Neeqpp3Dw4EGsXbsWP/zwAzZt2gQA6NOnDz7++GM88cQTTflxmpV+87yvr2+d7+uvl5SUmNyns7NzndeFQmGD76nVaqvGpW/j7e1dZ/8Ply2x5M8GIe0JZXESQpqFi4sLwsPDoVar2dkUfUAQHR0NRrflot7/DI0dOxZ//vkniouLcfz4cbzyyitITEzEuHHjkJSU1Oyfranovz85OTl1vp+dnW10X3OxZFz617m5ubXuV6vVKCgoqPMZ5v7ZIKS9oACNENJsiouLAQBarRYA4OjoiMjISCQmJqKoqMjs/hwcHPDYY4/h888/x+uvvw6lUonDhw+z7+uXzTQaDQejb5ilz2qoXXR0NADgzJkzRjNYeidOnAAA9O7d26xnWsvJyQmdOnVCZmYmbt++bdK49K/15UgMnTlzptbnt/bPBiFtHQVohJBmsXfvXty/fx82NjYYPHgwe3358uVQKpWYP39+nUt1xcXF7IwbAJw6darOYEU/M2Nvb89ec3d3BwA8ePCAq49RL0uf1VC7gIAAPPHEE0hNTa21D+vChQvYuXMnXF1dMWnSJMsGbYX58+eDYRisWLHCKLgqKCjA+++/z96jpy9X8uGHHxoFXFVVVXjttdfqfIa5fzYIaU9oDxohhHOGJwmUl5cjKSmJndn66KOPjPYhzZ8/H3///Te+/vprdOrUCaNGjUJQUBCKiopw//59nDp1Cv/3f/+Hb775BgDw0ksvITMzE0OGDGELt/7999/4888/ERwcjBkzZrB9jxgxAp999hkWLlyIyZMnw8nJCS4uLliyZAnnn3nEiBHYs2cPnnrqKYwZMwZ2dnYIDg7G008/3WC7mJgY8Pl8vPbaa7hx4wZcXV0BAG+++SYA4JtvvsGQIUOwYsUKHDt2DH379mXroPH5fGzZsqXWpv/m8P/+3//D4cOHsW/fPvTq1QtjxoxBRUUF9uzZg7y8PKxcuRKPPPIIe/+QIUOwdOlSfPXVV+jRowemTJnC1kFzdXWtcz+buX82CGlXmjdplBDSnqGO8hoCgYDx8fFhYmNjmWPHjtXb9sCBA8zYsWMZT09PxsbGhvH29mb69evHvPHGG0alHOLi4pgZM2YwnTt3ZhwcHBgnJycmMjKSef3115m8vLxa/a5du5bp1q0bIxKJ6izl0NBnMafMhlqtZl577TUmNDSULVlharmH7du3M7169WJsbW3Z75uhjIwM5rnnnmOCgoIYGxsbxt3dnZkwYQJz8eJFk/pv7DMxDMMEBwfX+72pr4RIZWUl8+GHHzKRkZGMra0t4+joyAwZMoTZuXNnnf1otVrmq6++Yv//8PX1ZV544QWmpKSkweeb+mejsc9ISFvCYxjaYUkIIYQQ0prQHjRCCCGEkFaGAjRCCCGEkFaGAjRCCCGEkFaGAjRCCCGEkFaGAjRCCCGEkFaGAjRCCCGEkFaGArQ2pqqqCikpKaiqqmrpoRBCCCGkiVCA1sakpaVh4cKFSEtLa+mhEEIIIaSJUIBGCCGEENLKUIBGCCGEENLKUIBGCCGEENLKUIBGCCGEENLKCFt6AIQQQkhTYxgGarUaGo2mpYdC2jkbGxsIBAKr+6EAjRBCSLumVCqRnZ2NioqKlh4K6QB4PB4CAgLg6OhoVT8UoBFCCGm3tFot7t+/D4FAAD8/P4hEIvB4vJYeFmmnGIZBfn4+MjIy0KVLF6tm0ihAI4QQ0m4plUpotVoEBgbC3t6+pYdDOgBPT0+kpqZCpVJZFaBRkgAhhJB2j8+nf+5I8+Bqhpb+xBJCCCHNLCQkBOHh4ZBKpYiIiMCsWbNQXl5ucX9bt25FcnJyve//9ddfiIqKQnR0NI4ePYoxY8YgJSXFpLZNKTU1Fd98843F7bdu3YqJEyeyfQkEAkilUvTq1Qt9+vTBiRMnGmyflZWFoUOHmvSsL774Ajk5ORaP1VwUoBFCCCEtIC4uDgkJCUhMTIRMJsPWrVst7quxIOvHH3/ErFmzcPXqVYwaNQqHDh1CeHi4SW2bUmMBmlqtNqs/JycnJCQk4Nq1a3jjjTcwbdo0MAxT7/1+fn44ffq0SX1TgEYIIYR0IEqlEhUVFXB1dWWv/fvf/0b//v3Ru3dvjB49mj1/+cCBA+jZsyekUil69OiBffv2YfPmzbh8+TJeeeUVSKVSHDp0yKj/NWvWIC4uDhs2bIBUKkVJSQlCQkKQkJDQaNu6fPLJJ4iKikKvXr0wcOBANjt2+/btGDBgAHr37o1HH30U165dA6ALAB9//HHMnDkTUVFR6Nu3L+7duwcAeO6555CSkgKpVIrY2FgAutnFVatWoX///pg7dy5ycnIQExODPn36IDIyEkuWLIFWq210nKNHj0ZBQQEKCwtx+fJlDB48GD179kT//v1x9uxZALoA0cXFhW3D4/Hw0UcfoX///ggNDcWWLVsAAO+99x6ysrIwffp0SKVSJCQkNPp8a1GSACGEkA5l7xtnUSFTNFn/9s5iTPxwSKP3TZ8+HXZ2dkhNTUWfPn0wbdo0AMDOnTuRkpKC8+fPQyAQYPv27XjhhRfw22+/4c0338SmTZswaNAgaLVayOVyuLi4YMeOHXj55ZfZ5T5Dq1evRnJyMqRSKV5++WWj9xYsWNBg24f9+OOP+OWXX3DmzBk4OzujuLgYYrEYZ8+exX//+1+cOnUKYrEYp0+fxqxZs5CYmAgAuHTpEhISEhAaGorVq1fjk08+waZNm/DNN9/g5ZdfrhXwFBYW4sKFC+DxeKiqqsKBAwfg6OgIjUaDCRMmYPfu3ZgxY0aDY/3vf/+LoKAgSCQSPPXUU/juu+8watQonDlzBpMnT8adO3fqbCcWi3Hx4kUkJyejX79+ePrpp/HWW2/hhx9+QFxcHKRSaaPfJy5QgEYIIaRDqZApUFHUdAGaqfT/2KvVaixevBirVq3C2rVrsXfvXly6dAl9+vQBAKPiuiNGjMCyZcswZcoUjBw5stmCBb2DBw/iueeeg7OzMwCws3779u3DtWvXMGDAAPbeoqIiVFZWAgAGDRqE0NBQ9vVXX33V4HPmzZvHbrbXarVYtWoVzpw5A4ZhkJeXhx49etQZoJWWlrLfE39/f+zfvx8pKSng8/kYNWoUAOCRRx6Bt7c3EhISEBAQUKuP2bNnAwC6desGoVCInJycOu9rahSgEUII6VDsncWtqn+hUIjJkydjxYoVWLt2LRiGwWuvvYZFixbVuvfzzz9HYmIiTpw4gblz52L27NlYuXIlV0O3GMMwmDt3Lj766KM637e1tWVfCwSCRveWGRZ5/fzzz5GXl4cLFy7A1tYWy5cvR1VVVZ3t9HvQDF2/fr3WfQ1lWpo71qZCARohhLRT9zMykJqZBbHIBk4ODgjy84OzldXN2wNTlh+b259//slu2p84cSLWrl2LKVOmwM3NDSqVCjdu3EB0dDSSk5MRGRmJyMhICIVCHDt2DAAgkUggk8ksevbDbTMzMzFixIg6EwdiY2Px1VdfYfLkyXB2dkZJSQmcnJwQGxuL2bNn47nnnkNQUBC0Wi2uXLmCvn37mvXsuhQXF8PHxwe2trbIycnBnj17MHnyZJM/X3h4OLRaLX7//Xc88cQTOHfuHHJyciCVSlFQUGByP9Z8jy1BARohhLQzWq0W5xMScC05xeg6j3cFXYKD0bdHJFwkkhYaHdHT70FTq9UIDg5msxlnz56NwsJCxMTEANBlMs6fPx/R0dF4/fXXkZKSApFIBHt7e2zcuBEAsGjRIrz66qtYt24dPvroI4wZM8bkcTzc1sPDA0Jh3eHB008/jaysLAwePBhCoRAODg74448/MHToUHz66aeYNGkS1Go1lEolxo4d22iA1rNnT0RGRqJHjx4ICwvD/v37a92jX9KNjIyEn58fHn/8cZM/GwCIRCL8+uuveOmll/Dqq6/C1tYWP//8MxwdHc0K0F566SUsXLgQ9vb22Lp1a5MvL/OYhvJPSauTkpKChQsX4rvvvmN/2yKEED2NVoujp88gNTOz3nuEQiEmj3wC7gbZa+1VVVUV7t+/j9DQUKOlK1K/zz77DL6+vpgzZ05LD6VN4urPHM2gEUJIO3I95RYbnPF4PAzpHQ13Fxdk5eXj+q0UVCmUUKvV+OPceUwZNdKqo2hI+7RixYqWHgIB1UEjhJB2o7JKgcs3brBfjx02DD3Dw+Hv7Y1+UT0wJzYWbtXZd4UlJbhYx+ZpQkjrQAEaIYS0E5euX4dSpQIAdAsLRZCfr9H7IhsbPD54EHsu5dWkm8gxYw8OIaT5UIBGCCHtQJFMhsTqwptCoRADevas8z4PV1f07xnFfn01KalZxkcIMQ8FaIQQ0g4k3ExmzxzsHREBB3v7eu/t1a0bHOzsAACpmVmQl5U1yxgJIaZrc0kCSqUS33//PY4dO4bS0lJ06tQJCxYsQL9+/Rptm5+fjw0bNuDSpUvQarWIjo7G0qVL4efnV+vegwcPYteuXcjJyYGnpyemTJlSZ90VU/t89NFH6xzTokWLKFOGEGIVlVqNuw8eANAtY/aK6Nbg/QI+H5FdOuPiP9fBMAwS79zBoGauSE8IaVibC9A+/vhjxMfHY+rUqQgICMDhw4excuVKrF+/Hj3rmdIHgIqKCixbtgzl5eWYM2cOhEIhdu/ejaVLl+KHH35gj60AdEdWrF27FsOGDcP06dPxzz//YP369aiqqmKPgDC3TwDo27cvRo8ebXStS5cuHH1nCCEd1d0H6VBVVzvvHBQEm3pqWBnq3qkTLt9IhFarxc27d9GvR496a18RQppfm1riTEpKwvHjx7Fo0SK88MILiI2NxRdffAEfHx+2WF999u7di4yMDKxZswazZs3CtGnTsHbtWhQVFSEuLo69T6FQYPPmzRg0aBDef/99jB8/Hm+88QaeeOIJbNu2DaWlpWb3qRcYGIiRI0ca/ac/m4wQQiyVcv8e+zo8zLSfKfZ2dugUFAgAqFIocad6Bo40j5CQEISHh0MqlSIiIgKzZs1CeXm5xf1t3bq1zsr/en/99ReioqIQHR2No0ePYsyYMUhJSTGpbVsxb948+Pv7QyqVIioqCo8++qjJn4vH46GkpKRpB2imNhWgnTx5EgKBALGxsew1sViMsWPHIjExEbm5ufW2jY+PR7du3RAREcFeCw4ORu/evXHixAn22pUrVyCTyTBx4kSj9pMmTUJlZSXOnz9vdp+GFAoFFIqWP6SXENI+yMvKkJmbBwBwcXKCj4eHyW2junZlXyfdvcv52EjD4uLikJCQgMTERMhkMmzdutXivhoLsn788UfMmjULV69exahRo3Do0CG22HlLBGiGB8AD4Oy8yxUrViAhIQHXr1/HmDFj8K9//YuTfltCmwrQbt++jYCAADg4OBhd1wdId6ozmB6m1Wpx7949dOtWe19GREQEMjMzUVFRwT4DQK17w8PDwefzcevWLbP71Dty5AhGjhyJJ554Ak8//TR+//33Rj9zQUEBUlJS2P/S0tIabUMI6ThS7t9nX4eHhTZ4CPTDvN3d2SOfcvILUFnPAdSkaSmVSlRUVMDV1ZW99u9//xv9+/dH7969MXr0aPZn/4EDB9CzZ09IpVL06NED+/btw+bNm3H58mW88sorkEqlOHTokFH/a9asQVxcHDZs2ACpVIqSkhKEhIQgISGh0bYP27p1Kx5//HHMnDkTUVFR6Nu3L+7d083g5uTkICYmBn369EFkZCSWLFkCrVbLtouJicHkyZMRFRWFixcvgsfj4e2330a/fv3w2muvIS8vD0899RSioqLQo0cPbNq0CQBw7NgxjBw5EgAgl8thY2ODb7/9FgCwbds2zJ8/v9Y4GYaBXC5nv6epqalwMTg5o6ysrN6/K+fOnWNn4ebPn49evXohPj6e/YzTpk1D//79ERUVhTfffLPB75c12tSGg8LCQri7u9e6rr9W35lacrkcSqWy0bZBQUEoLCyEQCAw+osCADY2NpBIJCgsLDS7TwDo0aMHYmJi4Ovri8LCQvz66694//33UV5eXmu2ztD+/fut+q2KENK+3U7TLU3yeDyEm7llgsfjITTAH1eT5AB0GZ0RncI4H2NrM/Pm5yhQlTZ+o4U8bJzw34jljd6nP4szNTUVffr0wbRp0wAAO3fuREpKCs6fPw+BQIDt27fjhRdewG+//YY333wTmzZtwqBBg6DVaiGXy+Hi4oIdO3bg5ZdfrvPfk9WrVyM5ORlSqRQvv/yy0XsLFixosG1dLl26hISEBISGhmL16tX45JNPsGnTJri4uODAgQNwdHSERqPBhAkTsHv3bsyYMQMAcOHCBVy9etXomEKBQIBLly6x34/w8HD8+uuvyMvLQ58+fdCrVy8MHToUM2bMgEKhwIkTJ9CvXz/88ccfWLRoEX7//Xc8+eSTbH+fffYZtm7divz8fAgEApw6dcqkz6SnVCoxffp0bNu2DTExMThx4gS2bNnCvj937ly8/vrrGDZsGNRqNcaNG4c9e/Zg6tSpZj3HFG0qQFMoFLCxsal1XSQSse/X1w6ASW0VCkW9G2VFIpHRfab2CQBff/210T1jxozBggUL8O233+LJJ5+EWCyu85mxsbEYMmQI+3VaWho++OCDOu8lhHQssrIylMh1wZWPhwccGyitUZ9Q/wBcTboJAEjNzOwQAVqBqhR5KllLDwNxcXGQSqVQq9VYvHgxVq1ahbVr12Lv3r24dOkS+vTpA8B4OXDEiBHs4eEjR45s8gO76zJo0CB2//SgQYPw1VdfAdCtLK1atQpnzpwBwzDIy8tDjx492ABt8ODBtc6QNpz9+uOPP/D3338DALy8vPDUU0/hjz/+wMCBAyGVSnH27Fn88ccfWL16NZYvXw6tVos///wTn332GdvHihUr2CB0y5YtmDJlCi5fvmzyZ0tOToZQKGQPqo+JiUGnTp0AAOXl5Th+/LjRdqqysjJ2Lx/X2lSAJhaLoaqukm1IqVSy79fXDoBJbcVicb1r4Uql0ug+U/usi42NDZ566imsXbsWKSkp9Wagenh4wMOMPSWEkI7jQVYW+/rhUwNM5eXuBjtbMSqrFEjPzoZarW732ZweNk6tqn+hUIjJkydjxYoVWLt2LRiGwWuvvYZFixbVuvfzzz9HYmIiTpw4gblz52L27NlYuXIlV0M3ieEB4AKBgP038/PPP0deXh4uXLgAW1tbLF++HFUGy+aOjo61+qrrmp7hEuTjjz+OP/74A6dOncKaNWsQFRWFHTt2wNXVFT4+PnW2nz59OubPn4/8/HwIhUKjQLfKjOV8/Tj0dQb/+usvqw5BN1Wb+lvo7u6O/Pz8Wtf1y471BTISiQQikYi9r6G27u7u0Gg0KC4uNlrmVKlUkMvl7PKlOX3Wx8vLC4BuuZQQQsz1ICubfR1cRz1HU/D5fIT4++Pm3XtQazTIyMlFSIA/V0NslUxZfmxuf/75Jzu7NHHiRKxduxZTpkyBm5sbVCoVbty4gejoaCQnJyMyMhKRkZEQCoU4duwYAN2/STKZZbOCD7fNzMzEiBEjzE4cKC4uho+PD2xtbZGTk4M9e/bUWT+0Po8//ji+++47fPjhh8jPz8evv/6KPXv2sO9NmzYNwcHBcHBwwOOPP4633nqrwWXZ48ePw8PDA+7u7tBqtWAYBklJSejevTu2bdtWZ5vw8HCoVCqcPHkSw4YNw8mTJ9n97Y6OjoiJicGaNWvwzjvvAACysrKg1WoREBBg8uc0VZtKEujcuTMyMjJqpSInVR9V0rlz5zrb8fl8hIWF1fmHLSkpCX5+frCvXhrQ1yV7+N7k5GRotVr2fXP6rE9W9W+/hhsXCSHEFGqNBpnVSy32dnZwt+LnSIh/TUB2PzPT2qERE02fPp3d7H/z5k2sX78eADB79mzMmzcPMTEx6NWrF6RSKf78808AwOuvv47IyEhER0dj+/btbKCwaNEifPTRRyZt9H/Yw20zMzMtmkVdtmwZLly4gMjISDz99NN4/PHHzWr/5Zdf4ubNm4iKikJMTAzeeOMNDBgwAICujqhMJsOIESMAAE888QTS0tLYr/U+++wzSKVS9OrVC++//z5+/vln8Pl8CIVCfPXVVxg3bhz69etX5+oXoFv52rVrF1566SVERUVhy5YtCA8PZ/+d/umnn3Dnzh306NEDUVFReOqpp+qcqOEE04YkJiYyQ4cOZXbu3MleUygUzIwZM5jFixez13JycpjU1FSjtjt27GCGDh3K3Lx5k72WlpbGDB8+nNm4cSN7raqqihk7diyzatUqo/bvv/8+88QTTzAymczsPouLi2t9lvLycmbGjBnMuHHjGKVSafL3IDk5mRk6dCiTnJxschtCSPuTlpnF/Oenncx/ftrJHD//l1V9KVUqZtOuOOY/P+1kfvjlV0ar1XI0ypZXWVnJJCUlMZWVlS09lDbj008/ZbZv397Sw2gxcrmcfX3x4kXGx8eHKS8vN7k9V3/m2tQSZ/fu3RETE4Nvv/0WJSUl8Pf3x5EjR5CTk4NVq1ax93344YdISEgwyt6YNGkSDh48iFWrVmHGjBkQCATYvXs3XF1d2Q2MgC56fvbZZ7Fu3Tq89dZb6N+/P65du4Zjx45h4cKFkFSnpJvT56+//oozZ85g8ODB8Pb2RmFhIQ4dOoTc3Fy88cYbdSYaEEJIQ9IM9p9ZurypZyMUwt/bG2lZWaisqkKxTA43F+fGG5J2acWKFS09hBb1yy+/YN26dWAYBkKhENu3b290RawptKkADdBN73p7e+Po0aMoKytDWFgYPvnkk0YzWezt7bF+/Xps2LAB27ZtY8/NXLJkSa0lxkmTJkEoFCIuLg5nz56Fl5cXlixZUiuN1tQ+o6KicOPGDRw8eBByuRy2traIiIjAqlWr2CwdQggxhz5BgM/jIcDH2+r+/Ly92KAvKz+PAjTSYc2bNw/z5s1r6WGAxzDVaQmkTUhJScHChQvx3Xff1UpXJoR0DKXl5di+bz8AwM/LExPN3OtTl9zCQvxyVLfhvHNQEEY+MqSRFm1DVVUV7t+/j9DQ0GbJvCOEqz9zbSpJgBBCCJCdV5PN7udl/ewZAHi6urKHrGfl5YF+dyekZVGARgghbUx2vmGA5slJn3w+Hz6eutJAFVVVkJWWcdIvIcQyFKARQkgbow/QeDwevOs4bs5SftW1GQHdLBohpOVQgEYIIW1IlUKBouqioh6urpxmgVOA1nxCQkIQHh4OqVSKiIgIzJo1q1aNT3Ns3bq1wcKyf/31F6KiohAdHY2jR49izJgx7BFFjbV9+DmmntnJlYMHD2L48OEAdIeeCwQCSKVSSKVSdOvWzeTjD995551aZ5G2ZhSgEUJIG5JTUMC+9vPkZnlTz8vNDUKBAAAFaM0hLi4OCQkJSExMhEwmw9atWy3uq7Eg68cff8SsWbNw9epVjBo1CocOHWITzcwJ0MxheLQSl5ycnJCQkICEhARcuHABGzZsQGJiYpM8qyVRgEYIIW2IYYKAD0f7z/QEAgG8q4+oK6uogLyM9qE1B6VSiYqKCqPjBf/973+jf//+6N27N0aPHo20tDQAwIEDB9CzZ0/2BIJ9+/Zh8+bNuHz5Ml555ZU6TxJYs2YN4uLisGHDBkilUpSUlCAkJAQJCQmNtq2LXC5HbGwsunfvjkcffRSpqakAdIFeTEwMJk+ejKioKFy8eBFHjx5F79690bNnTwwbNow9+ScnJwcxMTHo06cPIiMjsWTJEmi1WgC6oxVfeOEFdOnSBf3798eJEyfqHUt5eTkYhmFrlM6bNw9ffPEF+/7/+3//jz1twZD+GV27dsXAgQPx6quvsrN0ALB9+3YMGDAAvXv3xqOPPopr1641+n3hWpurg0YIIR2ZYYKAL8czaIAu6UB/hFRuQQEkDRxm3VY989LbKCy27NxKU7i7OmPbl+82et/06dNhZ2eH1NRU9OnTB9OmTQMA7Ny5EykpKTh//jwEAgG2b9+OF154Ab/99hvefPNNbNq0CYMGDYJWq4VcLoeLiwt27NiBl19+uc7lx9WrVyM5ORlSqbTWEt+CBQsabFuXs2fPIiEhAREREfj000+xaNEi9kzQCxcu4OrVqwgPD0deXh4iIiIQHx+PqKgo/PTTT5gyZQoSExPh4uKCAwcOwNHRERqNBhMmTMDu3bsxY8YMfPvtt0hJSWFnxUaNGmX0/NLSUkilUmg0Gty6dQsrV65EYGCgSWPX+/bbb3H79m32GWPGjDH6fP/9739x6tQpiMVinD59GrNmzWr2WToK0AghpI1Qq9XIKyoCALg4OcG+Cep6eRkkHeQVFqFLSAjnz2hphcUy5BUWt/QwEBcXB6lUCrVajcWLF2PVqlVYu3Yt9u7di0uXLrGFzA2XCkeMGIFly5ZhypQpGDlyZKNF2pvC4MGDERERAUB3juebb77JjnHw4MHs0umFCxcQFRWFqKgoALozRl988UVkZmbCzc0Nq1atwpkzZ8AwDPLy8tCjRw/MmDEDx48fxzPPPAORSAQAmD9/Pr7//nv2+folTgAoKirCiBEj0K9fP8TGxpr8GY4fP445c+awezjnzp2LzZs3AwD27duHa9euseeA6p9TWVkJOzs7S75lFqEAjRBC2oi8oiJ2GcinCWbPAN0+NMPntUfurk17SoK5/QuFQkyePBkrVqzA2rVrwTAMXnvtNSxatKjWvZ9//jkSExNx4sQJzJ07F7Nnz8bKlSu5GrrVHE2ccf3888+Rl5eHCxcuwNbWFsuXL0dVVVWd9/J4vHr7cXNzwxNPPIGjR48iNjYWQqHQKKCtqqoyaUyGz2AYBnPnzsVHH31k0mdpKhSgEUJIG5FbWMi+1tcs45qdrS2cHBxQWl6O/OqAkM9vX9uVTVl+bG5//vknO/M0ceJErF27FlOmTIGbmxtUKhVu3LiB6OhoJCcnIzIyEpGRkRAKhezSokQigUxm2bLtw20zMzMxYsSIehMHzp8/j+TkZHTr1g2bN29GTEwMBNXJJYYGDhyI69ev48aNG+jRowd27doFf39/+Pv7o7i4GD4+PrC1tUVOTg727NmDyZMnAwAef/xx7NixA7NmzQLDMNiyZUu9Y1coFDh79iymT58OAOjcuTMuXrwIAOy5188880ytdo899hh27tyJWbNmAQC2bdvGvhcbG4vZs2fjueeeQ1BQELRaLa5cuYK+ffs29q3kFAVohBDSRuQX1sxoGc50cc3LzQ2l5eVQazQolsvh/tB5xYQb+j1oarUawcHB+OabbwDolgILCwsRExMDQLe0PX/+fERHR+P1119HSkoKRCIR7O3tsXHjRgC6pcZXX30V69atw0cffWS0p6oxD7f18PCAUFh/eDB48GCsWrUKd+7cgbu7u1FwY8jT0xM//fQTnnnmGajVari6umLPnj3g8XjsMm1kZCT8/PzwuMFxZQsXLsSNGzfQvXt3uLq6YujQofj777/Z9/V70ABdgBYTE4Pnn3+e/SxTpkxBREQEwsLCMHDgwDrHtnjxYly/fp19Rt++fZFVfRbt0KFD8emnn2LSpElQq9VQKpUYO3ZsswdodBZnG0NncRLSce3YfwDysjIIBQIsmDqlyWa2riYl4XyCLmstZsAARHQKa5LnNAc6i9N8n332GXx9fTFnzpyWHkqTKi0thZOTE1QqFWbPno0+ffpg1apVVvfL1Z85mkEjhJA2oEqpZMteeLi6Numyo1GiQFFhmw7QiPlWrFjR0kNoFo8//jgUCgWqqqrwyCOP4KWXXmrpIRmhAI0QQtqAfIMN+55NuLz5cP95he0zUYCQCxcutPQQGtS+dn4SQkg7ZbT/zL1pAzSRjQ1cqgt/FpaUNFlFeEJI/ShAI4SQNiCvGWfQgJokBK1Wi4KSkiZ/HiHEGAVohBDSBuiXOG2EQrg4OTX58wz3oeXTMichzY4CNEIIaeUqq6pQWl4OAPB0a9oEAT1Pt5pzIQuKW77qPiEdDQVohBDSyjX38iYAo9pntMRJSPOzKItTX7HXGlOnTsWUKVOs7ocQQtq75ipQa0hkYwOJoyPkZWUoKilplycKtKSQkBCIxWLY2dlBoVAgOjoa3333HRwcHCzqb+vWrRg4cCC6detW5/t//fUXFi5cCKFQiDVr1mD9+vVYt24dwsPDG23bkIMHD+Lf//434uPjcfnyZXz22WeIi4trcJx79+7F3r17zX5WR2PR37acnByUlpaCYRiL/svNzUVZdT0fQgghDSsoqVli9GimAA2omUVTazRsDTbCnbi4OCQkJCAxMREymQxbt261uK+tW7fWezQTAPz444+YNWsWrl69ilGjRuHQoUNssfPG2pqqb9++DQZnxDwW10GbNm0a5s2bZ1HbYcOGWfpYQgjpcAqKSwAAQoEAziYeRs0FD1cX3M/IAKArt6EvvUG4pVQqUVFRAVfXmn1///73v7F7926o1Wp4eXlh06ZNCA4OxoEDB/DGG2+Az+dDrVbjww8/RH5+Pi5fvoxXXnkF77zzTq2jntasWYO4uDjY2dkhLi4O8fHxkEql2Lt3Ly5fvtxg24epVCosW7YMv//+O3sMk158fDxefvllJCQkID8/H7Nnz0Z2djZ4PB769OlT60zNrKwsTJgwAc8//zzmz5/P4Xe0faBCtYQQ0oopVSp29srNxaVZlxmN9qEVl6BTUFCzPbsp7TlyFBWVlU3Wv72dHaaOHtXoffqzOFNTU9GnTx9MmzYNALBz506kpKTg/PnzEAgE2L59O1544QX89ttvePPNN7Fp0yYMGjQIWq0WcrkcLi4u2LFjB15++WVMnDix1nNWr16N5ORkSKVSvPzyy0bvLViwoMG2D/v222+RkpKCxMREAMCoUXV/zh07diA0NJQ9zL2oyDgT+Pr165gxYwbWrVuHkSNHNvrcjsiiAG379u1wdna2+KHWtieEkI6iqETGvvZo5kPL3Q1mdArbUaJARWUlypswQDNVXFwcpFIp1Go1Fi9ejFWrVmHt2rXYu3cvLl26hD59+gCAUaHgESNGsAeNjxw5kj00vLkcP34czzzzDEQiEQBg/vz5+P7772vdN3DgQKxbtw6vvvoqHn30UYwePZp9LzExEbGxsdi7dy969erVbGNvayz6VSwoKMiqAMva9oQQ0lEY7j9zd3Vp1mdLHBxgI9T9Ht+eAjR7Ozs4NOF/9nZ2Zo1HKBRi8uTJOHLkCACAYRi89tprSEhIQEJCAq5fv47r168DAD7//HNs2bIF9vb2mDt3Lj799FPOvz/m4PF4dV4fNGgQEhISMGDAAPz666/o168fG2j6+fnB29sbf/75Z3MOtc2hJU5CCGnFDAMj92aeQePxeHB3cUFOQQFKy8uhUCohrp45actMWX5sbn/++Se7aX/ixIlYu3YtpkyZAjc3N6hUKty4cQPR0dFITk5GZGQkIiMjIRQK2SVEiUQCmUzW0CPq9XDbzMxMjBgxos7Egccffxw7duzArFmzwDBMrX1levfv34e/vz+mTZuG0aNHw8vLi00OdHV1xfbt2zFu3DiUlpbirbfesmjc7R2nmxlKS0vZ3wAIIYRYr7A6QQBo/gDt4We2p1m01mD69OmQSqXo0aMHbt68ifXr1wMAZs+ejXnz5iEmJga9evWCVCplZ5tef/11REZGIjo6Gtu3b8c777wDAFi0aBE++ugjSKVSHDp0yKxxPNw2MzMTQmHd8zcLFy5Ely5d0L17dzzyyCP1LrHGx8ejT58+kEqlGDx4MD777DOjlTMnJyccOXIE586dw4oVK8wab0fBYxiG4aqzO3fuYMGCBYiPj+eqS/KQlJQULFy4EN999x372xYhpH1iGAab9/wMlVoNJwcHPD0httnHcOP2bZy6dBkAMLRvH0R17drsY7BGVVUV7t+/j9DQUNja2rb0cNqEzz77DL6+vpgzZ05LD6VN4urPnFlLnLm5uQ2+X1BQYPFACCGEGJOXl0OlVgNomdmzh59rOJtH2i+a0WodzArQpk2bVu+GQED3215D7xNCCDFdocEZmB7NnCCgR0uchLQMswI0JycnPPvss/WuOaelpbHr4YQQQqxTYLT/zLX+G5uQyMYGTg4OKC0vR7FcTr+IE9JMzArQunbtitLSUoSGhtb5vkajAYdb2gghpENryQxOQ64SCUrLy6FUqVBeWQlHe/sWG4ultFptSw+BdBBcxUFmBWgTJ05EVVVVve97e3tj9erVVg+KEEJITYAmFAjg7NR8Rzw9zNXZGQ+yswEAxTJZmwrQRCIR+Hw+srKy4OnpCZFIRDOApMkwDIP8/HzweDzY2NhY1ZdZAdqjjz7a4PtOTk548sknrRoQIYQQQKVWs0c8uTo7t2hQ4eZccwZnkUyOQF/fFhuLufh8PkJDQ5GdnY2srKyWHg7pAHg8HgICAiAQCKzqhwrVEkJIK1Qil7Ov3Vr45BVXg+cXyy0rhtqSRCIRgoKCoFarjY5NIqQp2NjYWB2cARwEaMOHD8f27dsRGBho9WAIIYToFBlUdm/xAE1SM4NWLJM3cGfrpV9ysnbZiZDmYvVJApQUQAgh3GtNAZpYJIJD9fmSRTIZ/dwnpBlwetQTIYQQbhSVGARoLi0boAE1y5wKpRKVDSSLEUK4QQEaIYS0QsXVe9BshMJWkTVpmChQLG+by5yEtCUUoBFCSCvTmjI49QwTBQyXXwkhTYMCNEIIaWWKjTI4JQ3c2XzcJAaZnG00UYCQtoQCNEIIaWUM95+5tnCCgJ6rUS00mkEjpKlRgEYIIa1McSvK4NSzFYthZ2sLwHh8hJCmYXWANmvWLEgkrWMKnhBC2oPWVGLDkH65tVKhQJVC0cKjIaR9szpAW7x4MZxb0Q8QQghp6/QBWmvJ4NRzcaJMTkKai8UBmlKp5HIchBBCoMvgLC0vB6CbPWsNGZx6LhIn9nWJvLQFR0JI+2dxgDZp0iSsW7cOKSkpXI6HEEI6NMMzOF1bSQannovBdpaSUppBI6QpWXwWp1KpxN69e7Fv3z506tQJY8eOxRNPPAEnJ6fGGxNCCKmTYQkL11a2v9coQKMZNEKalMUzaPv27cPy5csRHh6OO3fu4Msvv8RTTz2F9957D3///TeXYySEkA7DcG+Xq6R17e91sreHgK/7Z4Nm0AhpWhbPoNnb22PChAmYMGECUlNT8dtvv+H333/H8ePH8eeff8LLywtjx47F6NGj4e3tzeWYCSGk3TIM0Fxa2Qwan8+Hs5MTimQyyErLoNVqwedTtSZCmgInf7NCQkLw4osv4pdffsEHH3yAgQMHoqCgAD/88ANmzJiBFStWID4+Hmq1movHEUJIu6Xfg8bn8yFxdGjh0dSmTxTQarVsMgMhhHsWz6DVRSAQYOjQoRg6dCiKiopw9OhRHDp0CBcvXsSlS5cgkUiwf/9+Lh9JCCHthlarRUmpbm+Xi5NTq5ydMiy1USIvhTPtOyakSTTZ3343NzfMnDkT77zzDqKiosAwDORUN4cQQuolLyuHVqsF0PqWN/WMSm3QPjRCmgynM2h6FRUV+P333/Hbb7/h1q1bYBgGtra2iImJaYrHEUJIu2BUYqPVBmiGxWopk5OQpsJpgHblyhUcOnQIp0+fhkKhAMMw6N69O8aOHYvHHnsM9hxUxFYqlfj+++9x7NgxlJaWolOnTliwYAH69evXaNv8/Hxs2LABly5dglarRXR0NJYuXQo/P79a9x48eBC7du1CTk4OPD09MWXKFEyePNmqPvX++ecfLFmyBACwf/9+uLi4mP4NIIS0W8VtLEAroVURQpqM1QFaXl4eDh8+jMOHDyMnJwcMw8DFxQWxsbEYO3YsQkJCOBhmjY8//hjx8fGYOnUqAgICcPjwYaxcuRLr169Hz549621XUVGBZcuWoby8HHPmzIFQKMTu3buxdOlS/PDDD0bHVe3btw9r167FsGHDMH36dPzzzz9Yv349qqqqMHv2bIv61NNqtVi/fj3s7OxQWVnJ6feGENK2FctrzuBsbUVq9WxFItiJxahUKNj9coQQ7lkcoB0/fhyHDh3ClStX2FTrfv36YezYsXjkkUcgFHK/epqUlITjx4/j+eefx8yZMwEAo0aNwrx587Bx40Zs3Lix3rZ79+5FRkYGNm3ahIiICADAgAEDMG/ePMTFxWHRokUAAIVCgc2bN2PQoEF4//33AQDjx4+HVqvFtm3bEBsbyxbjNbVPQwcOHEBeXh7Gjh2Ln3/+mbtvDiGkzTNcMmyte9AA3dgq8/NRUVkJpUoFkY1NSw+JkHbH4iSB9957D5cvX4a3tzfmz5+PuLg4fPbZZxg+fHiTBGcAcPLkSQgEAsTGxrLXxGIxxo4di8TEROTm5tbbNj4+Ht26dWMDKQAIDg5G7969ceLECfbalStXIJPJMHHiRKP2kyZNQmVlJc6fP292n3pyuRybN2/G/Pnz4ejoaNZnJ4S0bwzDsEuGjvb2sGmin6NcMD6Tk5Y5CWkKFgdoI0aMwOeff45du3Zh7ty58PLy4nJcdbp9+zYCAgLg4GBcG0gfIN25c6fOdlqtFvfu3UO3bt1qvRcREYHMzExUVFSwzwBQ697w8HDw+XzcunXL7D71Nm/eDDc3N6MAszEFBQVISUlh/0tLSzO5LSGk7aisqoJCqQTQevef6RmW2pDRMichTcLiX9HeeustLsdhksLCQri7u9e6rr9WUFBQZzu5XA6lUtlo26CgIBQWFkIgEMDV1dXoPhsbG0gkEhQWFprdJwDcvXsXBw4cwCeffAKBQGDqR8b+/fuxdetWk+8nhLRNbWV5EwCcnWpWAGSlZS04EkLaL87m0NVqNX799Vf88ccfePDgARQKBbvMd/v2bRw4cABTp05FYGCgxc9QKBSwqWOvg0gkYt+vrx0Ak9oqFIp6l2hFIpHRfab2CQDr16/HgAED0L9//zr7rk9sbCyGDBnCfp2WloYPPvjArD4IIa2frLT1Z3DqGRanlZXRDBohTYGTAE2hUODVV1/FjRs34OzsDAcHB1RVVbHv+/r64tChQ3BycsLChQstfo5YLIZKpap1XVm9LCAWi+ttB8CktmKxuN4jqZRKpdF9pvZ5/Phx3LhxAz/++GM9n6x+Hh4e8PDwMLsdIaRtkZXVzERJnFr3HlWJI82gEdLUODlJYPv27bh+/ToWLVqEvXv3YuzYsUbvOzo6QiqV4tKlS1Y9x93dnV1iNKS/Vl8gI5FIIBKJTGrr7u4OjUaD4uJio/tUKhXkcjm7fGlOnxs3bmSTJ7Kzs5GdnY2y6h/GeXl59S7NEkI6DrlBgObcypOIbIRCONjZAaAZNEKaCiczaH/++Seio6Mxa9YsAACPx6t1j5+fH7sB31KdO3fG1atXUV5ebpQokJSUxL5fFz6fj7CwMCQnJ9d6LykpCX5+fmwR3S5dugAAkpOTMWjQIPa+5ORkaLVa9n1z+szLy8Mff/yBP/74o9a9CxYsQOfOnfHDDz+Y9D0ghLRP8uqZKB6PB0eH1ndI+sOcnZxQXlmJyioFldogpAlwMoOWl5eH8PDwBu+xs7NDeXm5Vc8ZPnw4NBqN0YHrSqUShw4dQvfu3eHt7Q0AyM3NrZXtOGzYMCQnJxsFVA8ePMDVq1cxfPhw9lrv3r0hkUiwb98+o/b79u2Dra2tUdBmap8ffvhhrf8ee+wxAMAbb7zBnipACOmYGIZhlzid7O0haIWHpD/MOFGAZtEI4RonM2h2dnYoKSlp8J6srKw6K+ubo3v37oiJicG3336LkpIS+Pv748iRI8jJycGqVavY+z788EMkJCTg1KlT7LVJkybh4MGDWLVqFWbMmAGBQIDdu3fD1dUVM2bMYO8Ti8V49tlnsW7dOrz11lvo378/rl27hmPHjmHhwoWQGGzeNbXPoUOH1vos+tnEAQMG0FFPhHRwCqUSyur9rK19/5mes6NBokBpGTzd3FpwNIS0P5wEaJGRkTh37hxKS0vZKvuGcnNz8ddff9UZqJjr9ddfh7e3N44ePYqysjKEhYXhk08+gVQqbbCdvb091q9fjw0bNmDbtm3suZlLliypFSBNmjQJQqEQcXFxOHv2LLy8vLBkyRJMnTrV4j4JIaQ+RgkCrXz/mZ7RDBrtQyOEczyGYRhrO0lISMDLL7+Mzp07Y9myZbhw4QJ27NiBI0eOIDExEV988QUyMzOxcePGRpdCScNSUlKwcOFCfPfdd/S9JKSduJ2aht/PnQMADJL2QnT37i08osYVFBdj9+EjAIBuYaF4bODAFh4RIe0LJzNoUqkUL7/8Mr788kssXbqUvT569GgAug31y5cvp4CCEELqYDyDVnsVojVyplIbhDQpzgrVTpw4EVKpFPv27cPNmzchl8vh4OCAiIgITJo0CaGhoVw9ihBC2hWjEhttZA+ajY0N7G1tUVFVRUkChDQBTk/jDQkJwbJly+p9X6PRmHXMESGEdATyNrgHDdCV2qioqkJFVRVUKlWdJ6sQQizDSS73r7/+2ug9Go0G7777LhePI4SQdkW/xGkrFrepemLGiQK0zEkIlzgJ0L788kvEx8fX+75Wq8W7775rVPaCEEIIoNZoUF5RAaD1nyDwMMlDpTYIIdzhJECLiorCBx98gCtXrtR6Tx+cnTx5EpMmTeLicYQQ0m6UltUU8G5Ly5sAldogpClxEqCtWbMGgYGBePPNN42Oc9JqtXj//fcRHx+PiRMnNrg/jRBCOiLDwKatBWguToYzaBSgEcIlTgI0BwcH/Pvf/4ajoyNWrFiBrKwsMAyD9957D3/++ScmTJiAV155hYtHEUJIu9IWMzj1JFRqg5Amw9mBb+7u7li7di20Wi1effVVvP322zhx4gTGjRuH5cuXc/UYQghpV9pqBicAiEUi2InFAGgGjRCucXoib2BgID799FMUFxfj1KlTGDduHFasWMHlIwghpF0xnHlqawEaAEiqlznLKyuhUqtbeDSEtB8W1UHbunVrg+9HRETgzp07cHd3N7qXx+Nh7ty5ljySEELaJf0MmkAggIOdXQuPxnzOjo7ILSgAoPss7nQOMSGcsChA27Jli0n3/fjjj0ZfU4BGCCE1GIZhAzSJowN4PF4Lj8h8zk7GpTYoQCOEGxYFaOvXr+d6HIQQ0uGUV1ZCo9UCAJzbyBmcD3MxLLVB+9AI4YxFAZpUKuV4GIQQ0vEYJwg4tOBILCcxnEGjWmiEcIbTJAFCCCGmM04QaJszaA8vcRJCuEEBGiGEtBCjGmhtMIMTAGxFIohFIgC0xEkIlyhAI4SQFtKWa6AZ0s+ilVVUQK3RtPBoCGkfKEAjhJAWImsHe9AA4xMQDINOQojlKEAjhJAWIq/eVO9obw+BQNDCo7GcYQYqLXMSwg0K0AghpAUolEpUKZQA2vbyJmA8g0aJAoRwgwI0QghpAe1l/xnwUCYnldoghBMUoBFCSAswyuB0auMBGi1xEsI5TgO00tJSHDlyhMsuCSGkXZK1oxk0W7EIIhsbAICcljgJ4QSnAVpubi7WrFnDZZeEENIutYcaaHo8Ho/9DKUVFezxVYQQy5l11FNubm6D7xcUFFg1GEII6Sjkpe1nBg0AJE6OyC8uBsMwKCsvN9qXRggxn1kB2rRp08Dj8ep9n2GYBt8nhBCio1/iFNvYwFYsbuHRWM8wyJSVllGARoiVzArQnJyc8Oyzz9Z7WHpaWhreeecdDoZFCCHtl0ajQVlFBQDjw8bbMsNlWipWS4j1zArQunbtitLSUoSGhtb5vkajAcMwnAyMEELaq7KKCvZnZVs+QcCQ0QwaldogxGpmBWgTJ05EVVVVve97e3tj9erVVg+KEELaM1k7238GGNdCk5eVt+BICGkfzArQHn300Qbfd3JywpNPPmnVgAghpL0zzuBsuiVOrVaLq4m3cDT+PK5cT8GQfr3w/DOTYSsWcf4sBzs78Pl8aLVamkEjhANmBWiEEEKsJ2uGIrVarRYrPvgSp/66yl5Ly8jGX1eu44OVz6FLaBCnz+Pz+ZA4OKCktBTysnJKGiPESlbXQRs+fDjS09O5GAshhHQIzXHM08E/zhgFZ3r30jKxcMVHyM7lviyS/rOo1WpUNrAdhhDSOKsDNEoKIIQQ8+iXAPl8Phzs7Djvv7yiEv/58Wf261UvPoMfv3gHXcKC2Pe3/XyI8+caHZpOmZyEWIXO4iSEkGbEMAy7iV7i4AA+n/sfw1t3H0RRsQwAEDO4L6aMHYHuXUOx8eNVsLPV1Vw78PspFFbfw5WHa6ERQixHARohhDSjyqoqqNVqAE2zvJmTX4id/zsKALARCvHSs9PY95ydHDHpyRgAgEKpwn/3HuX02YYJD1QLjRDrUIBGCCHNqKkPST8W/xeUKhUAYPqEJxDg6230/uxJoyAUCgAAP//2J8rKKzh7tsSJaqERwhUK0AghpBnJmziD8/jZS+zryWNiar3v5eGGsSMeAaDbi7b/99OcPVviUFN0V05LnIRYhQI0QghpRk1ZpDY7twBJt+4DALqGBdWaPdObOXEk+/p0HZmelhIKhWzSAy1xEmIdCtAIIaQZNWWJjRPnLrOvRzzSr977woL84e/jCQC4mniL22XO6s9UqVCwS62EEPNZHaDNmjULEomEi7EQQki715QB2vEzNcubjw3pW+99PB4Pj/SXAtCdoXzxaiJnYzBctqVZNEIsZ3WAtnjxYjg7O3MxFkIIaff0SQL2dnawEXJ3mEteQRH+uXkHABAW7I+QQL8G7x/ctyf7+syla5yNw/jQdArQCLFUky5xMgyD9PR05ObmNuVjCCGkTVAZVNh35nj2LP78Ffb1iCH1L2/q9enZjT2T8+zlf6DVajkZh+HnokQBQizHSYB28uRJfPjhhygtrUmrzs7Oxrx58/D0009j+vTpeOedd6DRaLh4HCGEtEnGy5sODdxpvksJNcuUwwb1bvR+sUiEftLuAICiYhmS76RxMg6JQS00mkEjxHKcBGj79u3D7du34eRU8xdzw4YNSE1NRXR0NDp16oT4+HgcOsT90SKEENJWGGdwOjVwp3kYhkFC4u3qfh3QJTTQpHaP9JOyr89e5maZ03gPGtVCI8RSnARoqampiIiIYL+uqKjA+fPn8dhjj2HdunXYtGkTgoODKUAjhHRohgELl0ucaZk5KJHr+u7ZvYvJx0cN7lezD+3ClRucjEUsEkFkYwOAljgJsQYnAZpcLoebmxv79T///AONRoMRI0YA0NXG6du3LzIzM7l4HCGEtEn6MzgB46r71kq4kcK+lkZ2Nbmdj6c7Any9AADJd1LZI6iswePx2OCztKICGo72thHS0XASoDk4OEAul7NfX716FXw+H7169WKvCYVCVFVvjiWEkI7I8PgjLktsJCTdZl+bE6ABQGR4JwC6szlv30/nZDz64JNhGJSVlzdyNyGkLpwEaEFBQTh37hxkMhlKS0vxxx9/oGvXrkZ70nJycuDq6srF4wghpE3SL/nZCIWwE4s561c/gyaysUFElxCz2kZ168S+vp58l5PxGJXaoGVOQizCSYA2efJkFBQUYPLkyZg6dSoKCwsxceJEo3uSkpLQuXNnLh5HCCFtjlarRWn1bJLE0RE8Ho+TfvMLi5GZkw8AiOwayu7/MlUPgwDtBkcBmlGpDcrkJMQinFRJHD58OF555RX89ttvAIDHHnsMTz75JPt+QkICysvL0b9/fy4eRwghbU5ZRQW0DAOA2+XNa4bLmz3CzW7fNTQIIhsbKFUqJKY0wQwaZXISYhHOylhPnDix1qyZnlQqpQxOQkiHZjiT5MxlgkDiLfZ1r+5dzG5vYyNEeOdgXL95Bw+yclEiL4OLxLrxORtsb6EZNEIsQ4elE0JIM5A10Rmc/1TPoPF4PIsCNACICq9Z5uRiFs3Bzo4t9UF70AixDAVohBDSDIxm0DgK0NRqNe6kZgAAQgJ84ehgb1E/PThOFODz+ZA46E5KkJeVgale2iWEmI4CNEIIaQbyUu5n0O49yIKqunZZ107BFvfTg+MZNKDmM6o1Gvb8UUKI6Tjbg9ZclEolvv/+exw7dgylpaXo1KkTFixYgH79Gj8cOD8/Hxs2bMClS5eg1WoRHR2NpUuXws/Pr9a9Bw8exK5du5CTkwNPT09MmTIFkydPtqhPhUKBdevW4ebNm8jLy4NWq4Wfnx/GjBmDSZMmQShsc/83EELMpF/i5PF4cHTg5hzOlLs152eGdwqyuB8fL3e4uzqjsFiGGyn3oNVqTT6NoD7OTo5Atu61rKwM9nZ2VvVHSEfT5mbQPv74Y+zevRtPPPEEXnrpJfD5fKxcuRL//PNPg+0qKiqwbNkyJCQkYM6cOZg/fz5u376NpUuXQiaTGd27b98+fPrppwgNDcWyZcvQo0cPrF+/Hj/99JNFfSoUCqSmpmLgwIFYtGgRXnjhBXTu3BkbNmzARx99xN03hxDSKjEMwy5xOjk4QGBl8KNnHKBZPoPG4/HQvWsoAKCsvALZeYVWj41qoRFinTY1dZOUlITjx4/j+eefx8yZMwEAo0aNwrx587Bx40Zs3Lix3rZ79+5FRkYGNm3axJ4bOmDAAMybNw9xcXFYtGgRAF0wtXnzZgwaNAjvv/8+AGD8+PHQarXYtm0bYmNj2QK8pvYpkUjwzTffGI1nwoQJcHBwwK+//ooXX3wR7u7uHH6nCCGtiUKphFKlAqA7zJwrtzgK0ACgS0ggTl9IAADcSU2Hv4+nVf05O1ImJyHWaFMzaCdPnoRAIEBsbCx7TSwWY+zYsUhMTERubm69bePj49GtWzejQ92Dg4PRu3dvnDhxgr125coVyGSyWiVDJk2ahMrKSpw/f97sPuvj4+MDACijH16EtGsyo/1nTg3caTqtVotb9x4A0J2paW3pjk4hgezrOxwc+WR41ijVQiPEfG0qQLt9+zYCAgLg8ND+DX2AdOfOnTrbabVa3Lt3D926dav1XkREBDIzM1FRUcE+A0Cte8PDw8Hn83Hr1i2z+9RTqVQoKSlBbm4uTp06hV27dsHHxwf+/v6mfHxCSBslNwhQuMrgzMzJR3mlbvO9tbNnANAllOMAzeDntJyWOAkxm9lLnFqtFqmpqZBIJPDw8DB6T61W48aNG5BKpVyNz0hhYWGdS4H6awUFBXW2k8vlUCqVjbYNCgpCYWEhBAJBrXNDbWxsIJFIUFhYaHafeqdOncK7777Lft2tWzesWrWqwSSBgoIC9pkAkJaWVu+9hJDWyagGGkdFarlKENAL9PdmTxS4XV26wxpCoRAOdnYor6ykJU5CLGBWgJaTk4OVK1ciLS0NPB4PAwcOxGuvvQZnZ2cAuqDl5ZdfRnx8fFOMFQqFAjZ1nDMnEonY9+trB8CktgqFot6ASSQSGd1nap960dHR+Pzzz1FWVoa///4bd+7cQVUj6ef79+/H1q1bG7yHENK6GS5xcjWDZhigdQ2zfgZNKBAgLNgPyXfSkJ6VgyqFErZikVV9ShwdUV5ZiUqFAkqVyuxzQgnpyMxa4ty4cSM8PDywa9cufPfdd1AoFHjxxReNZq6asiChWCyGqnqjrSGlUsm+X187ACa1FYvFUFfXFarrXsP7TO1Tz83NDX379sXw4cPx6quvYvDgwVi+fLnRDNnDYmNj8d1337H/vfnmm/XeSwhpnZqiSC1XGZyG9PvQtFoG9x9kWt2f4b44mkUjxDxmBWjXrl3DCy+8AF9fX3Tp0gVr165Fz549sWTJEnaDPo/Ha5KBArqlw7qCGf21h5dc9SQSCUQikUlt3d3dodFoUFxcbHSfSqWCXC5nly/N6bM+w4cPR2VlJc6cOVPvPR4eHggPD2f/Cw7m5gcxIaT5yEp1e9DsbW3rnHW3REp1goCzkwO8Pd046bOLQaLAbS72oVGpDUIsZlaAVlVVZfTDRV+DrF+/fli6dCkyM63/jashnTt3RkZGBsrLy42uJyUlse/Xhc/nIywsDMnJybXeS0pKgp+fH+ztdUekdOmiO8vu4XuTk5Oh1WrZ983psz76JdCHPw8hpP1QqdWoqN7KwNX+s8JiGYqKdbUWu3YK5uwX486GiQKp1gdohrOFcsrkJMQsZgVoQUFBSElJqXX91VdfxcCBA7F69WrOBlaX4cOHQ6PRYP/+/ew1pVKJQ4cOoXv37vD29gYA5Obm1tpMP2zYMCQnJxsFVA8ePMDVq1cxfPhw9lrv3r0hkUiwb98+o/b79u2Dra0tBg0aZHafJSUldS79Hjx4EIAuQ5QQ0j7pZ88A49pg1riXVvPLcKfgAE76BIwzOW/ftz5RwLCkiKyMfhElxBxmJQk8+uij+P333zFy5Mha7y1fvhwAagU2XOrevTtiYmLw7bffoqSkBP7+/jhy5AhycnKwatUq9r4PP/wQCQkJOHXqFHtt0qRJOHjwIFatWoUZM2ZAIBBg9+7dcHV1xYwZM9j7xGIxnn32Waxbtw5vvfUW+vfvj2vXruHYsWNYuHAhJBKJ2X0eO3YM+/fvxyOPPAI/Pz9UVFTg4sWLuHz5MgYPHow+ffo02feMENKymmL/2f30mgAtLJi7Mj1uLhK4uUhQVCLHnfvpYBjGqtk54z1oNINGiDnMCtDmzJmDOXPm1Pv+8uXL2UCtqbz++uvw9vbG0aNHUVZWhrCwMHzyySeNlvawt7fH+vXrsWHDBmzbto09N3PJkiVwcXExuld/PmZcXBzOnj0LLy8vLFmyBFOnTrWoz549eyIxMRHHjx9HcXExBAIBAgMDsWTJEjz11FMcfWcIIa2RYYkNa4vJ6hnOoIUFcVtHsXNIIC4mJKJEXorCYhk83Fws7kssErGlO6gWGiHmaVNHPQG6Ga4XXngBL7zwQr33fPnll3Ve9/LywnvvvWfSc8aPH4/x48c3ep8pfXbr1s2o/hkhpONoilME7j3IYl+HBflx0qde51BdgAYAd1MzrArQeDwenB0dkV9cjNKKCmi0Ws7OISWkvbP6b8rw4cORnm79ZlJCCGmPjE4R4GAGjWEY3KsugeHp7gInDs/2BIwDvtSMbKv70ydGMAyDMkqIIsRkVgdoTVn3jBBC2jr9DJrYxga29dRqNEexrBQyua7P0EDuj4kLCfBlX6emcxCgUakNQixCc82EENJENBoNyqrP5JU4cZ/ByWWCgF5wILczaMalNihAI8RUFKARQkgTKS0vZ1cZuMrgvGdQ4T+U4/1nAOAicYSLRBdMpmVkNXJ344xm0CiTkxCTUYBGCCFNpCkOSTcM0DpxnMGpFxKoW+bMLyxBWXmFVX05G8wc0gwaIaajAI0QQpqI8SHp3Cxx3jfI4AxtogAt2GAfWpqVy5wOdnbgV2du0h40QkxHARohhDQRrjM4gZo9aB5uLpA4cZvBqaefQQOs34fG5/MhcdCNU15WRollhJiIAjRCCGkixjNo1gdoxTI5SuS6oK8p9p/pNVUmp1qjQWX1uaSEkIZZHaDNmjXL6PgjQgghOvo9aEKBAPZ2dlb315QnCBgK4TqT08kwUYCWOQkxhdUB2uLFi+Hs7MzFWAghpN3QarXspniJo6NVZ1rqGc5mhQY23Qyar5cHRDY2AIA0qoVGSIugJU5CCGkC5ZWV0Gq1ALjbf5aWWRMsGW7k55pAwEeQvzcAID07F2q12qr+DBMkKJOTENNQgEYIIU3AMBDh6gzOtIwc9nVwgA8nfdZHvw9NrdYgIyffqr4kTlQLjRBzcXpYukajQX5+PgoKCur9jUsqlXL5SEIIaZVkpdxncOpLXtjb2Vp1iLkpDE8USEvPNkocMJc+ixMA5LTESYhJOAnQtFottm/fjp9//hmlpQ3/dhQfH8/FIwkhpFUz3AzPRQanUqVCdl4BACDY34eTPW0NMcrkzMjGMCv6EgqFcLCzQ3llJS1xEmIiTgK0TZs2YdeuXXB1dcWTTz4Jd3d3CAQCLromhJA2yXAzPBfncKZn5UKr1dUQC2rC/Wd6hkuo6Zk5DdxpGomjI8orK1GpUECpUrFJCISQunESoB09ehSBgYH49ttvYW9vz0WXhBDSpumL1PJ5PDhx8HOxOfefAUCArxf7Oj07z+r+nJ0ckZ2v28smLyuDh6ur1X0S0p5xkiRQWVmJQYMGUXBGCCEAGIZhZ9CcHBzYo46sYXjkUrB/08+gOTk6sIemZ2TlWt0fldogxDycBGhhYWEoLCzkoitCCGnzKhUKqKoTpZw5WN4EgLTM5p1BA4BAP90sWl5hMaqqFFb1ZbgPT06ZnIQ0ipMA7ZlnnsHp06eRkpLCRXeEENKmGWZwSjhIEACABwYzaEH+zROgBfh6s6+tLrVhUGqEThMgpHGc7EEbNGgQXnvtNaxcuRJDhgxBp06d4OBQ9yG+o0eP5uKRhBDSahlmKnJRYoNhGHYPmpeHG+xsxVb3aQr9DBqgW+bsHBJgcV+G3wfK5CSkcZwEaEqlEufOnYNMJsNvv/0GALVSwBmGAY/HowCNENLuGR+Sbv0SZ4m8FPKycgDNt7wJAAF+NTNo6dnW7UMTi0QQ2dhAqVJRLTRCTMBJgLZhwwb8/vvv6NSpE4YNG0ZlNgghHZphtXwJBzNoRhmczZAgoBdouMSZZV0mJ4/Hg7OjI/KLi1FaUQGNVgsBB8kThLRXnARo8fHxCA8Px9dffw2hkNPDCQghpM0xnCHiYg/agxZIEAC4nUEDdMFqfnExGIZBWXk5ZwkUhLRHnPz6olQqER0dTcEZIYSgZgbNwd4eQg5WE4xKbDRDkVo9ZycHODnqyidZO4MGUKkNQszBSYAWHh6OjIwMLroihJA2rUqhQJVCCQBw5WiG6IFBHbLmyuAEdMuS+kzOnPxCKFUqq/oz3I9HiQKENIyTAG3hwoW4ePEizp07x0V3hBDSZpUYHpIu4SZAS8/UBWhCoQA+nu6c9GkqfSYnwzDIsrrURk12v4xqoRHSIE7WJC9fvgypVIrXX38dvXv3rrfMBo/Hw9y5c7l4JCGEtEol8prAw4WDGTStVouM6v1f/j5eEAiad2O9YS209Kw8hAT6WdyX4Z4zmkEjpGGcBGhbtmxhX//999/4+++/67yPAjRCSHtXUipnX7s4SazuL6+wGAqlbmkx0GDTfnMJ5DBRwMHODnw+H1qtlvagEdIITgK09evXc9ENIYS0eTLDGTQOljj1y5sAENTCAZq1Z3Ly+XxIHBxQUloKeVkZWx+TEFIbJwGaVCrlohtCCGnz9HvQ+Hw+nOo5UcUchrNWgf4tPYPGTSZnSWkp1BoNKqqq4GBnZ3WfhLRHnGxmuH79OjZs2FDvgekFBQXYsGEDEhMTuXgcIYS0SgzDsOdwShwdweegEGu6wayVYeHY5uLq7AQHO1sA1s+gAQ8d+UTLnITUi5MALS4uDmfPnoW7e93ZRR4eHjh37hx2797NxeMIIaRVKquogFqjAcBNggBgvMTZEjNoPB6PLVibnVsAtVptVX9GtdAoUYCQenESoCUnJ6Nnz54N3tOrVy8kJSVx8ThCCGmVZKXc7j8DgAdZulMEbIRCeHs0b4kNvUBfXakNjVaLrNwCq/qiWmiEmIaTAK2kpAQeHh4N3uPm5obi4mIuHkcIIa2SYQ00rkpsZGbrao8F+DZ/iQ09oyOfrFzmNDyblGqhEVI/Tv62Ozo6Ii+v4c2jubm5sKPNoISQdqxEXlNiw5mLEhsFxWz1/pZY3tQzyuS0MlFAYpA4QXvQCKkfJwFa9+7dcerUKeTm1v2bVW5uLk6fPo0ePXpw8ThCCGmVSjgusaFf3gSMC8Y2t4DqJU7A+hk0oVDIZm7SEich9eMkQJs2bRoUCgVefPFFHDlyBAUFuj0KBQUFOHz4MF544QUolUpMnz6di8cRQkirpF/itBEKYW9ra3V/LV0DTY/LGTSgJpOzUqGw+nxPQtorzuqgvfjii/j666+xZs0aALrMH4Zh2NdLly6lemmEkHZLo9GgtLwcgG7/GRcFWFu6Bpqeh5sLxGIRFAql1TNogO7Ip6w83d66ktJSeLm5Wd0nIe0NJwEaAEydOhW9e/fGvn37kJycjLKyMjg6OiIiIgITJkxAWFgYV48ihJBWR15Wzv5Sytkh6VmGM2g+nPRpCR6Ph0BfL9xJzUBWbj7UGg2EAoHF/RkmUMjkcgrQCKkDZwEaAHTq1AnLly/nsktCCGkTuD6DE6hZ4hTZ2MDLw5WTPi0V4OeNO6kZUKs1yM0vgr+Pp8V9GSZQGGa+EkJqtEzONiGEtDMlHNdA02i07H4vf19PTk4lsIbhKQbWnihg+P0xTKwghNSgAI0QQjhglMHJQQ203IJCqKqr9rfk8qZegJ9BJme2dQGas6Mju0ePZtAIqRsFaIQQwgFZqWENNOsDtPSsmmzJlkwQYMfga1is1rpMToFAwB4kXyKXs3v3CCE1KEAjhBAO6GfQ7GxtIRaJrO4v3aAGWmALltioawwZVs6gATWzjCq1GpVVVVb3R0h7QwEaIYRYSalSoaI6yGiSQ9JbsEitnpeHK0Q2NgCsL1YLGM8y0jInIbVRgEYIIVbiOkEAAB5ktY4aaHp8Pp/N3MzMzodWq7WqP0oUIKRhFKARQoiVZHLDEhvcBGj6ZUSxyAZe7i1bYkNPnyigVKmQV1hsVV8uEsNSG/IG7iSkY6IAjRBCrGQ4g8bFIekajRaZ2bpK+wG+3i1eYkPP8EzOTCuPfDIMZGkGjZDaOCtUq1KpcPr0afYUgfqmv1evXs3VIwkhpFXg+pD0nPyaEhutYXlTzzBAy8jOQ5+eERb35WhvD4FAAI1GQ3vQCKkDJwFaTk4Oli9fjqysrAbTpXk8HgVohJB2Rx9g8Hg8ODs6Wt2fUQZnK0gQ0PP3MQ7QrMHj8eDs5IiiEhnk1b/Ut5aZQkJaA04CtK+++gqZmZkYOXIkxo4dC09PTwisOKeNEELaCoZhUFK9B83JwYGTn32trQaanr8vdwEaoDsSq6hEBq1Wi9Lyck7qxxHSXnASoF29ehV9+vTBG2+8wUV3hBDSZlRWVbHLkZyV2DCYQQtqBTXQ9Py8PcDj8cAwjNV70ICH9qGVllKARogBTuaTtVotunTpwkVXhBDSphgnCDRBDbRWFKCJbGzg7eEGAMjI4SBAo1IbhNSLkwCte/fuSEtL46IrQghpU0qaoMSGvgaaWCyCh5sLJ31yRZ8oUFpWAXlpuVV9uRhkvMooUYAQI5wscS5evBhLly5FfHw8hg8fzkWX9VIqlfj+++9x7NgxlJaWolOnTliwYAH69evXaNv8/Hxs2LABly5dglarRXR0NJYuXQo/P79a9x48eBC7du1CTk4OPD09MWXKFEyePNmiPnNzc3Ho0CGcP38eGRkZEAgECA0NxTPPPIO+ffta9w0hhLSoIllNgObqbH2JDbVGg6xcXYmNQF+vVrdx3t/XC5f/uQlAtw+tu1OoxX0Zz6BRLTRCDFkUoG3durXWtejoaLzzzjvo1asXunbtCofqg3AN8Xg8zJ0715JHsj7++GPEx8dj6tSpCAgIwOHDh7Fy5UqsX78ePXv2rLddRUUFli1bhvLycsyZMwdCoRC7d+/G0qVL8cMPP8DZ2Zm9d9++fVi7di2GDRuG6dOn459//sH69etRVVWF2bNnm93nmTNnsHPnTgwdOhSjR4+GRqPB0aNHsXz5cqxevRpjxoyx6ntCCGk5xXIZ+9rV4OeIpXLyCqFWawAAgX4+VvfHtYdLbXTvanmAZisWQywSQaFUUqkNQh5iUYC2ZcuWet9LSEhAQkJCne9ZG6AlJSXh+PHjeP755zFz5kwAwKhRozBv3jxs3LgRGzdurLft3r17kZGRgU2bNiEiQle7Z8CAAZg3bx7i4uKwaNEiAIBCocDmzZsxaNAgvP/++wCA8ePHQ6vVYtu2bYiNjYVT9TKGqX327t0be/bsgYuLCzueCRMmYP78+fj+++8pQCOkDSuunkET2djA3tbW6v7SW9kRTw8zKlbLxT40JyfkFhairKICKrUaNkLOynMS0qZZ9Ddh/fr1XI/DJCdPnoRAIEBsbCx7TSwWY+zYsfj222+Rm5sLb++6f6DFx8ejW7dubCAFAMHBwejduzdOnDjBBlNXrlyBTCbDxIkTjdpPmjQJv//+O86fP4+RI0ea1WdoaO3fMEUiEQYOHIjdu3ejoqIC9vb2ln1TCCEtRqVSoayiAgDgKpGAx+NZ3WdrzeDUe3gGzVouEglyCwsB6Pahebi2jmOtCGlpFgVoUqmU42GY5vbt2wgICKi1fKoPkO7cuVNngKbVanHv3r06Z6oiIiJw6dIlNki6ffs2AKBbt25G94WHh4PP5+PWrVsYOXKkWX3Wp6ioCLa2thCLxY1/eEJIq1MsN9x/Zv3yJgA8MMjgDOgQAVrNPjQK0Aipwflcskwmw507d1BeXg4HBwd07tzZaH+XNQoLC+Hu7l7ruv5aQUFBne3kcjmUSmWjbYOCglBYWAiBQADXh35I2NjYQCKRoLD6Nz1z+qxLRkYGTp06hZiYmAYLWxYUFLDPBEDZsoS0IsYBmvUJAoBx0NMaZ9AcHezhLHGETF7GUbFa41pohBAdzgK07OxsfPnll/jrr7+Mjnvi8XgYNGgQli5dCl9fX6ueoVAoYGNjU+u6SCRi36+vHQCT2ioUCgjr2QMhEomM7jO1z4dVVVXh7bffhlgsxuLFi+u8R2///v11JmUQQlpekcwgQUDCTYCWnqlb4rSzFbe6Eht6AT5ekMnLkF9YDIVSCXH1zzxLODtRJichdeEkQMvMzMSLL76I4uJiBAQEICoqCq6uriguLsaNGzdw9uxZJCUl4euvv66zpIWpxGIxVCpVretKpZJ9v752AExqKxaLoa6uCl7XvYb3mdqnIY1Gg3feeQepqan49NNP4eHhUeez9GJjYzFkyBD267S0NHzwwQcNtiGENA/DgMKNg5UCtUaDzFzdSkCAnzcne9qaQoCvFxJv3QPDMMjKKUBokOU/140DNJpBI0SPkwDtm2++QUlJCV599VWMHz/e6IcKwzDYv38/1q1bh2+++Qbvvfeexc9xd3dHfn5+rev6JcD6gh2JRAKRSGS0VFhfW3d3d2g0GhQXFxstc6pUKsjlcnb50pw+DX322Wc4f/48/vWvf6FPnz4Nfl59H40FcYSQlqHP4BQKBHCqo7SQubJzC6DR6EpstMblTb2Hz+S0JkCzEQrhaG+PsooKWuIkxAAnFRD//vtvDBkyBLGxsbV+4+PxeJgwYQIGDRqEy5cvW/Wczp07IyMjA+XlxtWrk5KS2PfrwufzERYWhuTk5FrvJSUlwc/Pj93Mrz+y6uF7k5OTjY60MqdPva+//hqHDh3CkiVL8Pjjj5vykQkhrZRGo4GsrAyAbqM7NxmcBgkCBkFQa9NUiQIKpRJV9WwNIaSj4ewszpCQkAbvCQsLg1arteo5w4cPh0ajwf79+9lrSqUShw4dQvfu3dkMztzc3Fqb6YcNG4bk5GSjgOrBgwe4evWq0ekHvXv3hkQiwb59+4za79u3D7a2thg0aJDZfQLAf//7X+zatQtPP/00pk6davH3gBDSOpSUlrL7bV0l3CRCGQZoQf6tr0itHve10Gr279EyJyE6nCxxdu3aFampqQ3ec//+fYSHh1v1nO7duyMmJgbffvstSkpK4O/vjyNHjiAnJwerVq1i7/vwww+RkJCAU6dOsdcmTZqEgwcPYtWqVZgxYwYEAgF2794NV1dXzJgxg71PLBbj2Wefxbp16/DWW2+hf//+uHbtGo4dO4aFCxdCYrAR2NQ+T506hY0bNyIgIADBwcE4duyY0efq27cv3NzcrPreEEKaV1NkcBoVqW3FS5xcz6AZ7UMrlcPHk7Z1EMJJgLZw4UK88sorOHjwIMaNG1fr/f379+PixYtYt26d1c96/fXX4e3tjaNHj6KsrAxhYWH45JNPGq3NZm9vj/Xr12PDhg3Ytm0be27mkiVLjCr8A7rASygUIi4uDmfPnoWXlxeWLFlSa+bL1D7v3LkDQFdao64N/uvXr6cAjZA2ptgog5OrGmg1RWpbc4Dm4eYCsVgEhULJeS00mkEjRIfHGNbEsNDWrVuRmJiIS5cusVmcbm5uKCoqwvXr15GRkYF+/fohMjLS+OEcnM3Z0aSkpGDhwoX47rvvrJ6RJIRY7uiZs7j74AEAYMbYMZxkcT61YCXSs3Jhb2eL+J+/abVZnAAw/fnXcS8tEzZCIU7/7zsIBJbvmJGVleGn/QcAAKEBAXjy0aFcDZOQNouTGTTDsznT09ORnp5e656LFy/i4sWLRtcoQCOEtFX6GTQ+n2+0RGcptVqNrBxdlnqAr1erDs4A3RjvpWVCpVYjv7AYPl61i3abysneHkKBAGqNxujweUI6Mk4CtJY6m5MQQlqCRqNha6C5SJwg4Fufb5WVWwBNdSJVay6xoRfgY7wPzZoAjc/nw0XihILiEshKy6DRaBo8YYWQjoCTAK2lzuYkhJCWUFJaCm317hB3ZxdO+jRKEGjFGZx6/g9lcvbtFWFVf64SZxQUl4BhGMhKy+Dmws2+PkLaKk7KbBBCSEdSVFLCvuYqkDA8JL01JwjocZ3JaZgJS8uchFCARgghZis0yODkagYtI7uDB2gGmbD6ExoI6cgsCtDee+89nDx50uKHWtueEEJaUlFJTYDG2QxaG6mBpufr5QE+X5fIkMnxDFoRzaARYlmAdvz4cdy/f9/ih1rbnhBCWlJR9QyaUCjk5AxOAEivroHmYGcLNxduCt82JRsbIXw8dYkBGRycJuDs6Ah+deYqzaARYkWSwO3bt3HkyBEux0IIIa2eSq2GvPoMTjdnZ07KYahUamTnFQAAAv29W32JDT1/Xy9k5RagtKwCstIyODs5WtyXQCCAxMkJJXI5SuRyaLVa8DnIjiWkrbI4QDtz5gzOnj1rdjsO6uISQkiLKTLYf8ZFcVpAV2JDq9X9bAzwbf3Lm3oBvl64lJAEQLcPzZoADQDcnCUokcuh0WpRWl7OSX05QtoqiwK01atXW/3gLl26WN0HIYQ0N8P9Z+4c7T9Lz6o54qkt1EDTM6yFlpmdh8iuYVb1p0sUyACgO+uUAjTSkVkUoD355JNcj4MQQtqEIlkJ+5qrGbQHbawGmh73mZwGpTZkMoT4+1vdJyFtFS3wE0KIGYwzOF046TO9jdVA0zMsVmtYaNdSxrXQKFGAdGwUoBFCiBn0NdDEIhHsbW056dOwBlqQf9sJ0AyDSS5m0FwMZtCKKJOTdHAUoBFCiIkqqqpQUVkJAHB3ceEs21K/xOlgbwcXSdvZd2VvZwt3V90y7wMOZtBshEJIHHWJBsUyGSWVkQ6NAjRCCDFRYXEx+9rD1ZWTPlUqNXKqS2wE+bWdEht6+qSGomIZyioqre5Pv69PpVajtLzc6v4IaasoQCOEEBMVGJzB6eHqwkmfmTl5bImNwDa0vKkXYLDMycWJAoYnMxiWNCGko6EAjRBCTFRYXMK+5moGzfiIp7aTwalnuA/tQWZOA3eaxt0gM9YwIYOQjoYCNEIIMVFB9RInn8czKglhjQyDAK0t1UDT4zpRwDAzttCgpAkhHU2zBWgqlQrltJ+AENJGqTUalFSXfnB1doZAIOCkX8MZtIA2HqBxMYPm4uTEnslJM2ikI7M4QJs+fTp+/vlno2sXL17Ehg0b6rx/x44dGDt2rKWPI4SQFlUsk0FbnVXozlH9MwBIyzA4RaANFanV47pYrUAggHN1Jmtx9bFPhHREFgdoOTk5KKs+MFgvMTGxVtBGCCHtQYHR/jMXzvp9kJENAHCWOMJFYt1Zli3Bwd6O01IbAODm7AIA0Gq1kJWWctInIW0N7UEjhBATFJZwX2KjorIKeYW6foPb4OyZXiDHpTaMEgUok5N0UBSgEUKICQxn0NxdOMrgNNizFRzgy0mfLSGwKUtt0D400kFRgEYIIY1gGIYtUutgZwc7WzEn/bbHAI2LRAH9EidgfDg9IR0JBWiEENKIsooKKFQqAIA7R8ubAJBWvf8MaB9LnAA3iQISRwcIq7NkaQaNdFQUoBFCSCPyiorY156cBmgGGZwB7SNA42IGjc/nw7V6H5qsrAxqtdrqPglpa4TWND527BgSExPZrzMzMwEAK1asqHWv/j1CCGlr8gsNAjQ3N876TcvUzaDx+TyjchVtjeHY0znL5HRGflERGIZBkUwGL3d3TvolpK2wKkDLzMysM/C6ePFinfe3tUOACSEEAPINZtC83LkJ0BiGwYNMXTDj5+0JkY0NJ/22BAd7O3i4uaCgqISTGTRAV8ok5b7udUFxCQVopMOxOECLi4vjchyEENIqMQzDLnHa2drCwc6Ok37zC4tRUVkFoG0nCOgF+fugoKgExbJSyEvLIXFysKo/w1ImhiVOCOkoLA7QfHza7n4JQggxVWl5ORRKJQDd8iZXKwGG+8/acoKAXnCAD65cTwagW7qN6tbZqv4MT2swLHFCSEdBSQKEENIAo+VNDveftZcSG3rB/jWfwTD4tJStWAxHe3sAukPqmepjtgjpKCyaQVuzZo3FD1y9erXFbQkhpLkZZXC6cZjBmWlQYqMNZ3DqGX4G7vahuaKsogIqtRry8nI4O7a9o7AIsZRFAdrhw4frvM7j8er8LUd/ncfjUYBGCGlTmmoGra0fkv4ww1lAw/pu1nB3cUFqdSJaQXExBWikQ7EoQHs4QUCr1eLLL79EUlISpkyZgp49e8LNzQ1FRUW4du0afvnlF0RGRmLp0qWcDJoQQpoDwzDIL9JtULe3tYVD9ZIbF/RBjL2dLTzcXDjrt6X4entAKBRArdZwssQJPJQoUFyCToGBnPRLSFtgUYD2cILAjh07cPPmTfzwww/w8PBgrwcFBUEqlWLMmDF49tlnER8fj1mzZlk3YkIIaSbyhxIEuFJVpUBWbgEAIDTQr12UIBIKBAj09cb99CykZ+VCo9FCILBum7OHqwv7uqCYMjlJx8JJksBvv/2GmJgYo+DMkKenJ2JiYnDgwAEuHkcIIc3CsEAtV/XPACA1I5vdDhIa5MdZvy1Nvw9NqVIhJ7/Q6v4kjo6wEermEQpLSqzuj5C2hJMALT8/HyKRqMF7RCIR8vPzuXgcIYQ0i9zCAvY1lzNo9x7UFPgOC/LnrN/6qBkNClRyaBltkz7HcC8dF4kCPB6PLbdRWl6OqurZTEI6AqtOEtDz9PTE6dOn8eyzz0IsFtd6v6qqCqdPn4anpycXjyOEkGaRU1AzC+RTzwqBJe4/yGJfN9UMWoVGgU3Zx3Cs+BpylSXQQAsXgQP6S7pgrFsfDHeJ5PyZDycKDOoTZXWfHq6uyCnQBcqFxcXw9/ZupAUh7QMnM2jjxo1DVlYWXnzxRZw+fRoymQwAIJPJcPr0abz44ovIycnB+PHjuXgcIYQ0OY1Gg4LqDE5nJyfY1vHLp6UMA7SwYO5n0P4uvYtpN/+NrbknkKUsgga6mbMSTTmOFSdg2d3v8fGDX6FiNJw+17DgLneJAi7sa33CBiEdASczaDNnzkR6ejoOHz6Mf/3rXwCMS24wDIMnn3wSM2fO5OJxhBDS5AqKi6HR6gIbHw9uz4G8X73EaSsWwceT275PyZLw8p0f2KDMhidAZztfOAvskVjxAKUa3fFSu/LP4E5lNtZ1mg+JkJvjq4xm0DK5KbVhuLRsWPKEkPaOkwCNz+dj9erVGD16NI4cOYK7d++irKwMjo6O6NSpE0aNGoXo6GguHkUIIc3CcHnTm8PlTYVSiYycPAC6DE4+n7sDXZIrMrHy3jY2OJM6hOLdkOkIsfUCoNuLtq/gIj5O182eXS67i3+l7sQXneZzkknq4uwEZycHyErLOZtBc3N2Bp/Ph1arpQCNdCicBGh6UqkUUqmUyy4JIaRF5BbUJAh4u3M3y/UgMwdaLfcZnHlKGZbe2YxKrW4j/UhXKdaEzoGAVxMACnkCTPYchM52vlh6ZzNkmgrEyxLxY+4JzPN5jJNxBAX44vrNO8grKEJFZRXs7Wyt6k8gEMDDxQV5RUUoKS2FQqmEuJGkNELaA4t/dfvf//5HWZmEkHYrt1A3gyYUCIwO7rbWvbSaDM5QjjI4GYbB+w/2IE+l2//b0yEY74fMMArODPVyDMHHobPZr7/MPIQrZfc4GUtoYE3QmZrO0TKnQYkTqodGOgqLA7QvvvgCU6dOxaJFi7Bt2zbcvXuXy3ERQkiLKa+sRGl5OQDAy92d02XIe02QwflnyXWckiUBADxtJPii03zY8hueZRriHIGFPo8DADTQ4t3U3ZwkDRh+pvvpmQ3caTrDfWh5tMxJOgiLf+p8++23mDNnDlQqFb7//ns8++yzmDFjBjZs2ICEhARotU1bb4cQQpqK0fIm5wkCNQFaJw4yOMs1VfgkfS/79crAiXC3cTKp7fN+o9HLIQQAkKrIw+78s1aPx7Cum2Ewag0vShQgHZDFe9DCw8MRHh6OBQsWIDs7G6dPn8bZs2fxyy+/4Oeff4aTkxMGDx6MRx55BP369YOtrXX7EAghpLnkGARoXNY/A2pmlcQiG/h6WV8bclP2MeSqSgAAQyTd8IRLL5PbCnh8rAyciNnJXwAAvsk6inFufeAsdLB4PEYBWho3M2iuzs4QCATQaDRGpzsQ0p5xkiTg6+uLadOmYdq0aZDL5Th37hxOnz6N+Ph4HDlyBCKRCH369MHQoUMxePBguBocgEsIIa1Ndn7TJAioVGqkZ+YC0JWksPasyjylDP/NOwMAEPOEeC3oKbOzMXs4BGG8W18cKLoMuaYS32Qfw6rASRaPydvTDfZ2tqiorGLLiVhLwOfDw8UFuYWFkJWVUaIA6RA4zeIEAIlEgtGjR2P06NFQKpW4fPkyzpw5g3PnzuH8+fPg8/no3r07/vOf/3D9aEIIsZpKrUZ+dYKAi8QJ9nbc1AgDgNSMLLa2GhcJAj/kHIeSUQMAZnoNRaDYstm+pf5j8HvJP6jSKrE7/xzmecfAW+RiUV88Hg8hgb5IunUfWbkFqKpSwNbW+iK/nm5ubOJGflERAnx8GmlBSNvG3c7XOohEIgwePBgrV67E//73P2zYsAHTpk1jTxoghJDWJregANrqItt+nl6c9n37Xjr7umtooFV95SpL8EvBXwAAW74Iz3gPt7gvb5EL5ng9CkBXK21H3imrxqYPPhmGQRoHZ3ICxofV0z400hE0aYBmiMfjISoqCs8//zx27NjRXI8lhBCzZOXVlA/iYo+YodupNQFaZysDtC05f7KzZzM8h5icGFCfWV5DIebpFlV+zj8PubrC4r46GSUKcJ/JmUv70EgHYPES55o1ayxqt3r1aksfSQghTS4rL4997efF9QzaA/Z117Agi/spVJVyNnum527jhAke/bE7/xwqtArE5Z/FQt8nLOrLsNQGZ4kCEglshEKo1GqjLFtC2iuLA7TDhw+bfK/+XE4ej0cBGiGk1dJoNOw+JycHBzg5WJ7NWJfb93UzaK7OTnB3dba4n58LzrOzZ1M9Blk9e6Y31zsGP+efhxYMfso7jTnew2DXSD21uhjur7vPUakNPp8Pb3d3ZOTmsnXquP7/h5DWxOIAbePGjSbdl5GRgS1btiAri5u/pIQQ0lTyioqg0eiKtfpxvLxZUFSCohI5AKBLaJDFZ1+qtGrsztPVK+ODh1leQzkbY4DYHSNdpThSfBXF6jIcKbqKSR4DzO7H18sdYrEICoWSs0xOQHcmakauLgs2t7CQAjTSrlkcoHXv3r3B90tKSrB161YcPHgQKpUKUVFReO655yx9HCGENDnD5U1fjpc373C0/+xocQIK1KUAgMdcouAndmukhXlmez+KI8VXAQB78s9ZFKDx+XyEBvoi+U4aMnLyOCuLYVg0ODe/AJ2DLF8mJqS147zMRlVVFXbt2oW4uDhUVFQgJCQEixYtwpAhQzjpX6lU4vvvv8exY8dQWlqKTp06YcGCBejXr1+jbfPz87FhwwZcunQJWq0W0dHRWLp0Kfz8ah+3cvDgQezatQs5OTnw9PTElClTMHnyZIv73Lt3L65cuYKkpCTk5eVh9OjReP311y3/RhBCOGe0/6wpMzjDLAvQGIbBzrzT7NezqzMvuRRlH4Rudv5IrsxEYkU6ksrT0d3B/PGGBfkj+U4atFoGaRk5Vu250zMsGpxTvRRNSHvFWRanRqPB//73P8yYMQNbtmyBg4MDVq1ahS1btnAWnAHAxx9/jN27d+OJJ57ASy+9BD6fj5UrV+Kff/5psF1FRQWWLVuGhIQEzJkzB/Pnz8ft27exdOnSWmU/9u3bh08//RShoaFYtmwZevTogfXr1+Onn36yuM+dO3fiypUrCA0NhUAg4OabQQjhjEajYQvU2tvZwdnJkdP+b92vSRDoEmpZsPJPeRoSK3SBXoR9AKIdQzkZmyEej4dpnoPZr3fnn7OoH8N9aHfTMqweFwDYisVwdtLttyswWI4mpD3iZAbtxIkT2Lx5MzIzM+Hg4IDFixdj8uTJEIutL05oKCkpCcePH8fzzz+PmTNnAgBGjRqFefPmYePGjQ3ui9u7dy8yMjKwadMmREREAAAGDBiAefPmIS4uDosWLQIAKBQKbN68GYMGDcL7778PABg/fjy0Wi22bduG2NhYOFX/gDC1TwD48ssv4e3tDR6Ph1GjRnH6fSGEWC+3sBBqtW7jfUD131Uu6WfQBAIBQgJ9Lerj54Lz7OtZXkM5H6Pek269sTZjP8q1ChwuvorlAbGQCM0r2NvFYBn39r10PBnDzdh8PNwhKy2FRqtFQXExvDk+iouQ1sKqGbSrV69i8eLFePfdd5Gbm4vp06dj165dmDVrFufBGQCcPHkSAoEAsbGx7DWxWIyxY8ciMTERudWbR+sSHx+Pbt26sYEUAAQHB6N37944ceIEe+3KlSuQyWSYOHGiUftJkyahsrIS58/X/IA0tU8A8PHxabIfpoQQ66Vn1xRU5bpKvVKlQmpGNgAgNNAXIhsbs/uQqytwtEi3N8xJYIeRrqafuWkue4EY49z7AgCqtEr8VnTZ7D6MAjSD2UNrGQZkOQW0zEnaL4sDtBUrVuCVV17BrVu3MHr0aOzcuRPPP/88O7vUFG7fvo2AgAA4PJS5ow+Q7ty5U2c7rVaLe/fuoVu3brXei4iIQGZmJioqKthnAKh1b3h4OPh8Pm7dumV2n4SQ1i89pyZAC/TlNkC7/yCLXY6zdHnzt6K/oagurTHOrQ9sLSh/YY6pBsucBwrND9A83V3h7KT7Wa0vL8IFw31oVA+NtGcWL3FevHgRPB4P3t7eKCwsxGeffdZoGx6Ph08//dTSR6KwsBDudRxcrL9WUM9fVrlcDqVS2WjboKAgFBYWQiAQ1DrQ3cbGBhKJBIXVG1PN6dMaBQUF7DMBIC0tzar+CCG1VSkUyKv+e+bm7AwHDs/fBIBb9wz3n5m/4Z5hGLYwLQBM9hzIybga0sXOFxH2AbhZkYHEinTcrcxBJzvTA1cej4cuoUG4/M9NFBbLUFQih5uLxOpxuTk7QygUQq1WI7uggK2xSUh7Y9UeNIZhkJ2djezsbJPut/YvkUKhgE0dSwOi6vRthUJRbzsAJrVVKBQQCuv+tohEIqP7TO3TGvv378fWrVut7ocQUr9Mg+0RgU1wCHfSrfvs626dQ8xuf73iAW5X6n7O9nQIRhe72pnnTWG8W1/crNBt8D9YdBnL/MeZ1b5LWCAu/3MTgO4UhQG9e1g9Jj6fDx8Pd2Tk5KK8ogKl5eWQOHKb0EFIa2BxgBYXF8flOEwiFouhUqlqXVcqlez79bUDYFJbsVjMbhSu617D+0zt0xqxsbFGWbBpaWn44IMPrO6XEFKjKZc3ASDp9j32dUSXELPb/89w9sxjEBdDMslot2iszdgPDbT4rfAKlvqNAZ9n+s4Yw+Xc26npnARogK4ESkaOLqjOysujAI20SxYHaD5N8FtmY9zd3ZGfn1/run4J0KOebB6JRAKRSGS0VFhfW3d3d2g0GhQXFxstc6pUKsjlcnb50pw+reHh4cFJP4SQujEMwyYI8Pl8zgvUqlRqNoMzOMAXjg72ZrWv0ChwtCgBAGDPFzdpcsDD3G2cMMS5G07JkpCrKsGl0rsYIOlicnvjTE7uEgX8vL2A67rXWXn56BYWxlnfhLQWnNVBaw6dO3dGRkYGysvLja4nJSWx79eFz+cjLCwMycnJtd5LSkqCn58f7O11PzS7dNH98Hn43uTkZGi1WvZ9c/okhLRestJSlFb/TPH19IBNPVscLHUnNR2q6ll5S2bP/iy5jnKtbrvESNdesBdwnyHfkPHV2ZyAbpnTHKFBfhDwdf/McJko4OXuDn51v4bFhQlpTyz6SbRmzRqLH2jNYenDhw/Hrl27sH//frYOmlKpxKFDh9C9e3d4e3sDAHJzc1FVVYXg4GC27bBhw7Bp0yYkJyezmZcPHjzA1atXMX36dPa+3r17QyKRYN++fRg0qGYpYd++fbC1tTW6ZmqfhJDWKzWz5qzIIF/L6pM1xHD/Wfcu5s/07C+8xL6e4N6fkzGZY5hzJJwEtijVVOH34mt4LfApk4NEsUiE4EBf3EvLxP30LKhUatjYWB8ACwUCeLu7Izs/H/KyMpRVVMCRfiEm7YxFf1MOHz5c53UejweGYeq9zuPxrArQunfvjpiYGHz77bcoKSmBv78/jhw5gpycHKxatYq978MPP0RCQgJOnTrFXps0aRIOHjyIVatWYcaMGRAIBNi9ezdcXV0xY8YM9j6xWIxnn30W69atw1tvvYX+/fvj2rVrOHbsGBYuXAiJRGJ2nwBw9uxZtgyIWq3G3bt38eOPPwIAHnnkEXTq1Mni7wshxHKpmVns65CAAM77T7ptEKB1Na/yf5aiCBdLdT83AsXuTXJyQGPEfBuMdJXil4K/UKlV4s+S62yNNFN0CQ3CvbRMqNUapGZkWVxm5GF+Xl7Irt7ykp2Xjy4hwY20IKRtsShAezhBQKvV4ssvv0RSUhKmTJmCnj17ws3NDUVFRbh27Rp++eUXREZGYunSpVYP+PXXX4e3tzeOHj2KsrIyhIWF4ZNPPoFUKm2wnb29PdavX48NGzZg27Zt7LmZS5YsgYuLi9G9kyZNglAoRFxcHM6ePQsvLy8sWbIEU6dOtbjPkydP4siRI+zXt2/fZmuueXl5UYBGSAuoUijYf+RdnJzgKrG+DMTDblYHaAI+H+Fmnkd5sOhvMND90hvr3r/FykmMd+/Hlvk4UHjZzAAtEEfjdQW+b99L5zBA88TfibrXWXl5FKCRdofH1DXlZaYdO3Zgz549+P777+vc0J6fn49nn30WM2bMwKxZs6x9XIeWkpKChQsX4rvvvkN4eHhLD4eQNu3W/VT8UX06SK9u3TCkdzSn/VdVKTB8ynPQaLXoEhaEnRveN7ktwzAYn/gR0hWF4IGHw1Fvwlfk2njDJsAwDMbd+AgZSt1Yjkb9C94iF5Panrv8D5a9tRYAMGvSaLyycCYnY1KpVNj88y9gGAauzhLMHDuWk34JaS04SRL47bffEBMTU2+2oaenJ2JiYnDgwAEuHkcIIZy4b7D/LDTAv4E7LZNyNw0arRYA0N3M+mdXy+8jXaHLCO/v1LnFgjNAt01lnHsfAAADBoeKrpjc1rDu202D5V5r2djYwMvNDQBQLJOjorKSs74JaQ04CdDy8/PZ4qz1EYlEdZbIIISQlqDRaPAgS7f/TCwSGR0hxJVEo/1n5iUI7C+oSQ6Ide/H2ZgsZbisub/wUp37jevi5iKBj6euPFHynVRoNFrOxuTnXVMSJaOBs5gJaYs4CdA8PT1x+vTpeivnV1VV4fTp0/D09OTicYQQYrWs/Hy2/EWwnx9btoFLiSl32dfmJAhUaBQ4VpwAAHDgi/GYSxTXQzNboNgDUgfdZ7hXlYvkysxGWtTQf/bKKgVSM7IauduMMRnU48wwKDZMSHvAyU+kcePGISsrCy+++CJOnz4NmUwGAJDJZDh9+jRefPFF5OTkYPz48Vw8jhBCrHb3QU3h1KZY3mQYBgk3bgEA7GzF6GzGGZzGtc+kzV77rD5jq5c5AZi1zGk4e2hYdsRavp6eEAoEAID07ByTZ/UIaQs4qcg4c+ZMpKen4/Dhw/jXv/4FwLjkBsMwePLJJ9naZYQQ0pI0Wi3uPtAVThUKhQjy4/5sy6zcAuQVFgMAorp1ZgMJUxjWPov1aPnlTb2Rrr3wyYNfoYYWh4uu4GX/cRCYcPRT9y41s4dJt+5j/BNDORmPQCCAn5cXHmRno7yyEsVyOdycnTnpm5CWxkmAxufzsXr1aowePRpHjhzB3bt3UVZWBkdHR3Tq1AmjRo1CdDS32VGEEGKpjJwcKKrPzA319+f89AAAuJZ4i30t7dHV5HaGtc+CxB6Idmj+2mf1cRE6YIhzBE7KEpGvkuOyiUc/detcUwLD8FxSLgT6+uBBtu4g+fTsbArQSLvB6U8lqVTaaD0yQghpaXfS0tjXnYO5qcv1sKuJKezr6EjTS+IY1z7r12K1z+ozxq03Tsp0BcgOFf1tUoDm5OiAIH8fPMjMwe176ZydKAAAAQb70NJzctGr+lQXQtq6NnUWJyGEWEut0eBeegYAQGRj0yTHOwFAQvUMmkAgQI9w0zI4GYbB/sKLAAAeeGYVhG0uw1wiYc/X7Yn7o/gfKLQqk9rpEwVUajXupHJ3LqebszPs7ewAAFm5udBoNJz1TUhLogCNENKhPMjKYrM3wwIDIDBjb5ipimVypKbrlt0iOofA1ta0Tf5Xy2pqnw1w6tKitc/qY8cX4XHXngCAMm0VTsuSTGpneA4pl4kCPB4PgT66c5jVGg1yCgo465uQlkQBGiGkQ7mVarC8GdQ0xwMlWLj/bF/17BnQOmqf1WeMW2/29W8mZnMalhlJ4rBgLQAEGsyCGp6tSkhbRgEaIaTDqKiqQmqGbnnTztYW/tUzL1zTl9cAAGmkaQGarvbZNQDVtc9cW772WX36O3WBh9AJAHBalgS5uqLRNuFhQRBU15q7nnyH0/EE+fmxe/VSMzKo3AZpFyhAI4R0GCn370Nb/Y93t7BQNmDg2lWDGbRe3U0L0I6XXEdFde2zUW5S2PEbPp2lJQl4fIx202XmqxgNfq8OLBtiaytG1+rD4u8/yEKJvIyz8diKRPCtLoQuKytDibyUs74JaSkUoBFCOgSGYXDzbk1l/4iwTk3ynBJ5GZLvpAIAOgUHwEXiaFI7w9pnE9z7N8XQODXGzfyitYbLvdeSbjVwp/kMiw2nZmZw2jchLYECNEJIh5BTUMDOrPh5ecFF4tQkz7l4NZFdYhvYp4dJbXS1z24DAILEnujlENIkY+NSd/sABIt1s1aXy+4iR1ncaBupQbmRa4m3OR1PiH9NgHY/0/RjqAhprShAI4R0CEazZ53MO7jcHH9duc6+HtTbtH1kB4ous68ntMLaZ3Xh8XhGyQKmzKIZ7sdLMKgTxwVnJye4SiQAgJz8AlRWVXHaPyHNjQI0Qki7V1lVhdtpurM3RTY26BRo+rmY5mAYhg3QxGKRSRmcDMNgf4FueVNX+6xPIy1aD8OzOQ8UXm50c76biwTBAbqMy6TbqaiqUnA6nhCDZc60LMrmJG0bBWiEkHbvxu3bbAHTiLAwCJvgaCcAuJuagfzCEgBA7x7hEIsa3+h/tew+MpQ1tc98WmHts/oEij0Q7agrn3GvKhdJFY3v/ZJ21508oNFocCOF22OfDJc59WetEtJWUYBGCGnX1BoNbtzS7Xfi8Xjo2c30Y5fMdd5geXNgH9OWN/9XeIF9PaEVHYxuKsN6bYZ13Ooj7VHz/TesF8cFHw8POFSfKpCek4MqBbczdIQ0JwrQCCHt2q37qais/oe6U2AgnBwcmuxZf/19g3092IQArVRTiWNFCQAAJ4EdHnNpvbXP6vOEay/Y8mwAAEeKrkKpVTd4f1PuQ+PxeOgcpCvlodVqcS+DsjlJ20UBGiGk3WIYBteSk9mve0U03UHalVUKdkbIx9Od3WvVkEOFV1DF6M6yHOvWB7ZNWPusqYq3Ogns2KK6Mk0FTjVy9JO/jyc83V0AAP/cvAO1uuGAzlydg2tOh7iTltbAnYS0bk2zEYMQQlqBe+npKJbLAQC+np7wdndvsmedvXQNSpUu2BrUN6rRTEyGYfBLwXn268keAzkbS3lhJdKu5CE9IR+FaXKoKtRQKTSwdRLB0cMOHqEShA30hU+EG/h86zNGx7v3Y7M49xVeZM/qrAuPx0PvHt1w9ORfqKxS4EbKPZNPWzCFl7sbJI6OkJeVITM3DxWVlexh6oS0JRSgEULaJa1Wi4v/1OwJ6929e5M+7/iZmkKzI4Y0vpcssSIdKZW6TMMe9kHoau9n9RhK8yqQsO8ubp3KBKOpPWNWJVeiSq5EwT0Zko+nw8HNFr2ndEaXRwOsCtQGOHWBt40LclUlOCO7iVxlCbxFLvXf37sHjp78CwBw/u/rnAZoPB4PnYODcCUxCQzD4F56Bnp07cJZ/4Q0F1riJIS0S7fT0tjZMx8PDwT5Nb7kaKmqKgXOXEwAADhLHNGnV0SjbX4t+It9PdnTutkzrUaLq/+7g92vnkLKiQyj4EzsaAMXf0d4hErg4GYLw4m98qIqnP72Bva+cRb5d0ssfr6Ax2cTHLRgsM/gVIS6DDLYn3f+7+sN3GmZLgbLnLfSUjnvn5DmQDNohJB2R6PV4tL1mg37A3r1bNLir+cu/4MqhRIAMHxQHwgFggbvl6sr8Fv1kqA9X4zRrtEWP1ueW4H4/1xD3p0S9pqNnRDdRwYjdIA33IMk4BnMjqmq1HhwNR+3T2Ui41o+AKAorRQH3vkL/Wd3Q+SoYIu+V5PcB+C77D/AgMH/Cv7CAp8R4PPqngPwcHNBl9BA3L6fjuQ7qSiRlcLFmbuTHdycneHm7IwimQw5+QUolsnh6izhrH9CmgPNoBFC2p3E23cgL9Mdxh3g4w1/b+8mfd4fBsubjw9tfHlzb+FFVGl1Ad14976wF4gtem5OchH2/escG5zxeEDP8WGYsX44+k3vCo8QZ6PgDABsbIXoNMgXo1f1xdh/9Yd7iC5w0WoY/LXtJk5suAaNSmP2WPzEbhgs0ZXQyFIW47y84RIaA6tPWWAYBheu3mjwXnPxeDyj0yJu3rvbwN2EtE4UoBFC2pWKykpc/Ocf9usBPevfsM6FKoWyZnnTyQF9eza8vKlhtNiVd4b9eqbXIxY99+65LBz66CIUZbrEBIm3Pca9PRD9Z4ZD7GhjUh++Ee6Y8N4gRI0NZa/dO5+No5/9DWWl+dmVTxkkOhgu4dbFaJnzCrcBGgB0DQkFn6/7Jy7l3n22UDEhbQUFaISQduXc1QQ2m7JbWCi8PTya9HlnL11DZfWRRcMH9Wn0lILTsiRkKosAAIMl4Qi1NX92LyU+HSf+cw1atW6vmX+UOyZ+OBjeXc0/hYAv5GPA7G54/JXeEIh0/yRk3SjE4Q8vQlGuMquvYS6RcBfqlirjS24gTymr995ekV1gK9aVFfnr7+uclwGxsxUjLCAAAFCpUCCVDlAnbQwFaISQdiMrLw+3UlMBAGIbGwySSpv8mf87fIJ9/cSwxjf778w7zb6e5TXU7Ocln0jH6W9vANXxTHhMAEat6AuRvWmzZvUJ6eeNMa/3h8heF2Dm35Ph6GeXoaoyfSbNhifAUx4DAABqaLGn4Fy994psbNjZxsJiGW7de2DF6OsW0bkT+zrpLi1zkraFAjRCSLugVKnw5181xyYNkPaCna1tkz4zIzsXF64mAtAVYO3XSPZmckUmLpTqjp0KEntgiMS8wrl3z2XhzHc1y4E9ngzBIwt6gC/k5ke5d1dXjHt7IGwlupmtvFsl+H3tFaiVpi8PTvUcDEH1Py178s83eLLAoL41y88nz1+xcNT1C/D2hqT65Ij07BzISks5fwYhTYUCNEJIu3Dm7ytsYoC3uzu6d+rUSAvr/e/ISfb1pCdj2D1P9fk+5zj7erbXo/VmOdYlK7EQJzfW7K2LGhuKAXO6cZ6d6hbohCdX92Nn0rISC3Hym3/AaE1bgvQWuWBEdaHaYnUZjhZfrffemMF92PH/cabxczzNxePx0L1zZ/bra8ncHi1FSFOiAI0Q0ubdTU9H8r17AAChUIjHBw9qNFiylkqlxsHfdcuVAoEA4x5veLN/alUefi++BgBwEzpiokd/k59V+ECO3z+/Am11fbNujwWi/6zwJisd4h4iwejV/SAU68qF3P8rB5f33Da5veHS7c680/XuL/N0d0Wv7roisvcfZOFuGvdnZ3bv3Ikte5J87x4doE7aDArQCCFtWrFMjhMGS5tD+/SGsxN3NbXqE3/+bxSV6ArhxgzqDXdX5wbv35pzAkz1xrGnvYeZfO5mWUEljn5yGarqrMqg3l4Y/H/dm7SuGwB4dXbBY0ulbGHba/vu4la8aQGU1CEEEfa6DfpJFRm4Wna/3ntHPFJTluT46YYL3FrCVixGRPVsqlqjQeKdO5w/g5CmQAEaIaTNqlIo8NvJk2zWZqfAQHQLC2uklfUYhsGOXw+zX08aE9Pg/TnKYhwougwAcBLYYprnEJOeU1WmxJFPLqGiWDfr49nZGY8tlYIvaJ4f3UG9vTDwmZp9dae/v4GsxMJG2/F4PMw2mEX7wWBp92ExQ/qyr5timRMAenarmW28nnKLSm6QNoECNEJIm6TWaHDk9Bl235m7iwseGzigyWeWAN3JAUm3dLNCXUIDG619tin7GNSMLiiY4TkUjoLGkxfUSg1+X3sFJZnlAACJjz1G/r8+7LJjc4kcFYLuo3RHJzEaBn+su4KSzLJG24126w1fka7sx2n5TSRX1F3mwtvDDT0jdPvE7j/Iwr0H3JfDcHZ0RGh1yY2Kqiok36t/Ro+Q1oICNEJIm6PWaHD41Clk5eUBAOxsbTFm2KOwsbGu1IQpGIbB5p372K8XzJzQ4H63e5W52FugmxlyEthijvejjT5Dq2UQ//U15KYUAwBsJSKMXtUPdhLLThyw1sCnIxAY7QkAUFaocfTTy6iUN7yXy4YnwDzvmpnF7xuYRRsxtGY/3u+nLtR7nzWiI2qC6MuJiVDTLBpp5ShAI4S0KWq1GkdOnUZ6dg4AwEYoxJhHh8KpupxCU7tw9QZupOhqanUKDsDwwX0avP+rrEPQVu89+z/vx+AibHicDMPgr+03kXoxFwAgFAswamVfSLztORi9Zfh8Hh5bKoV7sG5vX2l+Jf5Yd7XRI6Emevz/9s47LqorfdzPFHqTIiBgAwuKkqgBUwTB2I0lxaibrLqJbjS2FFe/m43JmsSYaExPNGbNuslvk2hcu4CAsZGmxg5iQxREihTpbeb+/hi5MMwMDDogmPN8Psrcc97znve9Z+6975x7SihuakcA4vJPkFqebVRu6KAQlDe3pNoee7BZgicvD3e6+PoCUFJaSuJ58yc9CAR3AhGgCQSCNkNpWRlb9/zIlWvXAN2MzUciIpp9t4AatFotq7/+n3w8408N956dKE7lx4JTALS3cuZPZvSendp5iaTdlwFQKBU8/EI/2vs3PAGhJbCyVTN84QDs2+l68bLO5pOwLrHBHQBsldb82WswABISX1yLNSrn6eHGQyH3AJB9PY+fj5w0Kne7hAbXbi91NDGJqqqm7ZQgELQkIkATCARtgqzcXDbtjiU7VzdI3Uqt5pGIwXTwbN9iNmyO3iuPPQvo7MeQOgPc66ORtLyTtlk+ntVhBHaNzNy8kHCVQ9/VrtUVNrMPHe9pOf8aw8HdjmELB8hbQp0/cJWTO1IaLPNk+4dop9L1GkblHeVMqfGZoI+Nqn0dujlqr1GZ28XD1ZVunToBuu2fjot10QStGBGgCQSCVo1Wq+XIqdNsiY2juLQUAEd7ex4dNhQfT88Ws+N6XgGfrd8kH//t+T832Hu2Iecnkm4GI91svRtd9+zq6esc+OKUfDxgYnd6DPa7TastT3t/FyJm1+4AcPj7c1w6lGlS3lFly8wOQ+Xjj6/uMir3wIBgvNu7A7pJGNeyrlvIYn1CgvvKE0mOJiXJk0wEgtaGCNAEAkGrJSM7m027d3Po1Cm0N1+lebm788SI4Xi4Nn1j8Nvhgy+/pbhEFyA+MnQQA/qa3qYpq7KAT69Gycevdp6IWmF69mVuaiHxH+gvRHvvhObfCeFW6TqwAwOe7C4f7/v8BNdTTG+M/mT7h/C5OaPz58Kz/FZ4zkBGpVIyYeTN16GSxNbd+w1kLIGrszN9e/QAQKPRkPC75beYEggsgQjQBAJBqyM7L4/oAwfZGr+H6/kFgG5trfv69GHCsKHY29m1qD3bYw8Qu183u9DF2ZEFz042KStJEu+kbaFEq5vl+JjHQPo5djUpX5RdSsyKI1SV6QbGdxrQMgvR3i73jg+g2yAfADSVWmJX/U5JXrlRWWulmjk+o+TjVenb5WVH6jJueDiqm72Sm6P2UlpmXN/tEhrcV/4OpV69Smq65Zf2EAhuFxGgCQSCVoFGo+HClSts3/Mjm2J2cym9dqySh2s7Hh02lNDgvvIDvKVIPJfCu599LR+//NxTtHMxvVPB5uu/yhMDXNUOvOD7iEnZ8sJKYt49QlmBLpjz7N6OIXNbbiHa20GhUBA2sw9ePXQ9Y6X5FcS+9ztV5cY3Rx/t1p9AO90syrNlGXyXnWAg097dlaHhAwEoKCxi007TS3PcDtZWVjzUr598vP/IEcorK5ulLoHgVmn9dwGBQHDXUlFZSUpaOj/++ivrt2wlNuEn0rOy5Hx7W1siQkN5YsQIvFtopmZdcnLzWbzsE3mngifGPMyoyAdNyl8sy2RF2lb5eEmnibiYWFajukJD7Hu/c+OabiFaFx+HO7IQ7e2gslIx9KV+OLXX9Ublphby4yfH0VZrDWSVCiX/6PwECnQ9g59lRJNZmW8g9+zkcXLv4f/bHE1ZefPsndmtcyf8vL0A3bIb+w8danBGqkDQ0ogATSAQtAjV1dXkFhRw5mIK+347xPe7oli36X/EHDxIcsolKur0YDg7OjI4JISnx4+jd7eAZt/43BiZObk8t3g5WTl5AAT36sZLf/2TSflSTQWLL31DuaQL5p5s/yAPuwYbla2u1BD/4VGyLxQAYN/OhpGLQ7B1Mm9/ztaEnbMNw/82ACs7NQBpx3I4sPYUktYw2Al26MwTHg8AUKat5J20LQZBUddOPgwL102oyL9RxKZdzdOLplAoiBw4EBtr3Tm/eCWNs5fEDgOC1oP6ThsgEAjaLlqtlqrqaiqrqqiqrqa8ooKy8grKysspLS+npKyMwuIiCoqKKbk5A9MUVmo1Xfx86eXvj6+X1x0dg5WWkcXcV1eSkZkDgI93e955ZS5WVsZvmdWShkWXvuF8mW59tgBbb172G2dctlJD/AfHSD+hm6VoZadmxOL75F6otoirnxPDXupPzLuH0VZLXEjIwMbRivv/3MugHef7jmZPwUnyqovZW3CabbmHDWa4PjtlPHEHdD1a32yKYsKIwTg5Wn4hYicHBwaHhhCb8BMAB478joera4tPQBEIjCECNAGgG/8jSZJuvfOavyD/uq39C7olJ+vINSRfWwhJullSkjXIn+v+iq5bVtIVqlOnoY4am2rK6ttWW1auo17ZGn2GddQ7rut/PfmatPp+1fpX10bjOmrrqClXV67ueanvf73zINU5d/V11C0rgVbSotVKtX+1WrTSzb9aLVKdzzXpGo2Gyupqqqqrb2vTaYVCgUe7dni396BTBx98vb1Qq+78673Y/b/y9sf/puTmAPWOPl58vnwx7d2NP7QlSWJF2lYO3kgCwEllx3v+07A1suZZVXk1ez48RvpJXXCmtlEx4m8DcO/s3EzetBw+Qe4MmXcvez48hiRBYsxlFEoFA58K1AvSnNX2vNLpcRam/AeA5WmbudexC11sa5dM8e/ky7DwUGL3/0b+jSI++88m/m/OtGaxu1unTlzxzyA55RLV1dVE7T/AEyOGt/hEFIGgPiJAEwCwOS6enLy8O22G4C7F1sYaF0cnXJyccHNxwcvDA093N6zUrecWdC3rOp+t/4Hd+3+V07p29OGztxc1GJx9eHUnG3J0PTBqhYr3A6bjb+dlIFteWMnulUfIuahbjqJmCyfvQLdm8ObO0CXEm7CZfTmwVjdJ4nRUKkgw8Gn9IG2Y6z085jGQzdd/o1xbyaKUb/gmcD42ytq9VOc9M4mDvx2nrLyCzVF7GT3kIXlTdUsTft995BXcIDsvj+LSUqIPHGTcw0Na1fdT8MdDfPsEAkGjKBUKFEolSoUClUqFtVqN2kqNtdoKK7UaKyvdX1tra+xsbW/+s8Hezg5nR0dsrVvv2Kq0jCx+2BnP/3btlScDAIyKfJDFc6biYG+8J0UraXknbYscnAG83vlJQp26G8gWZBQTt+qoPCHAyk7NiL8NuKuCsxp6RPghSRIH/3UaJDgdnUplaRWDZvTRm536N78JHCu+xKXybM6WXeXV1O94t+vTKBU6Ge/27sz682N88OV3SJLE8k/+zTcfL0XdDEGTWq1m1OBwNu2OpaS0lKzcXKIPHGBUeLgI0gR3DPHNEwDg6eaGtZUaauZY3fxPAbW/fBU18690aYpaQfmzoq6cQk6RP8ty8o9phU5XvTrryxutQ1atQK5GoZDr1C9brw49eblC+bO+nXVsUsgSDcjXfq4vZ+BXPR16vtTNV9Q7t3Xapb5NNZ8N6lDUa09AqVSiVChRKhU3P9/8e/NzTVDW2tfkagqSJHE1M4efDp9g3y9HOXIiSS+/Zp2zR4YOMul3YXUZr6V+x94bpwHd+f5Hp8cZ5x5iIHv59yz2fX6SqjLd8hP2rjaMWHwf7p3a/mtNU/SM7AgKOPilLkg7t/8qZYWVDJl3L1a2useOvcqGFV2nMvXsx5RpK4nNP46fjRsL6ixL8uS4Yeza8xPnUq5wITWdj9Zt4OXnnmoWmx3s7BgdHsbW+D1UVVeTnpklgjTBHUUhiXnFbYqzZ88yc+ZMvvzyS3r27HmnzREIWiWSJFFUXEpewQ1yCwrJzL7O5fRMUi5f5fTZi+TmG656b21lxZPjhvLMpLENDkhPKklj0aWvSavQ7QmqRMGbXabwiLv+vpzVlRp+/+E8p3bVzgx09XNk+N/a9oSApnDpt2vs/ewE2mrdY8a1oxPDXuqHs1ft+d1fkMgLF79Ce3NM5ct+45jqFSHnnzl/iWdefpPqat14x6UL/8roIQ81m82ZOdfZsXcvVdW6gNrT3Z1R4WE4iDFpghZGBGhtjOYK0G4UFVNdrTE+WF8yMshekvQH2ksS1DvWH5iuPyhfb2C7UV21Nkj1yhrqqmNvvQkLUp1jJH3ZumWpd1y33trjWn9qJy+Y0lXv/NWfyGBKV81kA4PJGfUmQcj+6k8e0D9/9XUZP3/GdZk6B4Zla86rQRua0CXVCNXRY+r7oNVKaDRaNFqN7q9GQ/XNvzXplVXVlJfXzB6toLy8gvwbRfIDtjH8Onjy2KhIxg4La3AB2mJNOZ9nRPNddoIcTLio7Hm761MMcumlJ3v90g32rzlFflqRnNY11JvwWX3lHqQ/ChlJucS/f5TKUl17WNurGTw7mM4DasfpfZ+dwPI6G8s/7zOSv3oPk3swN0ftZfmn6wGwsbHmi3f/TlAP/2azuX6Q5mBvz6iwQXi6uzdbnQJBfUSA1sZorgBt6oJ/cub8pcYFBYI2jqODPUE9ujIguBdhofcS0MWvwVe4xZpyNuT8xDdZ+8mvrt1YO8i+Iyv9p+FrUzuOrLyokiMbz5H8Y5ocdCvVCkIm9aTP6C531aviplCQUUzc+0e5kVEip/WI8OP+P/fC+ub6aV9ci+XzjBg5f1L7h/ib33islGokSWLZR1+xLfYAoGvDj998mb6BzTNpAOB6fj5R+w9QfHN5GKVCwX19+9K/d687si6f4I+HCNDaGCJAEwiMo1KpsLO1wc7WGhcnR9zaueDu6oKbqzPt3Vzp5OtNl44d8PVu3+gDViNpOVGSyo7cw8TmnaBYW7snpI1CzXMdhjPVKwIrpS64KC+q5HR0Kom7U+U9NQHcOjkR8fw9uHUy3TP3R6GytIr9X5zi8uHanSIc3GwZ+HQgXQd6o1Ao+DprH6vSt8v59zh0YaX/VLys21FRWcn8Jas4eioZAHs7W95bsoCQe3s3m82lZWVEHzhIVm6unObp5sagAQPwbt/yO1sI/liIAK2N0VwB2of/+o60jKw6g8u5Oai8dsC9os4AdW4OHNcfqK9/XFOmVlfNR4URXfqD3RUKakb569mkqDdgvcaG2skIjenSH1xfM3jemK6acvXPARj/qz+hwsiEhXo21Za9mVrnWFHnuFZXQ+dAv2z9SRN1zx/1/Kk9V7Xnr9bOxnTp29Dw96H+d6teWerk1WkLtVqFSqVEpVKhUuo+q1W1aeqbgZmpRWTNoVJbzcXyTE6VXOFYcQo/3zhLgaZET0aJguGu9zLPdzR+Nu5IkkTupULO7LnCxZ+vUV1RG5hZ2aro91g3gkZ2QaUWvS01SJLE2X3p/PbNGarKa89Xh95uDHiiO96Bbmy9foi3rvxA1c3N1J1Utsz3HcPjHg9QWVHFS0s/lCd2KJUKZvxpAs9MGoeqmfYv1Wg0HD59mmNJZ/Re+Xfr1IkBfYJwb9euWeoVCNpcgFZZWcm6deuIjY2lqKiIgIAAZsyYQUiI4eyp+uTk5PDpp59y+PBhtFot/fr1Y968efj4+BjI7ty5k++//57MzEzat2/PE088weOPP94iOhtCTBIQCIwjSRJVkoYqqZpKqZoqrUb3V6qmXFvFjepS3T9NKQXVJWRU5JFWcZ30ilyyqm7Ujqmrh73ShpFu9zLNK5JOag9yUm6QdjyHS79lystm1KBUKegx2I9+j3fDwdW2JdxukxRmlfLz+kR5N4UaOvR2I2hEF4oCy1mU+jUZdfbq7G3vx6wOIwi17cbfl3/GT4dPyHk123AF9QxoNpszc66z79Ah8m7oTzDp5ONDn27d6OjTAZV49SmwIG0uQFu6dCn79u1j4sSJ+Pn5ER0dTXJyMh999BHBwcb3vQMoLS1lxowZlJSUMGnSJNRqNRs3bkSSJL766itcXFxk2W3btrFq1SoGDx5MaGgoJ0+eZPfu3Tz33HM89dRTzaqzMZorQFuVvp0r5Tl6j6i6Dyy9L0ndFe2N5BtLN/U1MypbN81IObPqlQwlTNso1SuDyYe1LFs3TTJWh6F+U+VM2WW0XhM2SvWkDfKNlDNWpqk2GrPX+PkwZW9jNjbsI4BGkqiSquUeF0vgoLQh1Kk7A7Xd6ZPVkdIr5eSmFpKTUqD3CrMGKzsV3Qf5EjzWH0cPMdvPHCRJ4srRbH77f8kUZulvA2bvZoP3Q25EB50gtuqEXl4Puw486jaQvPgsvvl+F9o6e34+PCiESeOGcW9Qj2YZ76fVakm6eJFDJ09RXqG/ibudrQ3+HTvSxdcXX0/PZlmvTfDHok0FaElJScyaNYvZs2czZcoUACoqKpg+fTrt2rVj9erVJst+++23rFmzhi+++IJevXQzri5fvsz06dOZMmUKf/3rX2V9TzzxBL179+bdd9+Vy7/55pskJCSwadMmnJycmk1nYzRXgPanMx+QWJpmMX0CQVvBUWtL+ypnPMqc6JDbDs90Z9ql2lGZW0WDd0cFeAe60e3BDgQ85POHm51pKbQaLRd/usaxrRcozDTcr/V6zyL2R54lwyFfL12tUNEzqz05P6RRkFmol9e1ow8RDw7goZB7COrR1eLBUlV1NUkXLnIiOVmeRFAXpUKBu6sr3h7ueLnrds1wcnQUPWyCJtGm7ij79+9HpVIxblztJsQ2NjaMGTOGtWvXkpWVhZeX4RYrAPv27SMwMFAOpAA6d+5M//792bt3rxxMHT16lBs3bjBhwgS98o8++ihxcXH88ssvDB8+vNl03ikKMoqh3R01oXVQ54Gs0Hs4K0ykGylXI6uXZhyFZCTHmK466QpzZI3m101XGElrWLYupvLlT03RZSIIMnpujOQrJFBplCg1SlQaBSqtElW1EqX25rFGibpaiW2ZNTblamzLrbCpsMKp0BaXG3bYVFgZ6K6gyiANwK6dDT693fAJcqdjP0/s29k0aKOgcZQqJd3Dfek2yIf0U9c5E3+FtGM5SDd7xjzOOvHY2QFcCsjhSGgqWT66V4zVkoZEz0yYpUZ5xAH13jIo0QJwKS2DSxsy+PeGHVhZqQnw9yOgsx9+Xp74eHng69UeTw83nBztsbezbfKsTCu1mnsCe9K3R3euXLvG2ZRLXLp6Fa1WV79WksjJyyMnL49TnAd0Yy2d7O1xdnLE2dEJRzs7bG1tsLPR7bpha2Oj25VDrUatVqNSKv+ws34FOtpUgHb+/Hn8/PxwcNBfRLImQLpw4YLRAE2r1ZKSksLo0aMN8nr16sXhw4cpLS3F3t6e8+d1F1NgYKCeXM+ePVEqlZw7d47hw4c3i847ydMJYVy/orvxmbwlNCUIaUS2LsYexLeuy1CLyQDAtKeCPzIKsHOxwcHVBpcODrh1dsa9kxNunZ1FQNaMKJQKOt7Tno73tKe8qJLLR7JIPZJF5pk8qso1+F/0xP+iJ9c9ikgOusaFHlkUOZeDSoF2oC2V/W1QJlWiPFyO8nLtGnhVVdUkn00l+Wyq6bqtlShtlCjUShRKBSgVKFQKFHX+3pTUnwij+wCAWqnEy9WVDq7tcHdywsXeXq8OSZIoLCmhsKQEyKIxJEmiWqOhWqtFo9XqrUeprVnjsc5aj3XTjerTV95wvgl7/khoJC3vzp9/R21oUwFabm4u7kYWCqxJu379ukEeQGFhIZWVlY2W7dSpE7m5uahUKlxdXfXkrKyscHZ2JvfmdOvm0GmM69ev6+VfuHAB0L1KtSQa7Q1UVmX6ifXiF3N+zJn3g09fyKBMAzrkW4SJiureQhQGsVy9ehs3zfAcGCvVaBkzMEdI0ch5M1qk6UGoYREz6m2kzK3EwuZ8Lwyr1U9RKhQo1ApUaiUKlQKVSqk7VilR2yixslWjtlVjZaPC2l6NrZM1tk7WKFR19VRRQh4lWXnmPFcFlsIHuoxzovMYR/KvFlNwtYQbmcVorykI2utCYJwTRc5lXOtQSF77YvLciyl2rUY7Qo22VIXyShWK9GoU2RoUN7QN11UG2rKGRcyhkKyb/WVgpVbRzsURV1dHnJ0ccXCwwd7O9rZmG9endk62wNKUVVRw9uzZZtHduXNnbG0bn0TUpgK0iooKrKwMX0dY39yIuaLeoM265QCzylZUVJgcr2Btba0nZ2mdxti+fTvr1683SH/rrbdMlhEIBII/BNnAhdpDxztmiHGKiqAo/U5bIbhVDu7c0Sx6zR1D3qYCNBsbG6qqDMeGVFZWyvmmygFmlbWxsaHaxBYxlZWVenKW1mmMcePG8dBDtfvOFRUVcfnyZXr06CEHgpbi8uXLvPXWW7z66qt07tzZorpbA8K/ts/d7qPwr+1zt/t4t/sHze+juTrbVIDm7u5OTk6OQXrNK0APD+MrOzs7O2NtbW30VWL9su7u7mg0GvLz8/VeSVZVVVFYWCi/vmwOncbw8PAw8Ou+++4zIW0ZOnfufFevsSb8a/vc7T4K/9o+d7uPd7t/cOd9bFNzfrt160Z6ejolJfqLQyYlJcn5xlAqlfj7+5OcnGyQl5SUhI+PD/Y3B3R2794dwEA2OTkZrVYr5zeHToFAIBAIBAJoYwFaREQEGo2G7dtr92qrrKwkKiqK3r17yzM4s7KyDAbRDx48mOTkZL0g6cqVKxw7doyIiAg5rX///jg7O7Nt2za98tu2bcPW1pYHHnigWXUKBAKBQCAQtKlXnL179yYyMpK1a9dSUFCAr68vMTExZGZmsnjxYllu2bJlHD9+nAMHDshpjz76KDt37mTx4sVMnjwZlUrFxo0bcXV1ZfLkybKcjY0Nzz77LB988AGvvfYaoaGhnDhxgtjYWGbOnImzs3Oz6ryTuLu7M3369AZfubZlhH9tn7vdR+Ff2+du9/Fu9w9aj49taicB0M2IrNmLs7i4GH9/f2bMmEFoaKgsM3/+fIMADSA7O9tg38y5c+fi5+dnUM+OHTvYsGED165dw9PTk0cffZSJEycaLFvQHDoFAoFAIBD8sWlzAZpAIBAIBALB3U6bGoMmEAgEAoFA8EdABGgCgUAgEAgErQwRoAkEAoFAIBC0MtrULE6BjmPHjrFgwQKjeatXryYoKEg+PnXqFGvWrOHcuXM4ODgQGRnJzJkz5TXaaqisrJQnXxQVFREQEMCMGTMICQkxy6acnByDyRLz5s3Dx8enVfh45swZYmJiOHbsGJmZmTg7OxMUFMSMGTPo2LFjo/ZER0ezfPlyo3lbtmxp8mwfS/vXFH2msGQbWtq/t99+m5iYGJP1/e9//6N9+/Ym87/66iujW6ZZW1sTHx9vhkeGmOvjoUOH+PHHHzlz5gyXL1/G09OTjRs3Gi2n1Wr5/vvv2bp1K3l5efj5+fH0008zdOhQs2wqKipizZo1HDhwgIqKCnr16sXzzz9/S4ttWtq/y5cvExUVxeHDh7l69Sp2dnb06NGDZ555hsDAQIvZYy6W9u/atWtMmjTJqL7XX3+dhx9+uFGbLNl+YHkfTV1HNXz22Wf07dvXZP6duI+Wl5cTFRVFQkICKSkplJWV4efnx9ixYxk7diwqlUqvXGu6BkWA1oZ5/PHH6dWrl16ar6+v/Pn8+fO8+OKLdO7cmblz55Kdnc2GDRtIT09n5cqVeuWWL1/Ovn37mDhxIn5+fkRHR7No0SI++ugjgoODG7SjtLSUBQsWUFJSwtNPP41arWbjxo3MmzePr776ChcXlzvu47fffsupU6eIjIwkICCA3NxctmzZwowZM1i9ejX+/v5m2fPss8/SoUMHvTRHx1vfAdCSbWiOPlM0Vxtayr9x48YZ7KAhSRKrVq3C29u7weCsLi+//DJ2dnbysVJ5+y8RGvMxPj6eH3/8kR49ejT6APryyy/573//y9ixYwkMDCQhIYE33ngDhULR6ANeq9WyePFiLl68yOTJk3FxcWHr1q0sWLCAL7/80qwfIs3p386dO9m1axeDBw9mwoQJlJSUsH37dmbPns3KlSvN3iHlVr/jt6qvKe0HMHToUO6//369NHOCx+ZqP7Ccj4MHDza6QsHatWspKyszK9CGlr2PZmRk8NFHHzFgwAAmTZqEvb09hw4d4v333ycxMZF//OMfeuVa1TUoCdocR48elcLCwqS9e/c2KLdw4UJpwoQJUnFxsZy2Y8cOKSwsTPrtt9/ktMTERCksLEz69ttv5bTy8nJp8uTJ0qxZsxq157///a8UFhYmJSUlyWmpqalSRESE9MUXXzTBs1os7ePJkyelyspKvbJXrlyRHn74YemNN95o1J6oqCgpLCxMOnPmTNMcMYGl/TNXnyks3YaW9s8YJ06ckMLCwqSvv/66UXvWrVsnhYWFSfn5+eaYbxbm+piTkyNVVVVJkiRJixYtkiZOnGhULjs7W4qMjJTef/99OU2r1Upz5syRHnvsMam6urrBevbs2WNgT35+vjRq1Chp6dKl5jlVB0v7l5ycLJWUlOilFRQUSGPHjpWef/55i9ljLpb2LyMjw+A+2hQs3X6SZHkfjZGZmSmFh4dLK1asaFT2TtxH8/PzpZSUFIP05cuXS2FhYVJaWpqc1tquQTEGrY1TWlpqdCP2kpISjhw5wvDhw3FwcJDTR4wYgZ2dHXv37pXT9u/fj0qlYty4cXKajY0NY8aMITExkaysrAZt2LdvH4GBgXq/YDp37kz//v316rlVLOFj3759sbKy0ivfsWNHunTpYrDrhDn2aDSaJnrRsL7b9c8cfQ3RnG1oaf9qiI+PR6FQmP3qoW69koVXF2ronHt4eKBWN/6yIiEhgerqah599FE5TaFQMGHCBHJyckhMTGyw/P79+3FzcyM8PFxOa9euHZGRkSQkJFBZWWmmN4ZYwr+ePXsaDK1wcXEhODj4lq7Bpn7Hb1Wfuf7VpaysjKqqqiaVac72A8v7WMOePXuQJIlhw4Y12Z6WuI+2a9eOrl27GqSHhYUB6H33Wts1KF5xtmGWL19OWVkZKpWK4OBgZs+eLXcxp6SkoNFoDN57W1lZ0b17d86fPy+nnT9/Hj8/P72HJCA/rC9cuCBvo1UfrVZLSkoKo0ePNsjr1asXhw8fprS01ODG3NI+GkOSJPLz8+nSpYvZ9ixYsICysjKsrKwICQlhzpw5t/XqwdL+NaTPFM3Zhs3VftXV1ezdu5c+ffoYvCppiEmTJlFWVoadnR2DBg1izpw5uLm5NdmvutzKOTfG+fPnsbOzo3PnznrpNdfh+fPnGxxucO7cObp3727w2rZXr17s2LGDtLQ0AgICmmyXpfwzRV5eXpNeoVvaHkvrW79+PatXr0ahUNCzZ0+DhdRN0VztB83bhnFxcXh6enLPPfeYXaYl76OmyMvLA9D77rW2a1AEaG0QtVrN4MGDuf/++3FxcSE1NZUNGzYwd+5cPv/8c3r06EFubi6A0fEE7u7unDhxQj7Ozc01KQdw/fp1k7YUFhZSWVnZaPlOnTrdUR+NERcXR05ODs8880yj9tjY2DBq1Cj69euHg4MDZ8+eZePGjTz//PP861//MhnAtpR/5ugzRXO0YXO336FDh7hx44bZv9qdnJx47LHHCAoKwsrKipMnT7JlyxbOnDnDl19+afDjxFI+NoXc3FxcXV0NdhYx5zoE3QPH2EOypnxubm7THg4W9s8YJ06cIDExkalTp7a4PZbWp1QqCQkJITw8HA8PDzIyMti4cSOLFi1i+fLlje65bOn2g+Zvw0uXLnHx4kWmTJli1o44d+I+aoyqqip++OEHOnTooBfItbpr0GxJQauhb9++ejNlBg0aREREBH/5y19Yu3Yt7733HhUVFQAGr/VAN3OtbldrRUWFSbmafFM0Vk9j5U1haR/rc/nyZT744AOCgoIYOXJko/YMGTKEIUOGyMdhYWGEhoYyb948vvnmGxYuXNgU9yzunzn6TNEcbdjc7RcfH49arSYyMtIseyZOnKh3HBERQa9evXjzzTfZsmULTz/9tFl66nI759wYt3Md1uTXyN5K+fpY2r/65Ofn88Ybb9ChQwemTJnS4vZYWp+XlxerVq3SSxsxYgRTp07ls88+azRAs3T7QfO3YVxcHADDhw83S/5O3EeN8eGHH5Kamsq7776r92q3tV2DYgzaXYKfnx+DBg3i2LFjaDQabGxsAIyOg6isrNT7EtnY2JiUq8k3RWP1NFa+KdyOj3XJzc1l8eLFODg48OabbxpMszaX4OBgevfuze+//35L5etjKf9M6TNFS7WhpfwrLS0lISGB0NDQ25ohPGzYMNzc3CzWfmD+OTfG7VyHNfnGgtrmbMNbpaysjMWLF1NWVsbbb799y0MgLGVPc+lzdnZm1KhRXLlyhezs7AZlW6L9wHI+SpJEfHw8Xbt2veVXr9D899H6fPfdd+zYsYNnn33WIGhubdegCNDuIjw9PamqqqK8vFyvS7U+ubm5eHh4yMfu7u4m5QA92fo4OztjbW19y+Wbyq36WENxcTGLFi2iuLiY995777Zt8/T0pLCw8LZ01Nd3O/41pM8ULdmGlvAvISGB8vLyJg9KNmWPJduvRmdj59wY7u7u5OXlGUxgMLcN3NzcGmzDpq4xZYpb9a+GqqoqXn31VVJSUnj77bfNXuKmuexpCX2gWx+rIVqq/Wpsul0fT506RWZmZqu8Dk35Fx0dzZo1axg/fjzTpk0zKNfarkERoN1FZGRkYG1tjZ2dHV27dkWlUnH27Fk9maqqKs6fP0+3bt3ktG7dupGenk5JSYmebFJSkpxvCqVSib+/P8nJyQZ5SUlJ+Pj43PKvY2Pcqo+g617+v//7P9LS0njnnXeaNDmgIXvatWt323rq6rtV/xrTZ4qWbENL+BcXF4ednR0PPfTQbdkiSRKZmZkWbT8w75wbo1u3bpSXlxvMaDTnOgTkiRVarVYv/cyZM9ja2t7WIOy63Kp/oJuQsmzZMo4ePcqSJUu4995776g9LaUPaLS3t6Xar8am2/UxLi4OhUJhkQCtOe+jNRw8eJAVK1YQHh7Oiy++aLRca7sGRYDWBikoKDBIu3DhAj/99BMhISEolUocHR257777iI2NpbS0VJbbvXs3ZWVlemN3IiIi0Gg0bN++XU6rrKwkKiqK3r176w3czMrKMvjyDh48mOTkZL0H/JUrVzh27BgRERGtwkeNRsM///lPEhMTWbp0KX369DFZ9/Xr17l8+bLelG1j9vzyyy+cPXvWrBlaze2fOfpqaIk2tLR/dfUeOXKE8PBwbG1tjdZtzD9j9mzdupWCggIGDhzYNOca0GnqnJvDoEGDUKvVbNmyRU6TJIlt27bRvn17ve+sse/o4MGDycvL48CBA3o27t27lwcffLDRV+L1sbR/oBv78+OPP/Liiy8yePDgBuu+fPmyXg+Ipe1pCX05OTlERUUREBCg1/vSEu1nyqbbbUPQzaLet28fffv2NTmwv7XcRwGOHz/O0qVLCQ4OZsmSJSb9bm3XoJgk0AZ5/fXXsbGxoU+fPri6upKamsqOHTuwtbXlueeek+VmzJjBnDlzmDdvHuPGjZNXaQ8JCdF7KPXu3ZvIyEjWrl1LQUEBvr6+xMTEkJmZyeLFi/XqXrZsGcePH9f7Aj766KPs3LmTxYsXM3nyZFQqFRs3bsTV1ZXJkye3Ch8/++wzfvrpJx588EGKioqIjY3Vq6/uINe1a9cSExPDhg0b5CUcZs+eTY8ePejZsycODg6cO3eOqKgoPD09+fOf/3zH/TNXH7RMG1ravxr27NmDRqNp8Fe7Mf8mTpzIkCFD8Pf3x9ramlOnTrFnzx66d++ut/5fc/h48eJFEhISALh69SrFxcX85z//AXS/yGt6Aj09PZk4cSLfffcd1dXV9OrVi4MHD3Ly5EmWLFmiN1bS2Hc0IiKCTZs2sXz5clJTU+VVzLVarVkzlZvbv40bN7J161aCgoKwtbU1uAbDwsLkHo/Nmzezfv16PvroI/r169cke+6Uf6tXr+bq1asMGDAADw8PMjMz2b59O+Xl5cyfP1+v7pZov+bwsQZzZlG3lvtoZmYmr7zyCgqFgoiICPbt26enIyAgQB5D19quQRGgtUHCwsKIi4tj48aNlJSU0K5dO8LDw5k+fbreNhw9e/bk/fffZ82aNXzyySfY29szZswYozezV155BS8vL3bv3k1xcTH+/v68++67Zr2CsLe356OPPuLTTz/l66+/lvdxnDt37i13W1vaxwsXLgDw888/8/PPPxvU19gspCFDhvDrr79y+PBhefzU2LFjmT59+i2to2Vp/8zVZwpLt2FzfEdBN3vT1dWVAQMGNMmeYcOGcfr0afbv309lZSVeXl5MmTKFqVOnmuyJs5SP586dY926dXpla45Hjhyp9/B77rnncHJyYvv27cTExODn58err75q1msklUrFihUr+Pzzz/nf//5HRUUFgYGB/P3vf2/yMjfN4V/NNZiYmGh0wc8NGzY0+Mrtdr/jze1fSEgIGRkZbNmyhaKiIhwdHQkODmbq1Klm7cNo6fZrDh9riIuLa9Is6hruxH302rVrFBcXA/DBBx8Y6Jg+fbreJIfWdA0qJEsvqS0QCAQCgUAguC3EGDSBQCAQCASCVoYI0AQCgUAgEAhaGSJAEwgEAoFAIGhliABNIBAIBAKBoJUhAjSBQCAQCASCVoYI0AQCgUAgEAhaGSJAEwgEAoFAIGhliABNIBAIBAKBoJUhAjSBQCBo44SHh+v9q6iokPOio6MJDw8nOjr6DlpYy7Zt2/Rsffvtt++0SQJBq0Rs9SQQCFol165dY9KkSQ3KeHt7s3HjxhayqHXj7e3NyJEjAfT2DGwODh06xMKFCwkJCWHVqlUNyr7xxhvEx8ezZMkShg0bRs+ePZk+fTrFxcVs2rSpWe0UCNoyIkATCAStGl9fX5P74Dk6OrawNa0Xb2/vW95Uu6ncd999eHl58fvvv5OVlYWXl5dRueLiYg4ePIijoyPh4eEABAYGEhgYyLVr10SAJhA0gAjQBAJBq8bX17fFAg+BeSiVSkaNGsX69euJiYlh2rRpRuXi4+OpqKhg9OjR2NjYtLCVAkHbRoxBEwgEdw3h4eHMnz+fvLw8li1bxtixYxk6dCizZs3i2LFjRsuUlpby1VdfMXXqVIYOHcro0aN5+eWXOXnypIHs/Pnz5TFeX375JZMnTyYyMpKvvvpKltm/fz8zZ85k6NChjB8/nhUrVlBUVMSTTz7Jk08+Kcu9+eabhIeHk5SUZNSudevWER4eTnx8/G2eFeNkZ2czbdo0hg4dyr59++T0/Px8PvnkE6ZMmcLDDz/M2LFjefXVV0lJSdErP3r0aBQKBdHR0UiSZLSOqKgoAMaMGdMsPggEdzMiQBMIBHcVxcXFzJkzh9TUVIYPH054eDhnz55l4cKFBkFGYWEhs2fPZv369Tg5OTF+/HjCw8M5d+4cCxYs4ODBg0brWLJkCTExMfTr148nnniCDh06ALBr1y6WLFlCeno6I0aMYOTIkSQmJvLSSy9RXV2tp2PcuHFymfpoNBqioqJwcXGRXw1aktTUVJ5//nmys7NZuXIlERERAFy9epUZM2bwww8/4OPjw2OPPcb999/PoUOHmD17tl4w6e3tzYABA8jIyDAa/KakpJCcnEz37t3p0aOHxX0QCO52xCtOgUDQqrl69apeD1VdgoKCGDhwoF7ahQsXmDBhAi+88AJKpe43aP/+/VmxYgWbN29m4cKFsuyHH37IpUuXWLRoEY888oicnp+fz8yZM1m5ciWhoaEGr+dyc3P597//jbOzs5xWVFTExx9/jJ2dHWvXrqVjx44AzJw5k4ULF3L27Fm8vb1l+XvuuYcuXbqwZ88e5s6di52dnZx36NAhcnJymDhxItbW1k09ZQ2SmJjI4sWLUavVfPLJJ3Tr1k3OW7ZsGXl5ebz33nuEhobK6VOnTmXmzJmsWLGC9evXy+ljxozhyJEjREVF0b9/f716RO+ZQHB7iB40gUDQqrl69Srr1683+u+3334zkLezs2PWrFlycAYwcuRIVCoVycnJclpBQQF79+6lf//+esEZgKurK1OmTKGgoIDff//doI6//OUvesEZQEJCAmVlZYwePVoOzgDUajUzZsww6tu4ceMoLS1lz549euk7d+4EYOzYsaZOyy3xyy+/8OKLL+Lk5MTnn3+uF5ydO3eO06dPM2LECL3gDKBjx4488sgjpKSk6PVChoWF4eLiwv79+ykpKZHTq6uriY2Nxdra2uQED4FA0DCiB00gELRqQkNDee+998yW9/Pzw97eXi9NrVbj5uZGcXGxnJacnIxGo6GqqspoD116ejoAly9f5sEHH9TL69Wrl4H8xYsXAQgODjbI6927t9GlL0aMGMEXX3zBzp075SAxLy+Pn3/+mT59+tClS5dGvDWfvXv3cvjwYQICAli5ciWurq56+TWvL/Pz842ejytXrsh//f39AeQAbNOmTcTHxzN+/HgAfvrpJwoKChg6dChOTk4W80Eg+CMhAjSBQHBX4eDgYDRdpVKh1Wrl48LCQgBOnTrFqVOnTOorLy83SHNzczNIq+lBqh/4gG7Wo4uLi0G6k5MTkZGRxMTEkJKSgr+/P9HR0Wg0Gov3niUmJqLRaAgODjZqY835+OWXX/jll19M6ikrK9M7HjNmDJs2bSIqKkoO0MTrTYHg9hEBmkAg+ENSE8hNmjSJOXPmNKmsQqEwqS8/P98gT6vVcuPGDdq3b2+QN378eGJiYtixYwcLFixg165dODg4EBkZ2SSbGuOvf/0rCQkJbNq0CZVKZeBzjf0LFizg8ccfN1tvQEAAgYGBnDlzhkuXLuHk5MShQ4fo0KGDwbg0gUBgPmIMmkAg+EMSGBiIQqEgMTHRIvoCAgIAjPbGnTlzBo1GY7RcUFAQAQEBxMXFcejQIdLT0xk2bBi2trYWsasGa2trli1bxgMPPMCGDRv49NNP9fJrXtveyvmo6SnbtWsXu3fvRqPRyMtwCASCW0MEaAKB4A+Ju7s7kZGRnD59mu+++87oWl5JSUlGX3EaY9CgQdjZ2bFr1y6uXr0qp1dXV7Nu3boGy44bN47CwkLeeecdAINJC5bC2tqat956iwcffJCNGzfyySefyHm9e/emd+/e7Nmzx2DSAuh6AY8fP25U79ChQ7G1tSU2NpaoqCiUSqW87ZRAILg1xCtOgUDQqmlomQ2Ap5566pZXqX/ppZdIS0tj9erV7N69m6CgIBwdHcnJySE5OZn09HS2bNliVm+Wk5MTc+fOZeXKlcycOZMhQ4bg4ODAr7/+irW1NR4eHiZ7lIYPH86aNWu4fv06PXv2bNZ1w6ysrHjzzTd57bXX+OGHH5Akifnz5wPw2muv8cILL7B06VI2bdpE9+7dsbGxITs7m9OnT3Pjxg2jC+c6ODgwePBgdu/eTUFBAQMHDjS5/ZNAIDAPEaAJBIJWTc0yG6aYOHHiLQdozs7OfP7552zevJkff/yR+Ph4tFotbm5udOvWjWnTphkd3G+KsWPH4uTkxDfffENMTAwODg489NBDzJo1i4kTJ+Lr62u0nIODA2FhYcTGxjZb71ldaoK0119/nU2bNiFJEgsWLMDHx4d169axYcMGDh48SHR0NEqlEnd3d+655x55QVtjjBkzht27dwO6XQYEAsHtoZBM7dEhEAgEAouQnp7On/70JyIjI1m6dKlRmWnTppGZmcnmzZtNzkQ1RXh4OPfeey8ff/yxJcxtEa5du8akSZMYOXIkr7zyyp02RyBodYgeNIFAILAQRUVF2NjY6K3+X1FRIQ/IDwsLM1ru119/5dKlS4wdO7bJwVkNx48fl7eFiouLa7Wbk2/bto1Vq1bdaTMEglaPCNAEAoHAQhw/fpx3332XkJAQPD09uXHjBkePHiUzM5P+/fszZMgQPfmtW7eSnZ3Nzp07sba25qmnnrqleqdPn653bGxR3NZCz5499ezt3r37nTNGIGjFiFecAoFAYCHS0tJYt24dp0+fpqCgAABfX1+GDBnC5MmTDXq1nnzySXJycujYsSOzZs0y2LFAIBD8cREBmkAgEAgEAkErQ6yDJhAIBAKBQNDKEAGaQCAQCAQCQStDBGgCgUAgEAgErQwRoAkEAoFAIBC0MkSAJhAIBAKBQNDKEAGaQCAQCAQCQStDBGgCgUAgEAgErQwRoAkEAoFAIBC0MkSAJhAIBAKBQNDK+P+DCW15j8w80QAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmgAAAHRCAYAAADewkVpAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAxkxJREFUeJzs3Xd8U/X+P/BXRpPOdO/dAqWUQspeChVkU0GQpVf4IkMZDrwIjuvGqyhyUX4iioKgXsBxKSBLgbJEdhFaWmaB7p10Zp7fH2kOJ3SlyelI+34+Hj5umpzP53ySC+Wdz3i/BQzDMCCEEEIIIW2GsLUHQAghhBBCTFGARgghhBDSxlCARgghhBDSxlCARgghhBDSxlCARgghhBDSxlCARgghhBDSxlCARgghhBDSxlCARgghhBDSxlCARgghhBDSxlCARgghdVAqlXj++ecRFhYGsVgMgUCA5ORkJCUlQSAQ4O23327tIbYrYWFhCAsLs7ofgUCAYcOGWd0PIa2NAjRCCG8EAkGt/6RSKcLCwjBr1ixcvXq1Rccze/ZsCAQCZGRkNLntK6+8gs8//xyxsbF49dVX8dZbb8HPz6/e64cNGwaBQNDk+7z99tsQCARISkpqcltCSPslbu0BEELan7feeot9rFAocObMGWzZsgW//PILTpw4Ablc3nqDM9OePXvQpUsX7N692+R5mUyGq1evwsvLq5VGRgjpCChAI4Twrq7lvyVLlmDdunX4z3/+g82bN7f4mJoqOzsbDz/8cK3nHR0d0bVr11YYESGkI6ElTkJIixg5ciQAoKCgoM7X//vf/yI+Ph5ubm6wt7dHdHQ03n//fahUqlrXHj9+HBMmTEBQUBCkUin8/PwwYMAAvPPOO+w1AoEA3333HQAgPDycXXJtbJ+TcamSYRgcPXqUbWfc1/TgHrSMjAwIBAIcPXqUve+DbeoTFhbGjjk+Pt6kLVdOTg4WLVqEsLAwSCQSeHt74/HHH8f58+cb7P9BxjHl5eVhzpw58PX1hZOTEwYNGoTjx48DACoqKrBs2TKEhoZCKpUiJiYGP/30U539qVQqfPjhh4iNjYWjoyNkMhkeeugh7Nixo87rGYbBunXrEBMTA3t7ewQGBmLx4sVQKBQNjrspfzYIaS9oBo0Q0iL++OMPAECfPn1qvTZnzhxs2rQJQUFBmDx5Mtzc3PDXX3/hX//6Fw4dOoTff/8dYrHh19X+/fsxbtw4yGQyJCQkIDAwEMXFxbh69Sq++OILdnn1rbfews6dO3Hp0iW88MILcHNzAwD2f+sze/ZsDBs2DO+88w5CQ0Mxe/ZsAKg3sHNzc8Nbb72FzZs3486dOybLu40Fgy+++CJ27tyJo0ePYtasWXVef/v2bQwZMgTZ2dl45JFHMGPGDNy7dw8//fQTfvvtN/zyyy8YP358g/fhKi0txeDBg+Hi4oIZM2aguLgY27Ztw6hRo3Dq1CksWLAAxcXFGD9+PDQaDf773/9i2rRpCA4OxoABA9h+1Go1Ro0ahaNHj6Jr165YtGgRKisr8fPPP2PatGlITk7GBx98UOv9fvbZZ/D398f8+fNhZ2eHxMREnD59Gmq1GhKJpNZ4m/Jng5B2hSGEEJ4AYAAwb731FvvfSy+9xAwZMoQRCATM+PHjGaVSadJm06ZNDABm0qRJTGVlpclrb731FgOA+c9//sM+9/jjjzMAmOTk5Fr3LygoMPl51qxZDADm9u3bFr2XoUOH1nr+yJEj7HvkGjp0KGPJr1Tjezxy5Eidr48cOZIBwLz//vsmz588eZIRiUSMh4cHU1ZWZta9jP//LFiwgNHpdOzzW7ZsYQAw7u7uzPjx45mqqir2tWPHjjEAmIkTJ5r09cEHHzAAmDFjxjAajYZ9Pi8vjwkNDWUAMCdPnjQZLwAmMjKSKSoqYp+vqqpiBgwYwABgQkNDTe7R1D8bxvdY1/9vhNgaCtAIIbwxBgB1/detWzfmhx9+qNVGLpczYrGYKSkpqfWaVqtlPD09mb59+7LPGQO09PT0Rsdj6wHavXv3GABMSEgIo1ara73+1FNPMQCY7777zqx7AWAcHR1rBclarZYRi8UMAObmzZu12oWFhTFhYWEmz3Xq1IkRCATM1atXa12/ceNGBgDzf//3f+xzc+fOZQAw3377ba3rjZ/pgwFaU/9sGN8jBWikPaB5YUII7xiGYR9XVFQgJSUFK1aswJNPPomUlBSsXLkSAFBZWYlLly7By8sL//nPf+rsSyqVmqTnePLJJ/Hrr7+if//+mDZtGuLj4zF48GAEBQU163tqDRcvXgQAPPTQQ7Czs6v1+iOPPILvv/8eFy9exNNPP21Wn126dIGLi4vJcyKRCL6+vqioqEBEREStNoGBgTh9+jT7c1lZGW7cuIHAwMA6D0w88sgjJuMHgAsXLgAAhg4dWuv6IUOGQCQSmTxnyZ8NQtoTCtAIIc3KyckJ/fr1w6+//oqgoCCsWrUKzz77LIKDg1FSUgKGYVBQUGCywb8hjz/+OPbs2YPVq1fj22+/xYYNGwAAvXv3xr///W88+uijzfl2WpRx87y/v3+drxufLy0tNbtPV1fXOp8Xi8UNvqbVaq0al7GNr69vnf0/mLbEkj8bhLQndIqTENIi3NzcEBUVBa1Wy86mGAOCuLg4MIYtF/X+xzVu3DgcPnwYJSUlOHToEF566SWkpKRg/PjxSE1NbfH31lyMn09ubm6dr+fk5Jhc11IsGZfxcV5eXq3rtVotCgsL67xHU/9sENJeUIBGCGkxJSUlAAC9Xg8AcHZ2RkxMDFJSUlBcXNzk/pycnPDII4/g008/xWuvvQa1Wo19+/axrxuXzXQ6HQ+jb5il92qoXVxcHADgxIkTJjNYRkeOHAEA9OrVq0n3tJaLiwsiIyORlZWF69evmzUu42NjOhKuEydO1Hr/1v7ZIMTWUYBGCGkRO3fuxO3bt2FnZ4dBgwaxzy9duhRqtRpz5sypc6mupKSEnXEDgGPHjtUZrBhnZhwdHdnnPD09AQB3797l623Uy9J7NdQuKCgIjz76KDIyMmrtwzp9+jR+/PFHuLu7Y9KkSZYN2gpz5swBwzBYtmyZSXBVWFiI9957j73GyJiuZOXKlSYBV3V1NV599dU679HUPxuEtCe0B40QwjtuJYGKigqkpqayM1sffPCByT6kOXPm4Pz58/jiiy8QGRmJUaNGISQkBMXFxbh9+zaOHTuG//u//8OXX34JAHj++eeRlZWFwYMHs4lbz58/j8OHDyM0NBTTp09n+x4+fDg+/vhjzJs3D5MnT4aLiwvc3NywePFi3t/z8OHD8dNPP+Hxxx/H2LFj4eDggNDQUPzjH/9osF18fDyEQiFeffVVXLlyBe7u7gCAN954AwDw5ZdfYvDgwVi2bBkOHjyIPn36sHnQhEIhNm3aVGvTf0v45z//iX379iExMRE9e/bE2LFjUVlZiZ9++gn5+fl45ZVXMGTIEPb6wYMHY8mSJfj888/RvXt3TJkyhc2D5u7uXud+tqb+2SCkXWnZQ6OEkPYMdaTXEIlEjJ+fH5OQkMAcPHiw3ra7d+9mxo0bx3h7ezN2dnaMr68v07dvX+b11183SeWwfft2Zvr06UynTp0YJycnxsXFhYmJiWFee+01Jj8/v1a/q1evZrp27cpIJJI6Uzk09F6akmZDq9Uyr776KhMeHs6mrDA33cPWrVuZnj17Mvb29uznxpWZmck8++yzTEhICGNnZ8d4enoyjz32GHPmzBmz+m/sPTEMw4SGhtb72dSXQqSqqopZuXIlExMTw9jb2zPOzs7M4MGDmR9//LHOfvR6PfP555+z/3/4+/szCxcuZEpLSxu8v7l/Nhp7j4TYEgHD0A5LQgghhJC2hPagEUIIIYS0MRSgEUIIIYS0MRSgEUIIIYS0MRSgEUIIIYS0MRSgEUIIIYS0MRSgEUIIIYS0MRSg2Zjq6mqkp6ejurq6tYdCCCGEkGZCAZqNuXPnDubNm4c7d+609lAIIYQQ0kwoQCOEEEIIaWMoQCOEEEIIaWMoQCOEEEIIaWMoQCOEEEIIaWPErT0AQgghpLkxDAOtVgudTtfaQyHtnJ2dHUQikdX9UIBGCCGkXVOr1cjJyUFlZWVrD4V0AAKBAEFBQXB2draqHwrQCCGEtFt6vR63b9+GSCRCQEAAJBIJBAJBaw+LtFMMw6CgoACZmZno3LmzVTNpFKARQghpt9RqNfR6PYKDg+Ho6NjawyEdgLe3NzIyMqDRaKwK0OiQACGEkHZPKKR/7kjL4GuGlv7EEkIIIS0sLCwMUVFRkMvliI6OxsyZM1FRUWFxf5s3b0ZaWlq9r//111+IjY1FXFwcDhw4gLFjxyI9Pd2sts0pIyMDX375pcXtN2/ejIkTJ7J9iUQiyOVy9OzZE71798aRI0cabJ+dnY2HHnrIrHv95z//QW5ursVjbSoK0AghhJBWsH37diQnJyMlJQUKhQKbN2+2uK/GgqzvvvsOM2fOxMWLFzFq1Cjs3bsXUVFRZrVtTo0FaFqttkn9ubi4IDk5GZcuXcLrr7+OqVOngmGYeq8PCAjA8ePHzeqbAjRCCCGkA1Gr1aisrIS7uzv73CeffIJ+/fqhV69eGD16NFt/effu3ejRowfkcjm6d++OxMREbNy4EefOncNLL70EuVyOvXv3mvT/4YcfYvv27Vi3bh3kcjlKS0sRFhaG5OTkRtvW5aOPPkJsbCx69uyJAQMGsKdjt27div79+6NXr154+OGHcenSJQCGAHDEiBGYMWMGYmNj0adPH9y6dQsA8OyzzyI9PR1yuRwJCQkADLOLy5cvR79+/TBr1izk5uYiPj4evXv3RkxMDBYvXgy9Xt/oOEePHo3CwkIUFRXh3LlzGDRoEHr06IF+/frh5MmTAAwBopubG9tGIBDggw8+QL9+/RAeHo5NmzYBAN59911kZ2dj2rRpkMvlSE5ObvT+1qJDAoQQQjqUna+fRKVC1Wz9O7pKMXHl4EavmzZtGhwcHJCRkYHevXtj6tSpAIAff/wR6enpOHXqFEQiEbZu3YqFCxfit99+wxtvvIENGzZg4MCB0Ov1UCqVcHNzw/fff48XX3yRXe7jWrFiBdLS0iCXy/Hiiy+avDZ37twG2z7ou+++wy+//IITJ07A1dUVJSUlkEqlOHnyJP773//i2LFjkEqlOH78OGbOnImUlBQAwNmzZ5GcnIzw8HCsWLECH330ETZs2IAvv/wSL774Yq2Ap6ioCKdPn4ZAIEB1dTV2794NZ2dn6HQ6PPbYY9ixYwemT5/e4Fj/+9//IiQkBDKZDI8//ji+/vprjBo1CidOnMDkyZNx48aNOttJpVKcOXMGaWlp6Nu3L/7xj3/gzTffxLfffovt27dDLpc3+jnxgQI0QgghHUqlQoXK4uYL0Mxl/Mdeq9ViwYIFWL58OVavXo2dO3fi7Nmz6N27NwCYJNcdPnw4XnjhBUyZMgUjR45ssWDBaM+ePXj22Wfh6uoKAOysX2JiIi5duoT+/fuz1xYXF6OqqgoAMHDgQISHh7OPP//88wbvM3v2bHazvV6vx/Lly3HixAkwDIP8/Hx07969zgCtrKyM/UwCAwOxa9cupKenQygUYtSoUQCAIUOGwNfXF8nJyQgKCqrVx5NPPgkA6Nq1K8RiMXJzc+u8rrlRgEYIIaRDcXSVtqn+xWIxJk+ejGXLlmH16tVgGAavvvoq5s+fX+vaTz/9FCkpKThy5AhmzZqFJ598Eq+88gpfQ7cYwzCYNWsWPvjggzpft7e3Zx+LRKJG95Zxk7x++umnyM/Px+nTp2Fvb4+lS5eiurq6znbGPWhcly9frnVdQyctmzrW5kIBGiGEtFO3MzORkZUNqcQOMmdnhPj7Q2ZldvP2wJzlx5Z2+PBhdtP+xIkTsXr1akyZMgUeHh7QaDS4cuUK4uLikJaWhpiYGMTExEAsFuPgwYMAAJlMBoVCYdG9H2yblZWF4cOH13lwICEhAZ9//jkmT54MV1dXlJaWwsXFBQkJCXjyySfx7LPPIiQkBHq9HhcuXECfPn2adO+6lJSUwM/PD/b29sjNzcVPP/2EyZMnm/3+oqKioNfr8fvvv+PRRx/Fn3/+idzcXMjlchQWFprdjzWfsSUoQCOEkHZGr9fj1MVkXKpJo2AkEAjQJSwMfbrHwNXFpZVGR4yMe9C0Wi1CQ0PZ04xPPvkkioqKEB8fD8BwknHOnDmIi4vDa6+9hvT0dEgkEjg6OmL9+vUAgPnz5+Pll1/GmjVr8MEHH2Ds2LFmj+PBtl5eXhCL6w4P/vGPfyA7OxuDBg2CWCyGk5MT/vjjDzz00ENYtWoVJk2aBK1WC7VajXHjxjUaoPXo0QMxMTHo3r07IiIisGvXrlrXGJd0Y2JiEBAQgBEjRpj93gBAIpHg119/xfPPP4+XX34Z9vb2+Pnnn+Hs7NykAO3555/HvHnz4OjoiM2bNzf78rKAaej8KWlz0tPTMW/ePHz99dfsty1CCDHS6XTYf/wE7mRn13uNnViMySNHwsPNtQVH1jqqq6tx+/ZthIeHmyxdkfp9/PHH8Pf3x1NPPdXaQ7FJfP2Zoxk0QghpR/6+do0NzoQCAQb16gV3Vxly8gtw+do1qNRqaLRa/HHqFCaPfNSqUjSkfVq2bFlrD4GA8qARQki7UVVdjfNXUtifxw0bih5RXRDs54d+PWLxj8cS4FFz+q6wpARnr1xpraESQhphczNoarUa33zzDQ4ePIiysjJERkZi7ty56Nu3b6NtCwoKsG7dOpw9exZ6vR5xcXFYsmQJAgICal27Z88ebNu2Dbm5ufD29saUKVPq3JRobp8PP/xwnWOaP38+TSMTQnhx5u/LUGs0AIDoyAgE+/ubvC6xs8PwgQPwy8HfodfrcTH1KsIDA+Hr5dUawyWENMDmArR///vfSEpKwhNPPIGgoCDs27cPr7zyCtauXYsePXrU266yshIvvPACKioq8NRTT0EsFmPHjh1YsmQJvv32WzanC2DI57J69WoMHToU06ZNw99//421a9eiurqazY/S1D4BoE+fPhg9erTJc507d+bpkyGEdGRFpaVIvXkTgGGPWf96fh96e3igb2x3nL70NxiGwYXUqxjzsHm1CAkhLcemArTU1FQcOnQIzz33HGbMmAEAGDVqFGbPno3169ezp1nqsnPnTmRmZmLDhg2Ijo4GAPTv3x+zZ8/G9u3b2XwzKpUKGzduxMCBA/Hee+8BACZMmAC9Xo8tW7YgISEBLjWnn8zt0yg4OBgjR47k90MhhBAAyVfT2JqDvWK6wdHBod5r5dHRuHLtOiqqqpCRlYWyigq4ODm11FAJIWawqT1oR48ehUgkYut1AYaSDOPGjUNKSgry8vLqbZuUlISuXbuygRQAhIaGolevXibV7i9cuACFQlGr5MWkSZNQVVWFU6dONblPLpVKBZWq9TNYE0LaD41Gg5v37gEwLGP2aOSEt0goREynTgAMCUavXL/e7GMkhDSNTQVo169fR1BQEJwe+KZnDJDqq6ul1+tx69YtdO3atdZr0dHRyMrKYou9Xq/5RfXgtVFRURAKhbh27VqT+zTav38/Ro4ciUcffRT/+Mc/8Pvvv5vztgkhpEE37t5js513Cg2FXT05rLi6dYqEUGj4J+DqzZvQcsoJEUJan00FaEVFRfD09Kz1vPG5+hLOKZVKqNVqs9oWFRVBJBKx9cWM7OzsIJPJUFRU1OQ+AaB79+6YO3cuVq5ciZdffhlCoRDvvfcedu7c2eB7LiwsRHp6OvvfnTt3GryeENLxpN++xT6Ojgg3q42jgwMig4MBANUqNW7Q75YWFRYWhqioKMjlckRHR2PmzJmoqKiwuL/NmzfXmfnf6K+//kJsbCzi4uJw4MABjB07Fuk1iYwba2srZs+ejcDAQMjlcsTGxuLhhx82+30JBAKUlpY27wCbyKb2oKlUKtjZ2dV6XiKRsK/X1w6AWW1VKlW9GZQlEonJdeb2CQBffPGFyTVjx47F3Llz8dVXX2HMmDGQSuuu3bZr1y5s3ry5ztcIIURRVobs/AIAgJtMBp86vjTWJ7ZLF1yvCcyu3ryFrhERzTJGUjdjsXS9Xo8JEyZg8+bNWLRokUV9bd68GW5ubnWu6gDAd999h5kzZ+LVV18FALZwuDltm4NOpzPJwafVauv9t7cpli1bhhdffBEA8OGHH+Jf//oXfvrpJ6v7bQ02NYMmlUqhqTlCzqVWq9nX62sHwKy2Uqm03sKoarXa5Dpz+6yLnZ0dHn/8cZSXl7PfYuqSkJCAr7/+mv3vjTfeqPdaQkjHk3brNvs4OiK8wSLQD/L18oSbzHDoKbewEFX1FKAmzUutVqOystJk5eaTTz5Bv3790KtXL4wePZpdPdm9ezd69OgBuVyO7t27IzExERs3bsS5c+fw0ksvQS6XY+/evSb9f/jhh9i+fTvWrVsHuVyO0tJShIWFITk5udG2D9q8eTNGjBiBGTNmIDY2Fn369MGtW4YZ3NzcXMTHx6N3796IiYnB4sWLodfr2Xbx8fGYPHkyYmNjcebMGQgEArz11lvo27cvXn31VeTn5+Pxxx9HbGwsunfvjg0bNgAADh48yB6wUyqVsLOzw1dffQUA2LJlC+bMmVNrnAzDQKlUsp9pRkYG3Nzc2NfLy8vr/bvy559/srNwc+bMQc+ePZGUlMS+x6lTp6Jfv36IjY1t1n+TbWoGzdPTEwUFBbWeNy47etWTy0cmk0EikbDXNdTW09MTOp0OJSUlJn9ZNBoNlEolu3zZlD7r4+PjA8DwB64+Xl5ejfZDCOm4bty9C6Cmzma4ecubRgKBAOGBQbiovAqGYXAnO7tDzKLNuPopCjVlzda/l50L/hu9tNHrjLU4MzIy0Lt3b0ydOhUA8OOPPyI9PR2nTp2CSCTC1q1bsXDhQvz222944403sGHDBgwcOBB6vR5KpRJubm74/vvv8eKLL9Y64AYAK1asQFpaGuRyOTu7ZDR37twG29bl7NmzSE5ORnh4OFasWIGPPvoIGzZsgJubG3bv3g1nZ2fodDo89thj2LFjB6ZPnw4AOH36NC5evGhSplAkEuHs2bPs5xEVFYVff/0V+fn56N27N3r27ImHHnoI06dPh0qlwpEjR9C3b1/88ccfmD9/Pn7//XeMGTOG7e/jjz/G5s2bUVBQAJFIhGPHjpn1nozUajWmTZuGLVu2ID4+HkeOHMGmTZvY12fNmoXXXnsNQ4cOhVarxfjx4/HTTz/hiSeeaNJ9zGFTAVqnTp1w8eJFVFRUmBwUSE1NZV+vi1AoRERERJ1r0ampqQgICICjoyOA+3nJ0tLSMHDgQPa6tLQ06PV69vWm9Fmf7JpyLNyonhBCzKUoK4OizBBo+Ht7w6mB1Br1CQsKxMWrVwEAtzOzOkSAVqgpQ75G0drDYJc4tVotFixYgOXLl2P16tXYuXMnzp49i969ewMwLAcaDR8+nC0ePnLkyGYv2F2XgQMHIrzmy8DAgQPx+eefAzAcnlu+fDlOnDgBhmGQn5+P7t27swHaoEGDatWQ5s5+/fHHHzh//jwAwwTG448/jj/++AMDBgyAXC7HyZMn8ccff2DFihVYunQp9Ho9Dh8+jI8//pjtg7vEuWnTJkyZMgXnzp0z+72lpaVBLBazherj4+MRGRkJAKioqMChQ4dMMkY0tgpmDZta4hw2bBh0Op1JtXu1Wo29e/eiW7du8PX1BQDk5eXV2kw/dOhQpKWlmQRUd+/excWLFzFs2DD2uV69ekEmkyExMdGkfWJiIuzt7U2CNnP7rGvjYWVlJX7++We4urpS0XNCiEXuZOewj0MD/Bu4sn6+np5wqNmOcS8np94tHu2Jl50LfOxcm+0/LzuXJo1HLBZj8uTJ2L9/PwDD8tyrr76K5ORkJCcn4/Lly7h8+TIA4NNPP8WmTZvg6OiIWbNmYdWqVbx/Po3hFgAXiUTsn5lPP/0U+fn5OH36NP7++2/MnDkT1Zxlc2dn51p91fWcEXcJcsSIEfjjjz9w7NgxDB8+HLGxsfj+++/h7u4OPz+/OttPmzYN58+fR0FBAcRisUmgW92E5XzjOIx5Bv/66y/2/5sbN2402zKnTc2gdevWDfHx8fjqq69QWlqKwMBA7N+/H7m5uVi+fDl73cqVK5GcnGwytTlp0iTs2bMHy5cvx/Tp0yESibBjxw64u7uz0T1g2Df2zDPPYM2aNXjzzTfRr18/XLp0CQcPHsS8efMgk8ma3Oevv/6KEydOYNCgQfD19UVRURH27t2LvLw8vP7663UeNCCEkMbcrZmFB4CQOkrWmUMoFCI0MBBpt25Bq9MhMy8PYYGBfA2xTTJn+bGlHT58mP2yPnHiRKxevRpTpkyBh4cHNBoNrly5gri4OKSlpSEmJgYxMTEQi8U4ePAgAMO2G4XCslnBB9tmZWVh+PDhTT7ZWVJSAj8/P9jb2yM3Nxc//fRTnSUS6zNixAh8/fXXWLlyJQoKCvDrr7+yG/xHjBiBqVOnIjQ0FE5OThgxYgTefPPNBpdlDx06BC8vL3h6ekKv14NhGKSmpqJbt27YsmVLnW2ioqKg0Whw9OhRDB06FEePHmVTeDk7OyM+Ph4ffvgh3n77bQCGlTC9Xo+goCCz36e5bCpAA4DXXnsNvr6+OHDgAMrLyxEREYGPPvqo0WleR0dHrF27FuvWrcOWLVvYupmLFy+utcQ4adIkiMVibN++HSdPnoSPjw8WL15ca43Z3D5jY2Nx5coV7NmzB0qlEvb29oiOjsby5cvZKWxCCGkKjVaLrJqlFidHR7YIuiXCgwwBGgBkZGa1+wCtrTDuQdNqtQgNDcWXX34JAHjyySdRVFTELrNptVrMmTMHcXFxeO2115Ceng6JRAJHR0e2gs78+fPx8ssvY82aNfjggw8wduxYs8fxYFsvLy+LTlQal15jYmIQEBCAESNGNKn9Z599hueeew6xsbFgGAavv/46+vfvD8BQKlGhUGD48OEAgEcffRSLFy9mfzYy7kFjGAZSqRQ///wzhEIhhEIhPv/8c4wfPx6enp6YMmVKnWOQSqXYtm0bFi1aBL1ej969eyMqKor9N/2HH37A0qVL0b17dwgEAjg5OWHDhg3NEqAJGOOcHbEJ6enpmDdvHr7++mtaGiWkA7uTlY3fjh4FAHSLjMSw/v0s7kuj1WLTL79Cq9PB0d4esyZNbNJp0Lasuroat2/fRnh4uMnSHKnfxx9/DH9/fzz11FOtPZRWUVZWxpZ0PHv2LBISEnDz5s1G95Ub8fVnzuZm0AghhAB3eFjeNLITixHo64s72dmorK5GiVJp1YwcsW3Lli1r7SG0ql9++QVr1qwBwzAQi8XYunWr2cEZnyhAI4QQG8MwDLv/TCgUIsjP1+o+A3x92KAvOz+fAjTSYc2ePRuzZ89u7WHY1ilOQgghQFlFBZQ1ZYH8vb0g4eGgUYC3D/s4Oz/f6v4IIdahAI0QQmyMsbQTAAT6WD97BgDeHu5skfXs/ALQ9mRCWhcFaIQQYmNyORVV/H28eelTKBTCz9tQtaSyqgqKsnJe+iWEWIYCNEIIsTHZNQGaUCBoUnH0xgT4cJY5C2iZk5DWRAEaIYTYkKrqapTW1O/19vBglyX5YBKg5VGA1pzCwsIQFRUFuVyO6OhozJw5ExU1+wotsXnz5gYTy/7111+IjY1FXFwcDhw4gLFjx7Ilihpr++B9zK3ZyZc9e/aw1XkyMjIgEokgl8shl8vRtWtXvP/++2b18/bbb9eqRdqWUYBGCCE2JLewkH3M1/KmkY+HB0QiEQAgh7OMSprH9u3bkZycjJSUFCgUCmzevNnivhoLsr777jvMnDkTFy9exKhRo7B37142l2ZTArSm4JZW4pOLiwtbaun06dNYt24dUlJSmuVerYkCNEIIsSHcAwL+3vwGaCKRCH5ehiXTsooKlFkxo0PMp1arUVlZCXd3d/a5Tz75BP369UOvXr0wevRotr707t270aNHD8jlcnTv3h2JiYnYuHEjzp07h5deeglyuRx79+416f/DDz/E9u3bsW7dOsjlcpSWliIsLAzJycmNtq2LUqlEQkICunXrhocffhgZGRkADIFefHw8Jk+ejNjYWJw5cwYHDhxAr1690KNHDwwdOhSpqakAgNzcXMTHx6N3796IiYnB4sWLodfrAQAajQYLFy5E586d0a9fPxw5cqTesVRUVIBhGLYM4+zZs/Gf//yHff2f//wnW5aJy3iPLl26YMCAAXj55ZdNamhv3boV/fv3R69evfDwww/j0qVLjX4ufKM8aIQQYkO4BwT8vPgN0ADA39sHWTXLm7kFhXBxcuL9Hq3t6effQlGJZXUrzeHp7ootn73T6HXGUk8ZGRno3bs3pk6dCgD48ccfkZ6ejlOnTkEkEmHr1q1YuHAhfvvtN7zxxhvYsGEDBg4cCL1eD6VSCTc3N3z//fd48cUX61x+XLFiBdLS0iCXy2st8c2dO7fBtnU5efIkkpOTER0djVWrVmH+/PlsTdDTp0/j4sWLiIqKQn5+PqKjo5GUlITY2Fj88MMPmDJlClJSUuDm5obdu3fD2dkZOp0Ojz32GHbs2IHp06fjq6++Qnp6OjsrNmrUKJP7l5WVQS6XQ6fT4dq1a3jllVcQHBxs1tiNvvrqK1y/fp29B7c01smTJ/Hf//4Xx44dg1QqxfHjxzFz5swWn6WjAI0QQmyERqtFQXExAMBdJoODvZT3e/hyDh3kFxehc1go7/dobUUlCuQXlbT2MLB9+3bI5XJotVosWLAAy5cvx+rVq7Fz506cPXuWrdXMXSocPnw4W/Ny5MiRjdahbg6DBg1CdHQ0AEMdzzfeeIMd46BBg9il09OnTyM2NhaxsbEADDVGFy1ahKysLHh4eGD58uU4ceIEGIZBfn4+unfvjunTp+PQoUN4+umnIZFIAABz5szBN998w97fuMQJAMXFxRg+fDj69u2LhIQEs9/DoUOH8NRTT8GuJofgrFmzsHHjRgBAYmIiLl26xNYBNd6nqqoKDg4OlnxkFqEAjRBCbER+URH0NfnJ+N5/ZuTj6cG5X3Gz3KO1ebo3b5WEpvYvFosxefJkLFu2DKtXrwbDMHj11Vcxf/78Wtd++umnSElJwZEjRzBr1iw8+eSTeOWVV/gautWcnZ3Nuu7TTz9Ffn4+Tp8+DXt7eyxduhTV1dV1XttQXVgPDw88+uijOHDgABISEiAWi00C2urqarPGxL0HwzCYNWsWPvjgA7PeS3OhAI0QQmxEflER+9jPy6tZ7uFgbw8XJyeUVVSgoKQEer0eQmH72q5szvJjSzt8+DA78zRx4kSsXr0aU6ZMgYeHBzQaDa5cuYK4uDikpaUhJiYGMTExEIvF7NKiTCaDQmHZsu2DbbOysjB8+PB6Dw6cOnUKaWlp6Nq1KzZu3Ij4+Hj2cAnXgAEDcPnyZVy5cgXdu3fHtm3bEBgYiMDAQJSUlMDPzw/29vbIzc3FTz/9hMmTJwMARowYge+//x4zZ84EwzDYtGlTvWNXqVQ4efIkpk2bBgDo1KkTzpw5AwAoKirC3r178fTTT9dq98gjj+DHH3/EzJkzAQBbtmxhX0tISMCTTz6JZ599FiEhIdDr9bhw4QL69OnT2EfJKwrQCCHERnBntHw8+Mt/9iAfDw+UVVRAq9WiRKmEp5tbs92rIzPuQdNqtQgNDcWXX34JwLAUWFRUhPj4eACAVqvFnDlzEBcXh9deew3p6emQSCRwdHTE+vXrARiWGl9++WWsWbMGH3zwgcmeqsY82NbLywviBtK3DBo0CMuXL8eNGzfg6elpEtxweXt744cffsDTTz8NrVYLd3d3/PTTTxAIBOwybUxMDAICAjBixAi23bx583DlyhV069YN7u7ueOihh3D+/Hn2deMeNMAQoMXHx+O5555j38uUKVMQHR2NiIgIDBgwoM6xLViwAJcvX2bv0adPH2TX1KJ96KGHsGrVKkyaNAlarRZqtRrjxo1r8QBNwFA9D5uSnp6OefPm4euvv2a/bRFCOoatibtQVlEBsViMuVMmN9vM1sXUVJxKNpxai+/fH9GREc1yn5ZQXV2N27dvIzw8HPb29q09HJvw8ccfw9/fH0899VRrD6VZlZWVwcXFBRqNBk8++SR69+6N5cuXW90vX3/maAaNEEJsQFW1ik174e3u3qzLjtzqBAXFxTYdoJGmW7ZsWWsPoUWMGDECKpUK1dXVGDJkCJ5//vnWHpIJCtAIIcQGGE9vAoYlyObkxcnHxd33Rkh7cvr06dYeQoPa185PQghpp/I5AZq3Z/MGaFKJBG4yFwBAYWlps2WEJ4TUjwI0QgixAQXF92eymnsGzXAPwzKnXq9HUWlps9+PEGKKAjRCCLEBxhOcEjs7uLq4NPv9TPKhFbfPfGiEtGUUoBFCSBtXUVWFiqoqAIC3h3uDiTv54s2ZpSssbv2s+4R0NBSgEUJIG2d6QKD58p9xcXOf0RInIS3PolOcxoy91njiiScwZcoUq/shhJD2jpugtrkPCBhJ7Owgc3aGsrwcRaWl7bKiQGsKCwuDVCqFg4MDVCoV4uLi8PXXX8PJwuL0mzdvxoABA9C1a9c6X//rr78wb948iMVifPjhh1i7di3WrFmDqKioRts2ZM+ePfjkk0+QlJSEc+fO4eOPP8b27dsbHOfOnTuxc+fOJt+ro7Hob1tubi7KysrAMIxF/+Xl5aG8vJzv90IIIe1SYcn9JUZvTgqM5macRdPqdFCWV7TYfTuK7du3Izk5GSkpKVAoFNi8ebPFfW3evLne0kwA8N1332HmzJm4ePEiRo0ahb1797LJzhtra64+ffo0GJyRprE4D9rUqVMxe/Zsi9oOHTrU0tsSQkiHY1xitBOLITOzGDUfPN3ccDszs2YMJWzqDcIvtVqNyspKuHOC708++QQ7duyAVquFj48PNmzYgNDQUOzevRuvv/46hEIhtFotVq5ciYKCApw7dw4vvfQS3n777Vqlnj788ENs374dDg4O2L59O5KSkiCXy7Fz506cO3euwbYP0mg0eOGFF/D777+zZZiMkpKS8OKLLyI5ORkFBQV48sknkZOTA4FAgN69e9eqqZmdnY3HHnsMzz33HObMmcPjJ9o+UKJaQghpw1RqNVtBwNPNrUUOCBh5ubuxj4tKSxEZEtJi925OP+0/gMqaQxfNwdHBAU+MHtXodcZanBkZGejduzemTp0KAPjxxx+Rnp6OU6dOQSQSYevWrVi4cCF+++03vPHGG9iwYQMGDhwIvV4PpVIJNzc3fP/993jxxRcxceLEWvdZsWIF0tLSIJfL8eKLL5q8Nnfu3AbbPuirr75Ceno6UlJSAACjRtX9Pr///nuEh4ezxdyLHzgJfPnyZUyfPh1r1qzByJEjG71vR2RRgLZ161a4urpafFNr2xNCSEfB3aDf0kXLufcrLCmt9zpbU8k5Fduatm/fDrlcDq1WiwULFmD58uVYvXo1du7cibNnz6J3794AYJIoePjw4Wyh8ZEjR7JFw1vKoUOH8PTTT0MikQAA5syZg2+++abWdQMGDMCaNWvw8ssv4+GHH8bo0aPZ11JSUpCQkICdO3eiZ8+eLTZ2W2PRHrSQkBCrAixr2xNCSEdhEqBxZrRagszZGXZica1x2DpHBwc4NeN/jg4OTRqPWCzG5MmTsX//fgAAwzB49dVXkZycjOTkZFy+fBmXL18GAHz66afYtGkTHB0dMWvWLKxatYr3z6cp6pvRHThwIJKTk9G/f3/8+uuv6Nu3LxtoBgQEwNfXF4cPH27JodocWuIkhJA2rIgzc+Xl1nIHBADDP74ebm7IKyxEWUUFVGo1pDUzJ7bMnOXHlnb48GF20/7EiROxevVqTJkyBR4eHtBoNLhy5Qri4uKQlpaGmJgYxMTEQCwWs0uIMpkMCoXCons/2DYrKwvDhw+v8+DAiBEj8P3332PmzJlgGKbWvjKj27dvIzAwEFOnTsXo0aPh4+PDHg50d3fH1q1bMX78eJSVleHNN9+0aNztHa9npsvKythvAIQQQqxXyJm58nBr+ZUHL84yZ3GpZQEAqdu0adMgl8vRvXt3XL16FWvXrgUAPPnkk5g9ezbi4+PRs2dPyOVydrbptddeQ0xMDOLi4rB161a8/fbbAID58+fjgw8+gFwux969e5s0jgfbZmVlQSyue/5m3rx56Ny5M7p164YhQ4bUu8SalJSE3r17Qy6XY9CgQfj4449NVs5cXFywf/9+/Pnnn1i2bFmTxttRCBiGYfjq7MaNG5g7dy6SkpL46pI8ID09HfPmzcPXX3/NftsihLRPer0eG3/6GVqdDjJnZzyVMKHFx3Dl+nUcO3sOAPBQn96I7dKlxcdgjerqaty+fRvh4eGwt7dv7eHYhI8//hj+/v546qmnWnsoNomvP3NNWuLMy8tr8PXCwkKLB0IIIcSUsrwc2pp9O14tvP/MiCoKdDw0o9U2NClAmzp1aoNHvBmGadEj4IQQ0p4VmpzgbNn9Z/fv68Y+LmpHJzkJaeuaFKC5uLjgmWeeqXfN+c6dO+x6OCGEEOtwA6KWTrFhJLGzg4uTE8oqKlCiVNIXcUJaSJMCtC5duqCsrAzh4eF1vq7T6cDjljZCCOnQuEuKrbXECQDuMhnKKiqg1mhQUVUFZ0fHVhuLpfR6fWsPgXQQfMVBTQrQJk6ciOrq6npf9/X1xYoVK6weFCGEENMSTy4WFtHmg7urK+7m5AAAShQKmwrQJBIJhEIhsrOz4e3tDYlEQjOApNkwDIOCggIIBALY2dlZ1VeTArSHH364wdddXFwwZswYqwZECCHEUPPQWOLJw9W1VYMKD1cZ+7hYoUSwv3+rjaWphEIhwsPDkZOTg+zs7NYeDukABAIBgoKCIBKJrOqHEtUSQkgbVKxUso9bI/8Zlzsnf1WJ0vZyoUkkEoSEhECr1ZqUTSKkOdjZ2VkdnAE8BGjDhg3D1q1bERwcbPVgCCGEGJRwMrt7tHJpPHfZ/Rm0EoWygSvbLuOSk7XLToS0FKsrCdChAEII4V8xJ0Bzb+UATSqRwKmmvmSxQkG/9wlpAbyWeiKEEMIPblml1p5BA+4HiSq1GlUNHBYjhPCDAjRCCGmDjDNoEjs7dvaqNXEPCpQobXOZkxBbQgEaIYS0MWqNBuWVlQAMM1dtIS0Ed5mVu/xKCGkeFKARQkgb05YOCBh5yDgnOW30oAAhtoQCNEIIaWOKTQI0WQNXthx3k1xoNINGSHOjAI0QQtqY4jY4g2YvlcLB3h6AbeZCI8TWWB2gzZw5EzJZ2/iGRwgh7UFbDNCA+7N5VdUqVKtUrTwaQto3qwO0BQsWwLUN/QIhhBBbV1yzx0tqZwfHNnCC08jN5f6X8VJlWSuOhJD2z+IATa1W8zkOQgghMJzgrDCe4HRrGyc4jdxkLuzj0jI6KEBIc7I4QJs0aRLWrFmD9PR0PsdDCCEdGveEpLusba1OuMkoFxohLcXiWpxqtRo7d+5EYmIiIiMjMW7cODz66KNwcXFpvDEhhJA6cTfgu7ex/b3cAI2WOAlpXhbPoCUmJmLp0qWIiorCjRs38Nlnn+Hxxx/Hu+++i/Pnz/M5RkII6TC4M1PubSTFhpGLoyNEQsM/G7TESUjzsngGzdHREY899hgee+wxZGRk4LfffsPvv/+OQ4cO4fDhw/Dx8cG4ceMwevRo+Pr68jlmQghpt7gzU21tBk0oFMLVxQXFCgUUZeXQ6/UQCilbEyHNgZe/WWFhYVi0aBF++eUXvP/++xgwYAAKCwvx7bffYvr06Vi2bBmSkpKg1Wr5uB0hhLRbxiVOkUgEFyenVh5NbcaDAnq9HmUVFa08GkLaL4tn0OoiEonw0EMP4aGHHkJxcTEOHDiAvXv34syZMzh79ixkMhl27dpl1T3UajW++eYbHDx4EGVlZYiMjMTcuXPRt2/fRtsWFBRg3bp1OHv2LPR6PeLi4rBkyRIEBATUunbPnj3Ytm0bcnNz4e3tjSlTpmDy5MlW9Wn0999/Y/HixQCAXbt2wc3NzfwPgBDSbun0eijLygEAbi4ubeoEp9GDqTZcad8xIc2i2eamPTw8MGPGDLz99tuIjY0FwzBQ8nDq59///jd27NiBRx99FM8//zyEQiFeeeUV/P333w22q6ysxAsvvIDk5GQ89dRTmDNnDq5fv44lS5ZA8UDZksTERKxatQrh4eF44YUX0L17d6xduxY//PCDxX0a6fV6rF27Fg5tKLcRIaRtUJSVQc8wANre8qYRpdogpGXwOoNmVFlZid9//x2//fYbrl27BoZhYG9vj/j4eKv6TU1NxaFDh/Dcc89hxowZAIBRo0Zh9uzZWL9+PdavX19v2507dyIzMxMbNmxAdHQ0AKB///6YPXs2tm/fjvnz5wMAVCoVNm7ciIEDB+K9994DAEyYMAF6vR5btmxBQkICe1LV3D65du/ejfz8fIwbNw4///yzVZ8HIaR9KW3DBwSMTFNt0ElOQpoLrzNoFy5cwPvvv2+SIy06OhrLli3D//73P6xYscKq/o8ePQqRSISEhAT2OalUinHjxiElJQV5eXn1tk1KSkLXrl3ZQAoAQkND0atXLxw5csTkPSgUCkycONGk/aRJk1BVVYVTp041uU8jpVKJjRs3Ys6cOXB2dm7SeyeEtH/cE5xubXYGjbvESTNohDQXq2fQ8vPzsW/fPuzbtw+5ublgGAZubm5ISEjAuHHjEBYWxsMwDa5fv46goCA4PbBx1hgg3bhxo84To3q9Hrdu3cLYsWNrvRYdHY2zZ8+isrISjo6OuH79OgCga9euJtdFRUVBKBTi2rVrGDlyZJP6NNq4cSM8PDyQkJCA7777rukfACGkXTNNUts2AzR7iQQOUimqVCooymgGjZDmYnGAdujQIezduxcXLlxgj1r37dsX48aNw5AhQyAW8796WlRUBE9Pz1rPG58rLCyss51SqYRarW60bUhICIqKiiASieDu7m5ynZ2dHWQyGYqKiprcJwDcvHkTu3fvxkcffQSRSGTuW0ZhYSF7TwC4c+eO2W0JIbaFOyPl1oY337vJZKgqKEBFVRXUGg0kdnatPSRC2h2Lo6h3330XAODv748xY8ZgzJgx8PHx4W1gdVGpVLCr4xeBRCJhX6+vHQCz2qpUqnqDS4lEYnKduX0CwNq1a9G/f3/069evzr7rs2vXLmzevLlJbQghtodhGHaJU+bs3CxfcvniJnNBTkEBAKC0rAw+Hh6tPCJC2h+LfwMMHz4c48aNQ+/evfkcT4OkUik0Gk2t542F26VSab3tAJjVViqV1puvTa1Wm1xnbp+HDh3ClStXLFrWTEhIwODBg9mf79y5g/fff7/J/RBC2raKqipoan73tNX9Z0bc2T2FkgI0QpqDxQHam2++yec4zOLp6YmCmm9tXMYlQC8vrzrbyWQySCQSk6XC+tp6enpCp9OhpKTEZJlTo9FAqVSyy5dN6XP9+vUYNmwYxGIxcnJyAADl5YZcR/n5+dBqtfWO3cvLq97XCCHth8kJzjYeoHFznynKaR8aIc2Btzl0rVaLX3/9FX/88Qfu3r0LlUrFnmS8fv06du/ejSeeeALBwcEW36NTp064ePEiKioqTA4KpKamsq/XRSgUIiIiAmlpabVeS01NRUBAALuZv3PnzgCAtLQ0DBw4kL0uLS0Ner2efb0pfebn5+OPP/7AH3/8UevauXPnolOnTvj222/N+gwIIe1TKWfDPTfXWFtkEqDRQQFCmgUvAZpKpcLLL7+MK1euwNXVFU5OTqiurmZf9/f3x969e+Hi4oJ58+ZZfJ9hw4Zh27Zt2LVrF5sHTa1WY+/evejWrRt7gjMvLw/V1dUIDQ1l2w4dOhQbNmxAWloae0Lz7t27uHjxIqZNm8Ze16tXL8hkMiQmJpoEaImJibC3tzd5ztw+V65cWeu9GGuWvv766/D29rb4MyGEtA/Kmll1AHBt42l4ZJzxKcrKG7iSEGIpXgK0rVu34vLly1iwYAFmzJiBTZs2YcuWLezrzs7OkMvlOHv2rFUBWrdu3RAfH4+vvvoKpaWlCAwMxP79+5Gbm4vly5ez161cuRLJyck4duwY+9ykSZOwZ88eLF++HNOnT4dIJMKOHTvg7u6O6dOns9dJpVI888wzWLNmDd58803069cPly5dwsGDBzFv3jzIOEsP5vb50EMP1XovxnQe/fv3p1JPhBCTQEfWxgM0O7EYTg4OqKiqoiVOQpoJLwHa4cOHERcXh5kzZwJAnfXjAgIC2KDEGq+99hp8fX1x4MABlJeXIyIiAh999BHkcnmD7RwdHbF27VqsW7cOW7ZsYetmLl68uFaANGnSJIjFYmzfvh0nT56Ej48PFi9ejCeeeMLiPgkhpCHGGTShUAhnTv7EtsrVxRkVVVWoqlZRqg1CmgEvAVp+fn6ds0RcDg4OqKiosPpeUqkUCxcuxMKFC+u95rPPPqvzeR8fHzY9SGMmTJiACRMmNHpdU/rkmjNnDubMmdPkdoSQ9odhGDZAc3FyglDYbGWSeePq4oLsfMOhLUVZGbzpJCchvOLlt4CDgwNKS0sbvCY7Oxuurq583I4QQtqVKpWKTbEhc3Zq5Oq2wdWZe1CA9qERwjdeArSYmBj8+eefKKvnNE9eXh7++usv9OzZk4/bEUJIu6Is4x4QaNsnOI1cXTgHBWgfGiG84yVAmz59OsrKyvDSSy/h8uXL0Ol0AIDq6mqcP38e//znP6HT6UxONhJCCDHgBjht/YCAEaXaIKR58bIHTS6X48UXX8Rnn32GJUuWsM+PHj0agGHT69KlSxEVFcXH7QghpF1Rlt/fn8udmWrLKNUGIc2Lt0S1EydOhFwuR2JiIq5evQqlUgknJydER0dj0qRJCA8P5+tWhBDSrihtcAZNYmcHB3t7VFVXQ1FOARohfOO1Gm9YWBheeOGFel/X6XQQiUR83pIQQmweN8CxlQANMNTkrKquRmVNHVG7NlzgnRBbw8setF9//bXRa3Q6Hd555x0+bkcIIe2KcYnT0d7epoIck4MCtA+NEF7xEqB99tlnSEpKqvd1vV6Pd955xySzPyGEEECj1aKyqgqAbc2eAYCMUm0Q0mx4CdBiY2Px/vvv48KFC7VeMwZnR48exaRJk/i4HSGEtBtKG13eBCjVBiHNiZcA7cMPP0RwcDDeeOMNk3JOer0e7733HpKSkjBx4sQG96cRQkhHZFIk3UZOcBqZptqgGTRC+MRLgObk5IRPPvkEzs7OWLZsGbKzs8EwDN59910cPnwYjz32GF566SU+bkUIIe2KTc+gOdMeNEKaC28F3zw9PbF69Wro9Xq8/PLLeOutt3DkyBGMHz8eS5cu5es2hBDSrnBnnmwtQJNKJHCQSgFQgEYI33ityBscHIxVq1ahpKQEx44dw/jx47Fs2TI+b0EIIe2KyRKnjQVoACCrWeasqEm1QQjhh0XnuTdv3tzg69HR0bhx4wY8PT1NrhUIBJg1a5YltySEkHbJmANNLBbDwd6+lUfTdK7OzsgrLARgCDY93dxad0CEtBMWBWibNm0y67rvvvvO5GcK0Agh5D69Xo+yCkMONFdnZwgEglYeUdM9eFCAAjRC+GFRgLZ27Vq+x0EIIR1ORVUV9Ho9ANvbf2ZEqTYIaR4WBWhyuZznYRBCSMfD3VhvuwEadwaNAjRC+MLrIQFCCCHmM5Z4AmwvB5oR5UIjpHlQgEYIIa2EuyQoc7LNAM1eIoFUIgFAM2iE8IkCNEIIaSW2XEWAyziLVl5ZCa1O18qjIaR9oACNEEJaibJmSVAgEMDZyamVR2M5bv42btBJCLEcBWiEENJKjMGMi6MjRELb/XXM3YempH1ohPDCdn8jEEKIDatWqaDSaADY7glOI+7ybCntQyOEFxSgEUJIK1Bwi6Tb8P4z4IGTnJQLjRBeUIBGCCGtgLsUaIs1OLlcnSkXGiF84zVAKysrw/79+/nskhBC2iVlBWcGzcYDNHupBBI7OwC0B40QvvAaoOXl5eHDDz/ks0tCCGmXuEldbT1AEwgE7Hsoq6yErqZ8FSHEck0q9ZSXl9fg64WFhVYNhhBCOgrTHGguDVxpG1ydnVFYUgKGYVBeUdEu3hMhralJAdrUqVMhEAjqfZ1hmAZfJ4QQYmAM0OylUnZ50JbJTIqml1OARoiVmhSgubi44Jlnnqm3WPqdO3fw9ttv8zAsQghpv3Q6HcorKwHY/vKmESWrJYRfTQrQunTpgrKyMoSHh9f5uk6nA8MwvAyMEELaK5Mi6c0coN2+m439Sadw4XIahvST48nHR0MsEvF+H26gSUXTCbFekwK0iRMnorq6ut7XfX19sWLFCqsHRQgh7ZlJkfRmCtAYhsHKzzYh8cBR9rnklGs4cSYZ7y17Fn4+nrzez6SaAM2gEWK1Jp3ifPjhhzFy5Mh6X3dxccGYMWOsHhQhhLRnJjNozZSk9sjJcybBmVFyyjXMevFtFJUoeL2fk4MDhDXlqihZLSHWo0S1hBDSwpTNPIOmUqux9tvt7M/zZk7Ef95ZCn8fLwBAcakS/915gNd7CoVCyGoKvivLK2i7CyFWsjpAGzZsGO7du8fHWAghpENo7hxo2xN/R3ZuAQCgr7wb5j05EYP79sTGT16Hndiws+Xn3w6jvKKS1/sa34tWq0VVA9thCCGNszpAo29JhBDSNMY9WiKRCE4ODrz2Xaoow7fbdgEAhEIBXpo3g01/5OPlgXEjBgMAKiqr8PNvh3m9t+sDqTYIIZajJU5CCGlBDMNAWWHYgyZzcuI9d+TBY3+hosowe5Uw8mF0Dg8xef3pKeMgFBru+d/Eg6hWqXm7N53kJIQ/FKARQkgLqqiqgk6nA9A8y5uHT55jH0+b8Git14MDfPHI4L4AgOISBQ4kneLt3jLKhUYIbyhAI4SQFmRa4onfAK1EocTFK+kAgJAAX0SGBdV53ZOTRrOPk05d4O3+rs73U23QSU5CrEMBGiGEtCBugCZz5rccUtKpC9DrDfuC4wf3qXf5NCYqAl4ebgCAs5dSoVLzs8wpc3ZiHytpiZMQq1CARgghLcj0BKdTA1c2HXd507iMWReBQIBBfXoAAFQqNS5cTufl/mKxmD30oKygAI0Qa1CARgghLchkiZPHGTRlWQXOJqcCAPx9vBDdOazB6wfXBGgAcPLsJd7GYdyHVlWtglqj4a1fQjoaqwO0mTNnQiaT8TEWQghp9xTlzTODdvzMRfbwQfyg3o2eDu0XFwNRTU3OE2eSeUuZxN1XRwcFCLGc1QHaggUL4OrqysdYCCGk3TMGLc6OjmyAxIfTF1LYx8MG9W70emcnR8TFdAEAZOUW4G5WHi/jMEm1QQEaIRZr1iVOhmFw79495OXx8xefEEJsmVqjQbVKBYD/FBuXUq8BAKRSCbpHRZrVZlBfzjLnOX6WOV25qTbooAAhFuMlQDt69ChWrlyJsrL7x6pzcnIwe/Zs/OMf/8C0adPw9ttvs9PvhBDSESnKmqcGZ15hMbLzCgEA3aMiYGcnNqvd4L492cenzl/mZSwyk1QbFKARYileArTExERcv34dLi73/2KuW7cOGRkZiIuLQ2RkJJKSkrB3714+bkcIITapuXKgXUq5zj7u2a2L2e3CgwPg4W7YonIl7Sb0er3VYzHdg0a50AixFC8BWkZGBqKjo9mfKysrcerUKTzyyCNYs2YNNmzYgNDQUArQCCEdmkkONCceA7Sa5U0AkMeYH6AJBALE1iyHlldU4m5WrtVjkUokkNjZAaAlTkKswUuAplQq4eHhwf78999/Q6fTYfjw4QAMuXH69OmDrKwsPm5HCCE2yeQEJ48zaMkphgBNKBQgNrpTk9rGREWwj6+k37J6LAKBgF2+LaushI6HWTlCOiJeAjQnJycolUr254sXL0IoFKJnz/v7G8RiMaqrq/m4HSGE2CTujJIrT3vQyisqcSPjHgCgU1gwnB0dmtSee6DgSvpNXsZkfG8Mw6C8pjA8IaRpeAnQQkJC8Oeff0KhUKCsrAx//PEHunTpYrInLTc3F+7u7nzcjhBCbJJxiVNqZwd7qZSXPi+n3WTLOzVledMouks4mzPtSho/ARp3dlBBy5yEWISXAG3y5MkoLCzE5MmT8cQTT6CoqAgTJ040uSY1NRWdOjVt6p0QQtoLnV6PsspKAPye4DQubwJNOyBg5OzogIiQQADAjdv3UF2tsnpMJqk26CQnIRbhJUAbNmwYXnrpJYSHhyM4OBgLFizAmDFj2NeTk5NRUVGBfv368XE7QgixOeUVFWy2fj73n/2dyjnBGdPZoj661+xD0+n1SLt5x+oxUbJaQqxnXrIcM0ycOLHWrJmRXC6nE5yEkA7NtEg6PwEawzBsQOXj5QFfL49GWtQtpmskEg8eA2DYh2bJUimXK2d7C82gEWIZKpZOCCEtQFnBf5H0rNwClFcYlk2jIkMs7qc79yQnD/vQnBwcIBQa/nlRUC40QizC2wxaS1Gr1fjmm29w8OBBlJWVITIyEnPnzkXfvn0bbVtQUIB169bh7Nmz0Ov1iIuLw5IlSxAQEFDr2j179mDbtm3Izc2Ft7c3pkyZgsmTJ1vUp0qlwpo1a3D16lXk5+dDr9cjICAAY8eOxaRJkyAW29z/DYSQJjKdQeOnSPq1W3fZx1GRoRb3ExESBAd7KaqqVbyc5BQKhZA5OaG0rAzKcsPSbmPF2wkhpmxuBu3f//43duzYgUcffRTPP/88hEIhXnnlFfz9998NtqusrMQLL7yA5ORkPPXUU5gzZw6uX7+OJUuWQKFQmFybmJiIVatWITw8HC+88AK6d++OtWvX4ocffrCoT5VKhYyMDAwYMADz58/HwoUL0alTJ6xbtw4ffPABfx8OIaTNMq0iwM8MWjpnv1iXCMtn0EQiIaI7hwMA8gqKUaqwftbLuIyr1WpRRSmWCGkym5q6SU1NxaFDh/Dcc89hxowZAIBRo0Zh9uzZWL9+PdavX19v2507dyIzMxMbNmxgqx70798fs2fPxvbt2zF//nwAhmBq48aNGDhwIN577z0AwIQJE6DX67FlyxYkJCSw6UPM7VMmk+HLL780Gc9jjz0GJycn/Prrr1i0aBE8PT15/KQIIW2NcalPKBTCyaFpucrqw9cMGgB0Dg/GhctpAIAbGZno0zO6kRYNc3VxBnIMjxXl5XDk6T0T0lHY1Aza0aNHIRKJkJCQwD4nlUoxbtw4pKSkIC8vr962SUlJ6Nq1q0lJqtDQUPTq1QtHjhxhn7tw4QIUCkWtAw+TJk1CVVUVTp061eQ+6+Pn5wcAKKdNtIS0awzDQFluSNjq4uTE7s+y1rWaGTQXZ0f4+3hZ1VdkWBD72Jj41homJzkpFxohTWZTAdr169cRFBQEJyfT/RvGAOnGjRt1ttPr9bh16xa6du1a67Xo6GhkZWWhsiY/0fXrhiPrD14bFRUFoVCIa9euNblPI41Gg9LSUuTl5eHYsWPYtm0b/Pz8EBgYaM7bJ4TYqKrqami1WgD8VRAoUSiRX1QCwLC8ae0er85hwezjG7f5DdDoJCchTWdTS5xFRUV1LgUanyssLKyznVKphFqtbrRtSEgIioqKIBKJalU9sLOzg0wmQ1FRUZP7NDp27Bjeeecd9ueuXbti+fLlDR4SKCwsZO8JAHfuWJ+jiBDSskxqcPIUoF27eX9505r9Z0YRofe/KN7IyLS6P+5JVTrJSUjT2VSAplKpYGdnV+t5iUTCvl5fOwBmtVWpVPUGTBKJxOQ6c/s0iouLw6effory8nKcP38eN27caLQ+6a5du7B58+YGryGEtG3KZgjQuAcErN1/BgCODvYI8vdBZk4+bt7JhF6vt2oplntSVUlLnIQ0WZMDNL1ej4yMDMhkMnh5me550Gq1uHLlCuRyOV/jMyGVSqHRaGo9r1ar2dfrawfArLZSqZRdiqjrWu515vZp5OHhAQ8PQyLJYcOGYevWrVi6dCl+/PHHeg8JJCQkYPDgwezPd+7cwfvvv1/ntYSQtom7B8uVpyoC3AMCfMygAUCnsCBk5uSjWqVGVm4BggN8Le5LLBbDycEBFVVVtMRJiAWa9PUoNzcXs2fPxv/93/9hypQpWLFihUk6CaVSiRdffJHvMbI8PT1NlvuMjM89GDAayWQySCQSs9p6enpCp9OhpKTE5DqNRgOlUskGUk3psz7Dhg1DVVUVTpw4Ue81Xl5eiIqKYv8LDbX+mzIhpGWZpNjgKUlt+i3DDJqdWIzw4Nq5HC0RydmHdp3HfWhVKhXUdXyZJYTUr0kB2vr16+Hl5YVt27bh66+/hkqlwqJFi0z2fhlrzTWHTp06ITMzExUVFSbPp6amsq/XRSgUIiIiAmlpabVeS01NRUBAABwdHQEAnTsbatk9eG1aWhr0ej37elP6rI9xCfTB90MIaV8UZff3YPGRpLa6WoW7WbkAgMiwQN6SXXcOvx+g3eThJCd3tpBm0QhpmiYFaJcuXcLChQvh7++Pzp07Y/Xq1ejRowcWL17MprhozmzRw4YNg06nw65du9jn1Go19u7di27dusHX1zAdn5eXV2sz/dChQ5GWlmYSUN29excXL17EsGHD2Od69eoFmUyGxMREk/aJiYmwt7fHwIEDm9xnaWlpnYHrnj17ABhOiBJC2i9jcOLk4MBLMJWRmQO93vA7pRNn1stapqk2rD8oQEXTCbFck35TVFdXm2yKN2bxX716NZYsWYJ//etfvA+Qq1u3boiPj8dXX32F0tJSBAYGYv/+/cjNzcXy5cvZ61auXInk5GQcO3aMfW7SpEnYs2cPli9fjunTp0MkEmHHjh1wd3fH9OnT2eukUimeeeYZrFmzBm+++Sb69euHS5cu4eDBg5g3bx5kMlmT+zx48CB27dqFIUOGICAgAJWVlThz5gzOnTuHQYMGoXfv3s36uRFCWo9ao0FVzWw5XxUEbt3NYh9zT19aK9jfF1KJHVRqDS+pNrgpReigACFN06QALSQkBOnp6bX2Qb388sv49NNPsWLFCl4HV5fXXnsNvr6+OHDgAMrLyxEREYGPPvqo0YMJjo6OWLt2LdatW4ctW7awdTMXL14MNzc3k2uN9TG3b9+OkydPwsfHB4sXL8YTTzxhUZ89evRASkoKDh06hJKSEohEIgQHB2Px4sV4/PHHefpkCCFtkenyJj8HBG7fzWYfR4TwF6CJREJEhATi6o0M3MvJR3W1Cvb2dR++MofMJNUGBWiENEWTArSHH34Yv//+O0aOHFnrtaVLlwJAraVBvkmlUixcuBALFy6s95rPPvuszud9fHzw7rvvmnWfCRMmYMKECY1eZ06fXbt2Ncl/RgjpOBTl/J/g5M6ghYfwc0DAKDIsCFdvZIBhGNy8m4WYLhEW92W6B41yoRHSFE3ag/bUU0/h448/rvf1pUuX4ujRo1YPihBC2gvu0h5fJziNM2j2Ugn8vPmt48vdh3bnXo5VfUklEkhqtsXQEichTWNTpZ4IIcTWcLPo8zGDZshRlg8ACA8O4K2up1FYkD/7OCPTugBNIBCwy7pllZXQ6fVW9UdIR2L13+xhw4bh3j3rN5MSQkh7xE1Sy8cetLtZuewJTj4PCBiFBXMCNCtn0ID7BwUYhkE5pRQixGxWB2jNmfeMEEJsnXEPmr1UCmlNGThr3DbZf8Z/gObv4w27mlQgGZnZjVzdOBln1lBBy5yEmI2WOAkhpJlodTpUVFYCME05YY1bnBOcfB8QAAwnOYMDDTkl72XnQavTWdWfSaoNOslJiNkoQCOEkGZiUiS9GU5wRjRDgAbc34em1eqQk1fYyNUNM01WSyc5CTEXBWiEENJMmvMEp1RiB38fb176fJDJQQEr96Fxk/PSDBoh5qMAjRBCmgnfJzjVGg0ysw1l9cKCAyASNc+v8FDuQQEr96E5OTiwJ00pWS0h5qMAjRBCmgn/Jzjz2FQVzbH/zCiUM4NmbS40oVAImZOhQLyyvIIOlhFiJgrQCCGkmShNqghYv8RpcoIzuIUCtKxcq/szBqdarRZV1dVW90dIR2B1gDZz5kyTAuKEEEIMjHU47cRiOEgtr2lpdJcTLHH3ifHN2dEB3p5uAHjKhcZNtUHLnISYxeoAbcGCBXB1deVjLIQQ0m7o9XqU1SRmdXVxhkAgsLrPO5n3A7SQZgzQACA0yDBDV6osQ6nCutOXJic5KRcaIWahJU5CCGkGZZWV0Nfst5LxdILzTpZhNksgECDI34eXPuvDnaG7Y2XJJ+4JVjrJSYh5KEAjhJBmoCzjnODk4YAAwzC4m2U4wenv4wl7qfVVCRoSGuTHPra2JiflQiOk6cR8dqbT6VBQUIDCwkJotdo6r5HL5XzekhBC2iSFyQEB6wO04lIlyisMVQlCAv0audp63Jqc3KVVS8icndjHSlriJMQsvARoer0eW7duxc8//4yysoa/HSUlJfFxS0IIadP4TrHBXWYMbeb9ZwAQ5O/LPs7MybeqL7FYDCcHB1RUVdESJyFm4iVA27BhA7Zt2wZ3d3eMGTMGnp6eEIlEfHRNCCE2SWmSpNb6PWjcE5wtMYPm52P4Pa7T6ZCZk2d1fzJnZ1RUVaFKpYJao4HEzo6HURLSfvESoB04cADBwcH46quv4OjoyEeXhBBi04wzaEKhEE4ODlb3x81HFtoCAZpYJEKgrxfuZuchMycfDMNYdRLV1cUZOQUFAAwHBbzc3fkaKiHtEi+HBKqqqjBw4EAKzgghBIYN/calPJmzM1vqyBrcGbSWWOIEgKAAwzJnVbUKRSUKq/qiVBuENA0vAVpERASKior46IoQQmxeZVUVtDodAH5OcAL3N+pLpRL4eLXM7BM3lYe1+9C4nwPtQyOkcbwEaE8//TSOHz+O9PR0ProjhBCbxvcJTq1WywZIIQG+vMzImYN7UOBetnX70Li54KiaACGN42UP2sCBA/Hqq6/ilVdeweDBgxEZGQknJ6c6rx09ejQftySEkDbL9ASn9QcEsvMKoauZkWuJAwJGwQGcGTQrAzRuoKqkXGiENIqXAE2tVuPPP/+EQqHAb7/9BgC1NpMaN5hSgEYIae+UPM+gcfOQtcQBASPjHjQAyMy1bolTKpFAYmcHtUZDudAIMQMvAdq6devw+++/IzIyEkOHDqU0G4SQDk3BcxUBY4knAAgJarkALcDXCwKBAAzD4F62dQGaQCCAq7MzCkpKUFZZCZ1eD1ELLdUSYot4CdCSkpIQFRWFL774AmIxr8UJCCHE5hj3WAkEArjUs92jKVo6B5qRxM4Oft6eyMkvxL3sPKtTbchqAjSGYVBeUcFLfjhC2itevr6o1WrExcVRcEYI6fAYhmFn0JwdHXlZTeDOXrVkgAYAQTX70MorKqEoq7CqL5kLpdogxFy8BGhRUVHIzMzkoytCCLFpxkz5AOAm42eG6F62YQZN5uzEy562pgjmnOTMsrKiAKXaIMR8vARo8+bNw5kzZ/Dnn3/y0R0hhNgshfL+/jM3F5nV/VWr1MgrKAYABHM27bcUbi40a/ehmSSrpZOchDSIlzXJc+fOQS6X47XXXkOvXr3qTbMhEAgwa9YsPm5JCCFtUkmZkn3sxsMeq+y8AvZxUGsEaJxUG/esnUHjfB40g0ZIw3gJ0DZt2sQ+Pn/+PM6fP1/ndRSgEULaO+4MmisPS5z3su4HRSGtEKBxlzitzYXm5OAAoVAIvV5Pe9AIaQQvAdratWv56IYQQmxeaRl3iZOHAI0za8WdzWopgdwlTivLPQmFQsicnFBaVgZlebnVp0IJac94CdDkcjkf3RBCiM0rrVniFAmFvKTYMJ1Ba9kTnADgYC+Fl4cbCotLkWVlgAYY9qGVlpVBq9Ohqroajg4OPIySkPaHl0MCly9fxrp16+otmF5YWIh169YhJSWFj9sRQkibxF26c3Vx4WV2yHQGreWXOAEguGYWrbhUifLKKqv64p5CpZqchNSPlwBt+/btOHnyJDw9Pet83cvLC3/++Sd27NjBx+0IIaRNKq+shF6vB8Bjio2aGTSZsxPcZC2bYsOIGxhaO4tmcpKT9qERUi9eArS0tDT06NGjwWt69uyJ1NRUPm5HCCFtUin3gAAP+89UajXyCg0pNlpj/5kRN73HPWuLpjvTSU5CzMFLgFZaWgovL68Gr/Hw8EBJSQkftyOEkDap1CTFhvU50LJyC8AwDAAguBX2nxlxc6Fl8jmDRrnQCKkXLwGas7Mz8vMb/kubl5cHB9oMSghpx7gzaHwscXJnq4JbcQbNJECzcgZN5nz/4ISSljgJqRcvAVq3bt1w7Ngx5OXV/Rc3Ly8Px48fR/fu3fm4HSGEtEm8p9gwCdBa54AA8EA1AStn0MRiMZxqvqzTEich9eMlQJs6dSpUKhUWLVqE/fv3o7CwEIDh9Oa+ffuwcOFCqNVqTJs2jY/bEUJIm2Qski61s4O9VGp1f5ltJEBzcXZiZwStnUED7i9zcuuWEkJM8ZYHbdGiRfjiiy/w4YcfAjBUDTDunRAIBFiyZAnlSyOEtFtarRZlFRUAAFeZjJcUG3dNArTW24NmuL8PSpVlyC8qQbVKDXupxOK+3GQuyCkwlLAqLSuDj4cHX8MkpN3gJUADgCeeeAK9evVCYmIi0tLSUF5eDmdnZ0RHR+Oxxx5DREQEX7cihJA2h5vTi4/lTQDIrClO7uLsCFcX65PeWiPQ3weX024CALJy8xEZGmRxX9zPR6FUUoBGSB14C9AAIDIyEkuXLuWzS0IIsQkm+894OCCgUquRW2BI/h0c4NvqJZFMa3JaF6C5ck64cj83Qsh9vOxBI4SQjq5UyW+KjezcwvspNvxbb/+ZETcPG7e6gSW4ASz35Csh5D4K0AghhAcKnmfQuEFQcGDrB2jcQwrW5kJzdXZmZwRpBo2QulGARgghPDCpIuBsfUkmbpH0NjGDxmMuNJFIxBaSL1Uq2ZlCQsh9FKARQggPjDNBTg4OsLOzs7q/tjaD5iZzgZOjIX+ZtbnQgPsHBTRaLaqqq63uj5D2hgI0QgixUrVKhWqVCgD/RdKBtjGDJhAI2GoGufmF0Gi0VvXHrVVKy5yE1EYBGiGEWIm7/8yVhwMCAJBZM4Pm4uwIV5n1S6Z8CPIzBGh6PYOc/EKr+qKDAoQ0jAI0QgixEt8lntQaDZtiI8i/9VNsGAVw9qFl5RZY1ZebyQyasoErCemYKEAjhBAr8V0kPTu3AHq9YeN8SCuWeHqQyUEBK/ehucnuzzQqaImTkFp4S1Sr0Whw/PhxtoqAXq+v87oVK1bwdUtCCGkTuDNAfORA45Z4CmpLAZofdwbNugDN2dERIpEIOp0OJbTESUgtvARoubm5WLp0KbKzsxs8Li0QCChAI4S0O8YZNKFAABdn60symRZJ92ngypYV6O/NPs6ycgZNIBDA1cUZxaUKKGu+1AuFtKhDiBEvAdrnn3+OrKwsjBw5EuPGjYO3tzdEIhEfXRNCSJvGMAy7RCdzdoaIhyCjLRVJ5/L18oRYLIJWq7N6iRMwzDYWlyqg1+tRVlFhcrKTkI6OlwDt4sWL6N27N15//XU+uiOEEJtRUVUFrU4HALwFGG11Bk0kEiLAxwt3s/OQlVsAhmGsOsDg9kCqDQrQCLmPl/lkvV6Pzp0789EVIYTYFJManHzlQKsJ0JydHHnrky+BNQcFqqpVKC617vQlpdogpH68zKB169YNd+7c4aOrRqnVanzzzTc4ePAgysrKEBkZiblz56Jv376Nti0oKMC6detw9uxZ6PV6xMXFYcmSJQgICKh17Z49e7Bt2zbk5ubC29sbU6ZMweTJky3qMy8vD3v37sWpU6eQmZkJkUiE8PBwPP300+jTp491HwghpFWZnODk4YAAN8VGsL9Pm0mxYRToZ3qS09Pd1eK+uJ8XneQkxBQvM2gLFizAhQsXkJSUxEd3Dfr3v/+NHTt24NFHH8Xzzz8PoVCIV155BX///XeD7SorK/HCCy8gOTkZTz31FObMmYPr169jyZIlUCgUJtcmJiZi1apVCA8PxwsvvIDu3btj7dq1+OGHHyzq88SJE/jxxx8RFBSEuXPn4umnn0ZlZSWWLl2KvXv38vfhEEJaXIny/t91d1frAzRuio22UOLpQUH+/J3kNJ1Bo1xohHBZNIO2efPmWs/FxcXh7bffRs+ePdGlSxc4OdU+ySQQCDBr1ixLbgkASE1NxaFDh/Dcc89hxowZAIBRo0Zh9uzZWL9+PdavX19v2507dyIzMxMbNmxAdHQ0AKB///6YPXs2tm/fjvnz5wMAVCoVNm7ciIEDB+K9994DAEyYMAF6vR5btmxBQkICXGr2SZjbZ69evfDTTz/Bzc2NHc9jjz2GOXPm4JtvvsHYsWMt/kwIIa2rWHE/sHCXWR+g3cu+H/QEtYESTw8yCdCsPChgL5VCKpFApVZTuSdCHmBRgLZp06Z6X0tOTkZycnKdr1kboB09ehQikQgJCQnsc1KpFOPGjcNXX32FvLw8+PrW/QstKSkJXbt2ZQMpAAgNDUWvXr1w5MgRNpi6cOECFAoFJk6caNJ+0qRJ+P3333Hq1CmMHDmySX2Gh4fXGo9EIsGAAQOwY8cOVFZWwtHR0bIPhRDSqkpqZn7spRI42Ntb3R+3SHpIG5xBC/S7n2qDn5OcLsgrKkJ5ZSU0Wi3sxLyl5yTEpln0N2Ht2rV8j8Ms169fR1BQUK3ZOWOAdOPGjToDNL1ej1u3btU5UxUdHY2zZ8+yQdL169cBAF27djW5LioqCkKhENeuXcPIkSOb1Gd9iouLYW9vD6lUWu81hYWFKCoqYn9uqb1+hJDGqdRqVFZVAQDcZZbvxeLiFklvizNogTyWewIMy5x5Nb/jFGVl8HJ3t7pPQtoDiwI0uVzO8zDMU1RUBE9Pz1rPG58rLKy7eK9SqYRarW60bUhICIqKiiASieD+wC8JOzs7yGQyNlhqSp91yczMxLFjxxAfH99gzrhdu3bVuaRMCGl9JZx9U3zsPwPuF0kH2uYMmoO9FJ7urigqUfAyg+b6wEEBCtAIMeB9LlmhUODGjRuoqKiAk5MTOnXqBFdXfr5ZqlQq2NnZ1XpeIpGwr9fXDoBZbVUqFcT1TLFLJBKT68zt80HV1dV46623IJVKsWDBgjqvMUpISMDgwYPZn+/cuYP333+/wTaEkJZRwjkMxMf+M+B+klonR4c2l2LDKNDPG0UlChSVKFBVrYKDff2rAI1xl5nmQiOEGPAWoOXk5OCzzz7DX3/9ZVLuSSAQYODAgViyZAn8/f2tuodUKoVGo6n1vFqtZl+vrx0As9pKpVJotdo6+1Gr1SbXmdsnl06nw9tvv42MjAysWrUKXl5edd7LyMvLq9FrCCGtw3QGzfovohqNFrn5hpWAkADfNpdiwyjI3wd/X70BwLDM2SksyOK+uMlpKRcaIffxEqBlZWVh0aJFKCkpQVBQEGJjY+Hu7o6SkhJcuXIFJ0+eRGpqKr744os6c46Zy9PTEwUFtfc8GJcd6wtkZDIZJBKJyV6u+tp6enoaiveWlJgsc2o0GiiVSnb5sil9cn388cc4deoU/vWvf6F3794Nvl9CSNtWwvMJzqy8+yk22lKR9Ac9eJKTvwCNUm0QYsRLgPbll1+itLQUL7/8MiZMmGDyrY9hGOzatQtr1qzBl19+iXfffdfi+3Tq1AkXL15kl0+NUlNT2dfrIhQKERERgbS0tFqvpaamIiAggN3Mb6yIkJaWhoEDB7LXpaWlmVRMaEqfRl988QX27t2LJUuWYMSIEU1564SQNsi4xGknFsOZh5PYpiWe2m6A9mCyWmsYP7vyykpa4iSEg5dEtefPn8fgwYORkJBQa0peIBDgsccew8CBA3Hu3Dmr7jNs2DDodDrs2rWLfU6tVmPv3r3o1q0be4IzLy+v1mnHoUOHIi0tzSSgunv3Li5evIhhw4axz/Xq1QsymQyJiYkm7RMTE2Fvb28StJnbJwD897//xbZt2/CPf/wDTzzxhMWfASGkbdBqtVBWVAAwzJ7xsRx511YCNB6T1QL3a3Kq1GpU17N3l5COhpcZNL1ej7CwsAaviYiIwMWLF626T7du3RAfH4+vvvoKpaWlCAwMxP79+5Gbm4vly5ez161cuRLJyck4duwY+9ykSZOwZ88eLF++HNOnT4dIJMKOHTvg7u6O6dOns9dJpVI888wzWLNmDd58803069cPly5dwsGDBzFv3jzIOMsY5vZ57NgxrF+/HkFBQQgNDcXBgwdN3lefPn3g4eFh1WdDCGlZ3Nke3k5w2kiAxl3i5CUXmkyGzDzDey9VlsHP2/JDB4S0F7wEaF26dEFGRkaD19y+fRtRUVFW3+u1116Dr68vDhw4gPLyckREROCjjz5qNPWHo6Mj1q5di3Xr1mHLli1s3czFixebZPgHDIGXWCzG9u3bcfLkSfj4+GDx4sW1Zr7M7fPGDcNm2szMzDpPYK5du5YCNEJsTLHJCU6ecqDZSIDm4SaDg70UVdUqq6sJAA/sQytTws+bDkYRwkuANm/ePLz00kvYs2cPxo8fX+v1Xbt24cyZM1izZo3V95JKpVi4cCEWLlxY7zWfffZZnc/7+PiYvQduwoQJmDBhQqPXmdPnnDlzMGfOHLPuSwixDSYHBHiaQbvHSbHh7to2U2wAhq0rgX7euJGRiez8Quh0eohElu+YMa3JSfvQCAF4CtDOnz+PuLg4fPLJJ9i2bRtiY2Ph4eGB4uJiXL58GZmZmejbty/Onz+P8+fPs+2sLf1ECCGtxaRIOg8nODUaLXJqUmwEB/i02RQbRkH+PriRkQmtVof8wmL4+1o+6+XG+fxK6CQnIQB4CtC4tTnv3buHe/fu1brmzJkzOHPmjMlzFKARQmxVcakhQBOJRJA5O1vdX3ZeIZtiIzjAz+r+mlvAAyc5rQnQXBwdIRaJoNXpTAJfQjoyXgK01qrNSQghrUGr1UJRXg4A8JDJIBRafyD+XnYu+ziYswm/rQp64CRnX3SzuC+hUAg3mQsKS0qhKCuHTqdrsAQeIR0BLwFaa9XmJISQ1lCiVLIVUzzc+DogcH+zfXBg259B4/skp7vMFYUlpWAYBoqyct4+V0JsFS950AghpCPhnuD0cHXjpU9ukXSbm0HjI0Bz5e5Do2VOQihAI4SQJjLuPwP4m0EzSVJrAzNoft6eEAoNBxmycmuX4GsqbqoS7glZQjoqiwK0d999F0ePHrX4pta2J4SQ1lRkMoPGT4BmTFLr5GDfplNsGNnZieHnbahNnMlDNQHuDFoxzaARYlmAdujQIdy+fdvim1rbnhBCWlNxaSkAQGJnx0sNTq1Wi5y8mhQbgb5tPsWGkbHkU1l5JZRlFVb15ersDGHN+6YZNEKsOCRw/fp17N+/n8+xEEJIm6fWaFBeWQnAMHvGRzCVnVcInV4PAAjyb7sVBB4U6OeNszWPM3Py0c0l3OK+RCIRZC4uKFUqUVpWBr1ez8vpWEJslcUB2okTJ3Dy5MkmtzOefCKEEFtkuv/MjZc+uSWeQtpwiacHcYPJzJx8dOtieYAGGBL+liqV0Ol0KKuoMCkBRUhHY1GAtmLFCqtv3LlzZ6v7IISQllasKGUfe/K0/4wboAXZVIBmmgvNWh6urridmQnAkMqEAjTSkVkUoI0ZM4bvcRBCiE0oaoYTnLZSJP1B/OdC46TaUCgQFhhodZ+E2Cpa4CeEkCYoboYTnLYaoAVyAjTue7CUaS40OihAOjYK0AghxEwMw6Co5gSng70UDvb2vPRrDG4cHezh4WZ94fWW4uzowI6XjwCNWzS9mE5ykg6OAjRCCDFTZVUVqlUqAICnmzsvfZqk2AiwnRQbRsYZv8LiUlRVq6zqy04sZgvPlygUdKiMdGgUoBFCiJkKS0rZx17ubrz0yU2xYQslnh7EPdTALVdlKeOysUarRVmFdbnVCLFlFKARQoiZCktL2MdePM2g3bOxEk8PCjbZh8bDSU7OwQvufj9COhoK0AghxExFJjNo/AdoQTY4g8Y91MDHPjRu6hJuzjlCOhoK0AghxEzGGTSRUAg3GT85urjpKWzpBKcRN1ktHwEaN/lvESfnHCEdTYsFaBqNBhW0n4AQYqM0Wi1KlWUADEEEX2WI7mTlso9DbHGJM4CbC42Hk5wuLmxNTppBIx2Zxb9hpk2bhp9//tnkuTNnzmDdunV1Xv/9999j3Lhxlt6OEEJalbFAOgB48lTiCQDuZuYAAJydHG0qxYaRi7MTO5vIxx40kUgE15r+SpRK6GsOUBDS0VgcoOXm5qK8vNzkuZSUlFpBGyGEtAeFnACNrxOc1So1cvKLAAChgX42l2LDyDiLll9YjGorU20AgIerGwBAr9dDUVbe8MWEtFO0B40QQsxQWMI5wcnTAYHMnHw215ctLm8amRRNzy2wuj/uQQHah0Y6KgrQCCHEDNwTnHwtcRqXNwEgNMh2A7TgQE6AxstBATrJSQgFaIQQ0ghuiScXJydIJRJe+rX1AwJGwdyTnLwkq3VjHxfTDBrpoChAI4SQRijKyqHRagHwt/8MMA3QQoP8eeu3pXFPcvKRakPm7ASRSASAZtBIx0UBGiGENKKguJh97OXuwVu/dzkBmi3mQDPilnu6l2V9gCYUCuFRUzhdUV4ObU1wTEhHIram8cGDB5GSksL+nJWVBQBYtmxZrWuNrxFCiK0pKLkfoPl48Big1exB8/X2gIO9lLd+W5qrizNcXZygKKvAXR5m0ABDrrmCkhIwDINihQI+np689EuIrbAqQMvKyqoz8Dpz5kyd19vqEXJCSMeWX3Q/QPP24OcEZ6myHIoyQ/JuW95/ZhQS5I/LV28gv7AYVdUqqwNOL3c3pN82PC4sKaUAjXQ4Fgdo27dv53MchBDSJjEMw6bYcHJ0hKODAy/93uGe4Ay03f1nRiGBfrh89QYAw9JtVGSoVf1xU5kUcYrUE9JRWByg+fnZ/jc+QghpjKKsDGqNBgDPy5vt5ASnUSjnPdzJtD5A46YyKeSkOCGko6BDAoQQ0oD8Yv6XN4EHZtBsOAeaETdA4waflrKXSuHs6AjAkCTYmNCXkI7Cohm0Dz/80OIbrlixwuK2hBDS0rgnOPmdQbu/mb49zKCFcNKE3MnKaeBK83m5u6O8shIarRbKigq4Ojvz0i8htsCiAG3fvn11Pi8QCOr8lmN8XiAQUIBGCLEpBSYzaPwFaMYgxk4shr+PF2/9tpYgfx/2dz0fM2iAYZkzo+YgWlFJCQVopEOxKEB78ICAXq/HZ599htTUVEyZMgU9evSAh4cHiouLcenSJfzyyy+IiYnBkiVLeBk0IYS0BIZhUFBs2KDu7OgIB3t7XvrV6nRsEBMS6AeRyPZ3m9hLJfD38UR2XiHuZOayX8qtwT0oUFhSiojgYGuHSYjNsChAe/CAwPfff4+rV6/i22+/hZfX/W+CISEhkMvlGDt2LJ555hkkJSVh5syZ1o2YEEJaSKmyjK0gwOfsWWZOPrRaHQAgPCSAt35bW0iQP7LzClFRWYXiUiU83V0bb9QAbtUGbrF6QjoCXr62/fbbb4iPjzcJzri8vb0RHx+P3bt383E7QghpEfnFRexjH0/+ArTbd+/nj4xoRwGa6UlO6/ehyZydYSc2zCMYa6ES0lFYlajWqKCgAJJGigdLJBIUFBTwcTtCCGkR+UWcAI3HGbTbd7PZx+Ehgbz1+6BTynT8XnIJmaoiFGrKEOngi4GyKAx1jYGnnQvv9wt54CRnr9iuVvUnEAjg6eaG3MJClFVUoFqthj1PheoJaet4CdC8vb1x/PhxPPPMM5BKa2ePrq6uxvHjx+Ht7c3H7QghpEXkFnJn0PjLZH/LJEDjfwZNqa3Eqns7sbv4nMnzN6tzcbDkEpyEUqwMfxLxbt15va/JDBpPBwW83N2RW1gIwHBQINDXdmuWEtIUvCxxjh8/HtnZ2Vi0aBGOHz8OhUIBAFAoFDh+/DgWLVqE3NxcTJgwgY/bEUJIs9NotSiq2ffk4eoKKY8zN8YlTpFQiJAAflNsZKqK8ETqJ7WCMzHn132FXoUXb36Lr3J+5zW/WCgn1QZfJzm5+9CMBzYI6Qh4mUGbMWMG7t27h3379uFf//oXANOUGwzDYMyYMZgxYwYftyOEkGZXUFwMfc3vMN969tdaQqfTs/uzggJ8YWfHy69hAECZrgpLbmxErqYUAOAstMfLwQkY4dYDTiJ7pFTew9a8JBwsuQQA+H/Z+yCEAHP9R/Byfx8vd0ilEqhUatzJ5CdA4x7O4KY8IaS94+U3g1AoxIoVKzB69Gjs378fN2/eRHl5OZydnREZGYlRo0YhLi6Oj1sRQkiLyOMsb/p68be8mZNfCJXaUDqKz+VNDaPDP29+h1vVhgS4oVJvfNXlWfhJ7qeq6OEUilXhT6Or42F8nrUXDBj8v+x9kDuHoY9LJ6vHIBQKERLgi+u379WcVNVCLLbunxkPV1cIhULo9XoK0EiHwt9XNwByuRxyuZzPLgkhpFUY9z0BgJ8nfzNo3AMCEcH8BWhf5/yOv8quAQDcRE5Y12muSXBmJBAI8IzfcGj0WqzPOQA9GCy/tRU7uv2Tl4MDoUH+uH77HnQ6HTJzCxAWZF0heJFIBC83N+QXF6O0pi6qxM7O6nES0tZZvAftf//7H53KJIS0SwzDIK8mQJPY2cHdVcZb39wUG3yd4Myozse3uYcAGPaarYn8P4TYN3woa57/oxjg0gUAUKgtw3t3fuJlLNy0Idz3ag1vT1rmJB2PxQHaf/7zHzzxxBOYP38+tmzZgps3b/I5LkIIaTXllZWorK4GYDi9aW1GfK5b9/g9wckwDFbe/QUaxpD4dpZfPHq5RDTaTiQQ4oPwJ+EpNsyaHVFcwZmy61aPhxt0cmcLrcHdh5ZPARrpICwO0L766is89dRT0Gg0+Oabb/DMM89g+vTpWLduHZKTk6HX6/kcJyGEtBiT5U0e958BQEZN0CIQCExOPVpqX8kFNrAKkLhjnv+jZrf1tHPBC4Hj2J8/ubcLOsa6391hnGXbWzwFaD50UIB0QBbvQYuKikJUVBTmzp2LnJwcHD9+HCdPnsQvv/yCn3/+GS4uLhg0aBCGDBmCvn37wp6nGnaEENLc8jgBGp8nOBmGwe2aGbQAXy/YS61L3aHRa/FZ1l725+XBj8NB2LQ+J3j2wY/5x5FWlYX0qizsKTqHx7z6WTymkEBfiIRC6PR63pY43V1dIRKJoNPpUFBEARrpGHg5JODv74+pU6di6tSpUCqV+PPPP3H8+HEkJSVh//79kEgk6N27Nx566CEMGjQI7u61N64SQkhbkVPACdB4TFCbV1CMyirD0mk4DwcEEovOIkdtyA02WNYVw9ximtyHUCDEy8EJmHdtPQDg8+y9GOPRCxKhZf88SOzsEBTgizuZObiTmQOdTm91MXiRUAgvNzfkFRVBUV4OlVrNa146QtoiXk9xAoBMJsPo0aMxevRoqNVqnDt3DidOnMCff/6JU6dOQSgUolu3bvh//+//8X1rQgixmkqtZgtze7i5wr6O6iiWun77Hvu4U3iwVX1p9Fp8k/sH+/NzAaMs7qufS2cMdY3BUUUKCjRK7Ck+h8e9BljcX3hIAO5k5kCl1iAnvxBB/j4W92Xk7eGBvJrSWwXFxQjy4zfBLyFtDe8BGpdEIsGgQYMwaNAgMAyDK1eu4MSJEzh58mRz3pYQQiyWW1jIJtkO8LY+sOC6fvsu+7izlQHa7uJzyObMnsU6hVrV31z/ETiqSAEAfJebhIme/SAUWDbzFREcgCScB2A4KMBXgGZEARrpCHgp9WQOgUCA2NhYPPfcc/j+++9b6raEENIk2fn57OMAX74DtPszaJ3DQyzuR8vosDHn/uzZs/4jrRoXYEhi28c5EgCQocrHUUWqxX2ZnuTkZx+aDyfVRh7tQyMdgMUzaB9++KFF7VasWGHpLQkhpNnl5N/P7xjg3XAusaa6kWEI0CR2dggOtLzod1LpFWSpDUHKQFkUejiH8TE8zPaLx7kbhpRJm3MPW1xMnZs+hJtWxBruMhnsxGJotFqTQxyEtFcWB2j79u0z+1pjXU6BQEABGiGkzdJotWyeLTcXFzg6OPDWd7VKzRYQjwgNgFgksrivH/KPs49n+Q6zdmisIbJodLL3w43qXCRXZOBSeQZ6WhD8hQb5s7/3+ZpBEwqF8PX0RGZeHiqqqlBeWQlnR0de+iakLbI4QFu/fr1Z12VmZmLTpk3IzubnWxQhhDSXvMJCNodjgA+/y5u37mRBrzfsbbNmefNqZSYulN8CAETY+7LVAPggEAjwtO8wvHlnGwDgp4I/LQrQ7KUSBPh6ISu3ALfvZrNf0K3l6+WFzDxDrdHcwkJ0CrH8cySkrbM4QOvWrVuDr5eWlmLz5s3Ys2cPNBoNYmNj8eyzz1p6O5ZarcY333yDgwcPoqysDJGRkZg7dy769u3baNuCggKsW7cOZ8+ehV6vR1xcHJYsWYKAgNrH3ffs2YNt27YhNzcX3t7emDJlCiZPnmxxnzt37sSFCxeQmpqK/Px8jB49Gq+99prlHwQhhHfZnOVNf5/mWd4ErDvB+SNn9myGz0O8VjkAgFEecnySmQilrgoHSpKxLPgxuIqdmtxPeEggsnILUFWtQl5BMfx8rE9Xwi1an0cBGmnneD8kUF1djc2bN2PGjBn43//+h8DAQHzwwQdYt24dune3bD8D17///W/s2LEDjz76KJ5//nkIhUK88sor+PvvvxtsV1lZiRdeeAHJycl46qmnMGfOHFy/fh1LliyBQqEwuTYxMRGrVq1CeHg4XnjhBXTv3h1r167FDz/8YHGfP/74Iy5cuIDw8HCIrFjaIIQ0n5wCzgEBnmfQrt3inOAMsyxAK9KUYV/xBQCAi8gB4z168zI2LnuhBAmehi+8akaL3UXnLOqHW5Pz5p1MXsbmyylan1tYxEufhLRVvKXZ0Ol02LVrF7777juUlJTA29sbS5YswejRoyEU8hMHpqam4tChQ3juuecwY8YMAMCoUaMwe/ZsrF+/vsFl1507dyIzMxMbNmxAdHQ0AKB///6YPXs2tm/fjvnz5wMAVCoVNm7ciIEDB+K9994DAEyYMAF6vR5btmxBQkICXFxcmtQnAHz22Wfw9fWFQCDAqFGW5ysihDQPrVaL3JoEtS5OTnBxavqsUUO4M2iWptjYVXSWrbk5yas/HEX85WjjmuI9EN/nHwMA/FRwCk/6PNzkmbrI0CD28c2MTAzu29PqcTnYS+Hq4gJFWRkKi4uh0+noCy9pt3iJnI4cOYKnn34aa9euhUajwYIFC/DDDz9g7NixvAVnAHD06FGIRCIkJCSwz0mlUowbNw4pKSnIq9mbUJekpCR07dqVDaQAIDQ0FL169cKRI0fY5y5cuACFQoGJEyeatJ80aRKqqqpw6tSpJvcJAH5+frwvRRBC+JNdUABdzf6zID/LT1jWhWEY3KhJseHt6QY3VxeL+vi18DT78xNeA3kb34PC7X1NUm6cLb/R5D46R9wPQq9x0otYy1jZQafXswmFCWmPrIqeLl68iAULFuCdd95BXl4epk2bhm3btmHmzJmQ8ph92+j69esICgqC0wPfbI0B0o0bdf8S0ev1uHXrFrp27VrrtejoaGRlZaGyspK9B4Ba10ZFRUEoFOLatWtN7pMQ0vZl5uayj4P9rC9izpVfVAJFWQUAoJOFy5vnym/irsqwR66vSyeE2PO7R+5BU7wHsY8TC882uX1YUAA7u3WDxwDNz5uWOUnHYPES57Jly3D27FkIBAKMHj0ac+bMgQ/PezYeVFRUBM866uIZnyusJzeOUqmEWq1utG1ISAiKioogEolq1Qu1s7ODTCZDUU2pkab0aY3CwkL2ngBw584dq/ojhNTtXs79AI3vGbQbt61f3vy18C/28WQryjCZ6xG37nAR2aNMV41DpX/jdd3kJi2p2tmJER7sjxsZmcjIzIFao4HEzs7qcXFroxryoUVZ3SchbZHFAdqZM2cgEAjg6+uLoqIifPzxx422EQgEWLVqlaW3hEqlgl0df8ElNUVzVSpVve0AmNVWpVJBLK77Y5FIJCbXmdunNXbt2oXNmzdb3Q8hpH6VVVUoKi0FYCgpxGf9TQC4ej2Dfdwloulf2hTaCvxRYjgI5SpyxCNusXwNrV5SoR1GusvxS+FfqNKrcaj0MiZ49mlSH53DQ3AjIxM6nQ6372YjKtK6clQA4OnmBrFYDK1Wi5yasly0fYS0R1YdEmAYBjk5OcjJyTHremv/EkmlUmg0mlrPq9Vq9vX62gEwq61UKoVWq62zH7VabXKduX1aIyEhAYMHD2Z/vnPnDt5//32r+yWE3HfPZHmT/xqPV2/cZh936xLR5PZ7is9DzRh+L03w7AOp0PqZKHOM9+yDX2pm7vYUnbMgQAvGvprtuDcy7vESoAmFQvh5eSIzNw8VlZUoq6iAzNnZ6n4JaWssDtC2b9/O5zjM4unpiYKCglrPG5cAvby8ar0GADKZDBKJxGSpsL62np6e0Ol0KCkpMVnm1Gg0UCqV7PJlU/q0hpeXFy/9EELqZ7L/zJ//AC31miFAc3ZytKhwOHcP2KQWWN40inMKR6DEA1nqYpwpu458tQI+Elez23PzvV27dQ/jhvMzrgBvH2TmGg6FZefnU4BG2iWLAzS/ZviW2ZhOnTrh4sWLqKioMDkokJqayr5eF6FQiIiICKSlpdV6LTU1FQEBAXCsKRnSuXNnAEBaWhoGDrx/SiotLQ16vZ59vSl9EkLaLoZhcK/mH3uxSAQ/nr8QFRSVoLC4FAAQ3TmsySsJ6ZVZSK8ylEvq7hiCTg4t97tXIBBgnGdvfJXzO/RgsK/4Amb5xZvdnrvfjs+DAv6c/c7Z+QXoGtH0WUlC2jreE9U2p2HDhrH51ozUajX27t2Lbt26wdfXsLE3Ly+v1mb6oUOHIi0tzSSgunv3Li5evIhhw4axz/Xq1QsymQyJiYkm7RMTE2Fvb28StJnbJyGk7SoqLUVlVRUAQ3JavvNqGWfPAKBb5/Amt9/FSRRrTCDbksZ73F/W3FPctKS1nu6ucK9JKXL99l0wDMPLmHy9PNkUTjn5+Y1cTYhtsmgG7cMPP7T4htYUS+/WrRvi4+Px1VdfobS0FIGBgdi/fz9yc3OxfPly9rqVK1ciOTkZx44dY5+bNGkS9uzZg+XLl2P69OkQiUTYsWMH3N3dMX36dPY6qVSKZ555BmvWrMGbb76Jfv364dKlSzh48CDmzZsHmUzW5D4B4OTJk2waEK1Wi5s3b+K7774DAAwZMgSRkZEWfy6EEMtlZN2vExwSwG96DQBIvW55gKZhdNhbfB4AYCcQYbSHnM+hmSXU3hs9nELxd8UdXKvKQXplFqIcA81qKxAI0Ck8GGeTU1GiKENRiQJeHm5Wj0ksEsHX0xM5BQVQlJejorISTrRiQdoZiwK0ffv21fm8QCCo8xuS8XmBQGBVgAYAr732Gnx9fXHgwAGUl5cjIiICH330EeRyeYPtHB0dsXbtWqxbtw5btmxh62YuXrwYbm5uJtdOmjQJYrEY27dvx8mTJ+Hj44PFixfjiSeesLjPo0ePYv/+/ezP169fZ3Ou+fj4UIBGSCvJyMpiH4cFmhd4NAU3QItuYoD2pyINxdpyAMAw1+4W1cTkw3iPPvi7wrAqsaf4vNkBGmA4yXk22bAN5UbGPV4CNMAw25lTsyc5O78AncOsP4BASFsiYCyYc87lbKgFDElbP/vsM6SmpmLKlCno0aMHPDw8UFxcjEuXLuGXX35BTExMvYXJifnS09Mxb948fP3114iKovw/hFijsqoKm/+3E4AhfcO0sWN47Z9hGDw6YzEUynK4u7rgwI+fN2kP2ss3N+OPUkN6jc8in8FQtxhex2euUm0Fhv/9NrSMDt52MhyIfRMigXk7ZPb8cQLvfPo1AOD5OdPwjyljeRnTvZwc7D6SBACI6dQJQ/u1/PIvIc3Johm0Bw8IfP/997h69Sq+/fZbkxOHISEhkMvlGDt2LJ555hkkJSVh5syZ1o2YEEJ4wl3ebI7Zs5z8QiiUhhmw6M7hTQrOFNoKHFWkAAA8xM4Y5Fq7aklLcRM74SHXaBwpvYICjRKny65jkMy8L4jcgwJpNzN4G5Oflxe7OpNdQPvQSPvDyyGB3377DfHx8fWmg/D29kZ8fDx2797Nx+0IIYQXzb68ec3y5c39xclsYfRxHr1hJ2jdouAmhwWKzD8sEBkaCKnEkLeNm7DXWnZ2dvDx8AAAlCiUqKyu5q1vQtoCXgK0goICNnt+fSQSSZ05zAghpDVotFo2/5mjvT18PD14v4fJCc4uTQvQEovOsI9b4/Tmgx527QaZyAEAcKj0Mip15lVKEYvFbPWEe9l5UNbUJOVDgO/9dBuZD2y9IcTW8RKgeXt74/jx4/WWNqqursbx48fh7d28xX0JIcRcmbm50OoMM1RhgYHNUi7o76vX2cdNOcF5qyoPKZWGvGFRDoHo4tj6e3clQjFGussBANV6NZIUV8xuy509vHojg7cxcas+UIBG2hteArTx48cjOzsbixYtwvHjx6FQKAAACoUCx48fx6JFi5Cbm4sJEybwcTtCCLHazbv3E6eGBfG/vKlSq9kZtOAA3yadXtxVdL9ywGNtYPbMaKxHL/bx3qILZrczCdA4p1qt5e/tDXFN3rp7Obm85VkjpC2wqhan0YwZM3Dv3j3s27cP//rXvwCYptxgGAZjxozBjBkz+LgdIYRYRavV4nZmJgBAamfXPPU3r2dAU1PXt2e3zma30zF6NiGsGEKM4QRFrS3OORx+dm7I1ZTiT2U6ijXl8LBrvMwSd3mXu+xrLZFIhAAfH9zNyUFFVRVKlEp4uJpfioqQtoyXAE0oFGLFihUYPXo09u/fj5s3b6K8vBzOzs6IjIzEqFGjEBcXx8etCCHEaneyc9jgKTw4mPfqAQCQnHKNfSyP6WJ2u7+U11CgUQIAHnLtZlYA1FKEAiFGe8Rhc94R6KDHH6WXMNV7cKPtQgP94WAvRVW1itcZNMBQO/VuTg4AQ+oNCtBIe8FLgGYkl8sbTRhLCCGt7QanFFzn0JBmucclToDWswkB2m7O8uYEzz4NXNk6xnr0wua8IwCA34oumBWgiURCdO0UhotX0pFbUITiUiU83GSNtjNHEGf2815uHnp2bb10JITwyaZqcRJCiLXUGg0ysg35zxykUgTW1PDlk16vx6WaAwLuri4IDTRvCbVMV4XDpZcBAG4iJzzs2o33sVmri0MAIu0N7ye54jayVMVmtWuufWgerq5wdDCcLs3Oy4Ou5uAHIbaOAjRCSIeSkZnF/iMeERLMFt3m0607WSgrrwRgmD0z94ToweJkqBjD0usYjzjYCXld5OCFQCAwOSywv+SiWe26dQ5jH6fyGKAJBAIE+xmCbK1Oh9zCQt76JqQ1UYBGCOlQrmVksI87hzZP/cbkVM7+s27mL2/u4iSAbQu5z+oz2uP+nuK9RefNatOtSwT7mM+DAgAQ7H+/yD23OgQhtowCNEJIh1FWUcFuKHdxcoJ/M+VmTE65n/9M3t28AO1OdQGSKwyBS6S9H6Idg5plbHwIknpC7hQGALhRnYvrVY0HRUH+PpA5G4q9X067wWtKjBB/f3aWMiMzk9JtkHaBAjRCSIeRdotTeikiolmS0zIMg4uX0wAA9lIJoiLMO4SwmzN79phn32YZG5+46T/2FjeeE00gEKBHTboRhbIcdzJzeBuLvVTKBtuK8nKUKst465uQ1kIBGiGkQ9Dr9bh68yYAQ7AQFdG00kvmunU3C/lFJQCAuO5REIsb30em5+Q+E0KAsZ69m2VsfHrUvSdENf+E7Cu+CD2jb7QNN90INw0JH8I5yYYzsjJ57ZuQ1kABGiGkQ8jMy0N5pWHjfrC/P1ycnJrlPqcv3C+BNKBXd7PanC27iRy1IagbJIuCtx0/KSiak6edCwbKDAFXjroEyRUZjbaRcxL28h2gcYvd387K4rVvQloDBWiEkA7h6o2b7ONukRENXGmdU9wArXesWW24uc8SPPvxPqbmwl3m3MNZoq1PdJdwSOzsAPAfoLm6uMBdZghscwsKUVVdzWv/hLQ0CtAIIe1eWUUFbtWUdnKwlyI0kP/amwBQrVKz+898PN0RHtx4kfNKnQp/lP4NAHAROWCYW0yzjK05POIWCwehBABwsOQSVHpNg9dL7OwQU1P2KSu3AAU1S8F84dZUvZNNpzmJbaMAjRDS7l2+do092RfTqTNEzZD7DDBUD1CpDUHKgN6xZm30/73kEqr0agDAKHc5pEK7Zhlbc3AUSTHCrQcAQ5Ldo4qURttwqypcSr3ewJVNx13mvHn3Hq99E9LSKEAjhLRrao0GqTXLmyKhEN07d2q2e526cJl93D/OvP1nO4vOsI/bcu6z+nDLUe0yY5mzOQ8K+Hl5wammqsC93FxUq9W89k9IS6IAjRDSrl29eRNqjWFWq0t4GFsWqDkYDwgIBAL0i2t8qfJ2dR4ulN8CAETY+6KHU/Mkzm1OfV06wc/ODQDwpyINRZqGU1z0iO7EzizyHaAJBAJ0CjGkNdHr9bh9j2bRiO2iAI0Q0m7p9Xr8nc4pWt6MhbTzCotxI8Owz61b53C4yZwbbfO/wtPs48e9BvCe+0xTrUXBLQWyLhfizrk85F0rQUVRFRg9f4lchQIhxtfMoumgbzQnmouzEzqFGZLwXr99F2XlFbyNBQA6capDXL9zl9e+CWlJba/QGyGE8CT99m2UVRgCgBB/f3i4ujbbvQ6fuL+8N7hvj0av1+i17JKgnUCE8TzlPtNpdLh+LAu3z+Qh52oR9NrawZiDmxQRA/zQaUggvCOs/0wmePbBxtw/AACJRWfwlM/DDQabvXtE4/rte9DrGZy9dBWPDO5T77VN5ePpAZmzM5Tl5cjKy0NldTUc7e1565+QlkIzaISQdkmn0+Hs5fspL3p3b97TkYdP3k+VMfyhxlNlJClSUKItB2A4DekubnzGrSF6nR5X/7iLHS8dw4lvUpB1ubDO4AwAqkpVSNl/B4lv/InfV5+HIse6Wawwex/0rCn9dL0qB1cqG5654uaH+4uzb48PAoEAnUINy5wMw+AWHRYgNopm0Agh7VLqzZtsYtoQf/9mq7sJAAVFJeyJxPDgAESENJ7G45fCv9jHj3sNsOr+yrwKJH3xN/Kvl5o87+Rpj8DunnBws4dYIkSVUg1lbgWyU+7PrN05n497yQXoNbkzeiZEQCC0bJl1kld/XKpJVvu/wtOIbWA/Xe/YrrATi6HRavHX+StgGIbX5d3OoaG4kJIKALh2JwPdu3RupAUhbQ8FaISQdkej1eL8lfspH/r1bHzJ0RpH/jzPpvF4ZEjjJzEzqvNxSpkOAAiUeKCfi+UnS2/+mY0TG69AU61jnwvp5YO4SZHwinCtM/BRVWhw889sXPzfTVSVqqDXMTi34xpy00swbGEP2LtImjyOUe5yfHxvJyr0Kuwrvoh/Bj0GR5G0zmvt7aWQd++Cs8mpyMkvxN2sPIQG+TX5nvXxcHWFh6srihUK5BYUokShhLtr26/OQAgXLXESQtqdS1fTUFmTST4iOAg+Hh7Nej+T5c0hje+n2l5wkn08zXswhIKm/ypmGAYX/3cDR9ZdYoMzFx8HjH+zP0b+sze8I93qnZWSOtmh26OhmPrpw+iZEAHUXJZ5qQC73jwFZV5lk8fjKJJitEccAKBSr8L+kosNXj+w1/0qC82xzBnNqRZx9dbNBq4mpG2iAI0Q0q4oy8txPtWwvCUQCNAvtnlnz4pKFLh4xTAbFhLgi05hwQ1eX6GrRmKhIfeZvcAOE72aXtpJr2dwYuMVnP/pfqLXzg8HYtK/h8Cvq/nBqJ29GH2nR2HMir6wlxlmzZR5ldjzzl8ovtdwuoy6cJdqf+Us4dZlQG/OPrTz/AZoANAlLBzCmoTE6bduQ6fTNdKCkLaFAjRCSLty/Nx59h/jHlFd4OHWfCc3AeD3Y6eh199f3mxsL9XuonOo0KsAAOM8e8NV3LSi7Xo9g+MbLiP9SCb7XN8ZUXh4QSwkDpbtWgmM9cKklYPgFmg4qFBZqsJv755G0V1lk/qJcQxGlIOhvNXliru4WplZ77WdwoLh6W74/+bc31fZXHV8cbCXIiLIkM6jSqVCBhVQJzaGAjRCSLtxOzOTrcHo6OCAvrHmFSu3FMMw+N/+JPbn0fEDG7xez+ixreAE+/MMnyFNu5+ewbEv/8b144ZgQyASIH6JHD0nRFi9yd7J07A86h1pCJpUFRrs++Bsk054CgQCPOE9iP35v/knGrzWeJqzWqXmPWktAER3imQfp96kZU5iWyhAI4S0C1XV1Th65v5esMFxcZDYNW9dy7+v3sCtO4ZgqWe3zogMDWrw+mOKq7hdnQ8A6OMcic4OjRdT5zr9QxpunDAEoAKRAMOflyNyoL8FI6+bvYsEY17rB5/ObgCAaqUae1eeQXlhldl9jPPoDReRoVrDvuILKNaU13vtoD492cdHTp63bNANCPL1hczJMEN5LycXirKmL9sS0looQCOE2DyGYZB05gx7MCDE35/NhdWcuLNnk8YMa/BahmHwbe4h9uenfRu+/kGX997GlX0ZAACBUIDhz8chrC9/Jx+NJA5ijFrWBx6hLgCAiuJqHPj4PNSV5i1BOoqkmOhp2FenZrT4XwN70Yb06wmpxBBEH/7zHHQ6vZWjNyUQCNCt0/0TspfS0nntn5DmRAEaIcTmXb15E7czDTNZ9lIpHhnQn/eySQ9SllXgj2OGUk0uzo4YPqThzf7ny2+yecI62fvhIddos+91668cnP4+jf15yNwYhPX1bfqgzSR1tsOYFX0h83UEAJTcK8ORdZegNzOAmu4zBIKao6E7Cv6Elql7g76jgz0G9jEc4iguUeBSKv/LnN06RUIsEgEA0m7dQrVKxfs9CGkOFKARQmxabmEhjp+7vzwW379fsxZEN9p35E+o1IZZpbGPDIa9tOHcYd9wZs/m+A03O7VGztViJH1xif057vFOiBrW8ElRPji4SjFyWW9InQwzXPeSC0yCxIYEST3ZADRXU4rfS/6u99rhg+/njTt88ly911nKXiplU25odTqk3LjB+z0IaQ4UoBFCbFZZRQX2HTsOnd4wsxPTuRPCgxreB8YHjUaL73/Zx/48cfSwBq9PrbiHP2sS0wZIPDDKQ27WfUoyy/D76vNs1v8uQwPRa7LlSW2byi3AGcNfjINAZJgNSzlwB6kH75jV9imfoezjTbmH2ES+DxrSX87uFTx88iz0en6XOQGgR1QU+/hy+jVKuUFsAgVohBCbVK1WY+/RY6iq2XcW4OODIb16tci99x4+idyCIgDA4L490Sms4aDw8+y97OPZvvEQC0SN3qOipBoHVp2DulILAAjq4YUhz3Rv9qXbBwXEeOKhZ+7nLDv1XSruXSpotF0/l06IcTTM9KVXZeOksu7ZN2dHBzYnWkFRKS5f5X+Gy9XFBRHBhrFUVlcj7fZt3u9BCN8oQCOE2ByVWo3dh4+gqLQUACBzdsboh4ZAJGo88LGWVqvFt9t3sz8/MyOhwevPlF03mT2b5NW/0Xuoq7Q4uOocygsNwadnmAyPvBAHobh1fmV3GRZkqDgAgGGAw59dRElmwyciBQIBnvEbzv7MXeJ9EHeZ88DRhhPcWiou+v6ev3NXUqClWTTSxlGARgixKdUqFXYfSUJBcTEAQ0LScUOHwl5ad91Hvu1P+gvZuYYZpP5xMYjtWv+SI8MwWJv52/9v77zjmrz2P/7JIAkj7CWgKCBTsQ7QVlnuUVwtVTvUtti67fDqbX+1vWqtdde2VqtXr7e9rRWtW0BBRaW14sDFUJAlG9mBEEjy/P4IPBDyBAImEOx5v168wnPG93y/z8mTfHPG99DXix0mgsduO5isXCrHhW8SUZqtcIBMrA0x4R9DOx2EVlsMe80dff0VGxMaxDKc33IL4qq2F9yHmA+Ai0BR57YoA4ki5pGrwBGDwW9cwxd16Rrq6rS/kN/O2gp9HRWH2NfU1iIpLa2dGgRC90IcNAKB0GMor6rC7+fOo7hUMb1oyOdj2ugxXXYQdp2kHvt+PUFfh78+vc3yFyru4UFtDgCgv2EvTLZsewqWoijE73+AvPtPASjOzJywehiMLATPpLc2YLFZCF40CNb9FPe6ukSM2B2JkDWoH4lis9h42340fb0rP4pxLZqJsRHGBypGFkU1tYi5mqBl7RX4+zYHLr6dlIwGLZ9eQCBoE+KgEQiEHkFWXh6OnTuPSpEi8KmhQICpY0br/Cinlvznt1P06JnfC954wcddbdlamQRbc0/R18scJoPTzs7N27+n49FlRbgQjgEb4z4eAovG45f0AS6fg3EfD4WRuWK0suhhOf44kKR2AwAATLIcgj58awDAjep0XKtmDqUxc1II/X/L+HLaxNrCAm59FPHxxBIJ7pC4aAQ9hjhoBAJBr2mQShGXkIDIy1cgaRzxsDI3x6sTxsPK3LzL9MjMycdPvysW+3O5HPxj4Vttlt9bEIOC+nIAwAihOwLNvNss//DSEyQea1wgzwKCFvl26ODzrsLYUoBxHw8Bx0Dx9fHoch7un1W/6N6AxcESh0n09c7cM5BTqjs1fTxc0L+fYiH//ZR0pGc+0bLmCvx8B9IbLW4nJ6NKpP6kAwKhOyEOGoFA0EsoikJaVhYOnTmL5PTmcxT7OTlhxrixEBp37JDxZ0Eul+PrXf+FVKqYzpv7ymT066P+mKZ0cSF+LooDoHBQPukzs83dl08SixG/P4m+Hv66J1xGaO8IJ21j42qOoEW+9HXCoYfIvlWktvx4i0HwNFSs/0oV5+F8+V2VMiwWSylcybGoS9pTuAUWpqYY6K4Y+ZTJZIi/dVsn7RAIzwpx0AgEgl5BURQyc3Px+/kYxPx5DaLaWgAAl8NBkL8fJgaM0vkZm635968ncfu+IkyEo70N3p6tfuemlJJhfXYEpFCMEr1jPwZ9BbZqy5c8rsCFb++AkiumCQdM6ouBU/ppUXvd4DKiV3NMNgqI23UXpTlVjGXZLDZWOL1MX+/MO4NamepGgEkhL9KbBU7HXEVZBbO8Z8XfdyAdzDgrLw9ZjadQEAj6BHHQCASCXlBbV4c7Kan47Wwkoq5cpTcCAEAfBwfMmjwJPm5uXR4HLD7hDr0xgM1m4f+Wv9PmqQH/LojFncYjnXrzrfBOi0XyrakqqsG5LbcglShG5vqNsMfwNzy1pruuGTzTjR7pa6iTIWbrLdRWMu/AfFHojhFCxchVfn059hXGqJQRmhhj+gRFgNs6ST1+OR6tE715BgYYOXgwfX355k3U1dfrpC0CobMQB41AIHQLFEWhvLIK9x89wqmLF/HT8RP4MzER5VXNoyaW5maYEhyEl4ODYCYUdrmO6Vm5+Hzrj/T14nlh8HtB/VqyRFEmfiw4DwDggI0Nfd+AgM3szImrJIj++ibqqhSOgb2nBYIW+oLF7loH9FlgsVgIXDgQNi6KjRqip3WI2XILDXVSxrKf9JkJg8YgvT8VxiFdXKhSbu6rk2HAVYQUOXI6FhWVbcdb6yxuzn3gZK8IAVJTW4vLCQltbnYgELoa4qARCASdI5fLUSkSISe/ADcfPMCZuMs48PsxHDp7Fldv3kJuYRHkLb4ce9nYYHJQIGZNmgRnB/VrvXRJWmYOFv3za1SLFFOsIS8Nw9xXJ6stX9pQjU8y/wc5FHa87zAeg0z6MpaViBpwbtNNVBUpZFs4mWDcR0PB5ek+0K624fI4GPvxEBhZKnZ2lmRUInbHbcikqhsB+gps8U5j8Fop5Pgy5whkrTYM2FpbYlrjKJq4ToJDJ87pRG8Wi4WQ4cPB5ykc6Mc5T/CQnDBA0CO6N/IhgUDokchkMjRIpYq/BinqpQ1okEpRVyeBWFKH2ro6iOskqKmtRZVIhKqamnbPWBQaG8OtTx94urrAwrRr4pqp415KOj7613ZUVtcAALzd++Hzj8LVTq/Wyeux4vF+etfmEBMXhNuPZSwrqWlA1Nc38DRTMVJoZMHHhNXDwDfp2nV12sTYQoCJq/xwZt1fqK+VIu9+KeJ23UXI0kFgc5THAd61H4PIslt4IilFoigT/y26RDttTcx7bQpOnIuDVCrDb6di8OrLY2BjZaF1vYXGxgjy98P5+D8AAFdu3oK1hQWsLbTfFoHQUYiDRgAAiGprIZPJoBjEoND40vQfPfTfcgqAoprKNZcHKFAt6rUlg67bbpst81uVY2iTalamhY4MbSi9NsnRoM2mfIpqUY++K826MNwHqllQq7rNMjQrp1yeyRblNlvVadSdksshp+SQyynI5XLIqaZXRRoll0PWmEY1pkllMq0caG3I58PO2hr2Ntbo06sXrMzNu3x9WWsoisIvx6Px/X+O0AdqD/R0xbfrV8LEyJCxjpyS47PMQ7hfowhIa2dgjk393mKMeSaukuDcppu0cyYw5WHSJ34wsWKW3ZOw7CPE+H8MQ9TGBMjq5ci8Xgg2h4WgRb5KThqfbYB/Oc9C+KPdoEBhV14U/IRuGGjsTJext7HCtAlB+P3sRdSK67Bj3yF89c/FOtHbrU8f5LjkIzUjE1KpFJGXr+DVCePpTQQEQndBHDQCACDqylX66BwCQZtwuVyYmZjATCiEmdAElmZmsLe2hqmJSbc7ZC15+DgbO/b9ilv3mg/1HjLQE9u++ECtcyalZPgi6zBiKhRhI4zYfHzn9i5searBc6tLahH99U1UFihG5QSmPEz5zB8WTl2/tk5X2HtYYOwHQxCz/RbkUgqP/ywAABUnbZjQDe/aj8G/C2MhhRyfZP4Ph7w+gpDTfJ8XvjkTsVcTUFklQsyV6wgdF4AXhw5UaVMbBA4bhrKKShSXlUFUW4uoK1cxdcxoei0cgdAdsCiyKrJH8fDhQyxYsAD79u2Dh4eH1uQeiT5HHDQCWCwW2Gw22K1f2Ww6j8Nmg2dgAAMuFwYGXMUr1wAGBlwIeDwYCgQwFAhg1PhnKBDolSPWEoqicD/1MSJOxeD8letKI8TzX3sZ7781E1w1B7A3UDJ8mvk/OqYXB2zsdHsHAQwBaUseVyBm+23Ulit2OBpZ8DHpE7/nyjlrSc7tYsTuuA25THE/ew+2wZjlg8HlN9/LBkqG+anf0UdhjRC64/v+C+hNBIAi1Ma6Hf8GADj1ssWhXV9CINDNmas1YjGOnjuPmsawLk72dpgUGEicNEK3QRy0HoauHLTrd++hqkYEFhRfpIrvU5bqq+KFTlNbnqlc43d00/+sFuWVZDResFTKN6ajZVto/PJvbrOl/OZmm/9vdhaU22CxWpbTpE3VNhSqNJVvUa5VeeY2m+u2dGjUydC8Tab8xn5p4YCxWSy9daS0iVQmw8P0LFxNuIvL124hPStXKd/R3garl8xrc7SmpKEK/8j4L334N5fFweZ+b2GMha9K2UdxufjjP0mQNSimhc16GWPiP/0gtHm+p9CybxXhws5EyKWKrxhbd3OM/3goBMLmXa25klK8kfINKmSKUcVXrEdgTZ8w+n1IURTeX70RiQ8URzJNGTMSX3y0QGfv05KyMpyIvYAGqWIXKnHSCN0JcdB6GLpy0AiE5wlxnQSl5ZUoq6hCaXkFCopLkZNbgMfZeUhJz4JEohrzykxojLdnTUVY6Jg2A+Fer0rDp5n/w1OpIvwDn8XFdte3McrMS6lcfW0D/vo5hT5bEwDsPCww7sMhEJiqj6P2PJGfVIqY7bfQIFas5zOxMcS4j4bAyrl5E8htUQbee7QbDZSiTLj9WCx1mEQ7YVlP8vHW8i9Q19hnqxbPRdjLY6ArCkue4vSlS7STZmtlhUmBATAma9IIXQxx0HoYunLQCotLFYEaWyySp1ovmqcX9zcuhG+9YaBVXVVZzWWbF9g3121ey64sX2mhO0WpyFLVo9VGAyZZLTYqtNZdaYMBk6wWGwWY21eWjZa6tr4PKrJA64lW16qyGDZeUMy6Q8WWFv3HIKtpc4Ry/7XeIMEgq8U9aG1L27Ja1W26lsshk8khk8kglStem66bXusbpBBLJIodpHUS1NZJGB0wdQz0dMXMyaMxNsC/zQC0ZQ0ibM89hdNlN+k0OwNzbHWdB98WC9wBhWNyZe99iErEdJrXuD4Y8ZYXONy/V3Sjp1mVOLfpJsSVij7h8jkY+bYP3AIcaCcssuwWPsn8ha7zpm0gVjpNo/PPX76O/9v0AwCAw+Hg+y//gWGDvKArWjtpxkZGmBQwCrZWVjprk0BoDXHQehi6ctDmrvgXUtIytSaPQNBXHOxtMMDDBUN9vRDg/0K74RvKGkT4uTgOvxX/gVp5c5R8f2F/fN3vTVgZNK8jqymrw/VfUpFxrYBOMxBw8OJ8b7gHOmnfmB5CTakYMTsS8TSjkk7rN9weI9/xoac8fyuOx8Ynx+j8KZZDscY5DIaNgX537DuEXxtPFuDzedj+xQfwf8FHZzo/LS9H5OUr9FFjbBYLwwYOxBBvL7DZfy8nm9A9EAeth0EcNAJBFQGfB0MBH4aGAhjy+TAzNYGVhRkszU1hZWEGa0tzODv1grOTPcyEJu3Kq5dLcaM6DSdLb+BSxQPUU82R8YUcQ6xwnIJXrEeA3RhKo7a8DndPZyD1whN6rRkA2LlbIGiRL0ztjLRvdA9DWi/DnweT8Siuec2fwJQHv9nucA90AovNwvGn17E2O4IenfUwdMBWl3noI7CBVCbDP9btRPwNxaYMPs8AX32yBIHDBzO2pw1qxWJEXbmKohbHjtlaWmLU0KGwt7HWWbsEAkActB6Hrhy0vf87jvyiEpXF5KwW10oL91msFovcG/NaLaJvvdC95aaCJlktF743LXZXXCvLaFroziSreZF88zVz+8qy0Y4tyrJoSUrXrMZrZVkMC/XV6A6Ge9B6E4NSXaX70KL9FrJa6854D+iNEMyymDYeqL4XGDZZqLGls+8FFljgcjngcNjgchSvHHbjK4cDLodNb3J4FkSyOqSJC3C/Jhu3qzNwvTpNabQMAAxYHEy3Go6FDuNhbWAKiqJQ9LAcKbE5yLxeSO9YBAC+iQH85njAI8ipRx3d1BVk/FWAPw4kQSJqoNNsXMwwNKw/HH2tEVtxD2uyDkEsV0yJCtg8LO41Aa/bBYKSyvHJxl248lciXXfuq5OxaO4r4OpoIb9MJsONBw+QmJyiNJXv1qcPhg7wgZW5uU7aJRB6nINWX1+P/fv34/z586iuroarqyvCw8Ph5+fXbt2SkhJ8//33uHHjBuRyOQYPHoxly5bBgeEomTNnzuC3335DYWEhbGxs8Oqrr+KVV17pEpltQTYJEAiqUBSFBkqGekqKBkqKerkUDZSM/r9O3oBKWS0qpTWolNaiQlqDvPoy5EpK8UTyFOXSGrWyLbjGmGI5DHPtgmAFIYrTKvDkTgkyrxdA9LROqSyHx4b3OGcMmuYCgcnfYyNAZ6gpr8NfP6Ug87ryWZw2bmYYMLEvZL7AP7J+QpakmM5zFdhjocN4BBl741/b9iH2agKd5+XWFx++9zoGD9DdZ2JhyVPEJSSgrLJSKb2PgwMGuLmht0MvcMjUJ0GL9DgHbe3atYiLi0NYWBicnJwQFRWF1NRU7Ny5E76+qlvcm6itrUV4eDhqamowa9YscLlcREREgKIoHDhwAGZmzYElT548iW3btiEoKAj+/v64d+8ezp07h/fffx9vvPGGTmW2h64ctE1PjiO7rqR5UTmAlm8MpreJ2rItF9Uz0Bx/X42sFpHv25TPWEc5vV1dKVVdlNtl0JVSlcXUpjod1ekCDe1Sr6t6/VTbZbhH7djFqKua+96uru3Yxdguxay/DBSkjTsAtYUF1wQvmbjDv8EN/QvsUZldi7KcKpRkVEJWr3qKAt/EAB4hvTFgcl8YmekmTtfzSN6Dp/jr5xSUPxEppQtMeXAYaYWLvsk4I72l1N/9BLaYaTUCkvhK7P/vSfrEBwAIGP4CZk8bD79B3joJxSGXy5H8+DES7t1HnUR5hNVQwIdL797o6+gIR1tbnY3oEf4+9CgHLTk5GQsXLsSiRYswZ84cAIBEIsH8+fNhbm6O3bt3q63766+/Ys+ePfjxxx/h5aXY/ZOdnY358+djzpw5eO+992h5r776Kry9vbFp0ya6/vr16xEfH4+jR49CKBTqTGZ76MpBez1lB5Jqn2hNHoHQU7CQGcOm3hTWtUL0KjGHTa4QJpl8SKoa2qzH4rDgOMAKriMd0M/fvkcedK4PUHIKWTcKcftYuoqjBgBl/WpwddxD5AhLldK5YMO91AZlR/JRllehlNfHwQ7BI4dhlN8g+Hi4tBk2pTM0SKVITn+Mu6mp9CaClrBZLFhZWMDe2gp2VtawtbKE0MSEjLAROkSPcvEvX74MDoeDqVOn0ml8Ph9TpkzB3r17UVRUBDs7O8a6cXFx8PT0pB0pAHB2dsaQIUNw6dIl2pm6ffs2KisrMX36dKX6M2bMQExMDK5du4bx48frTGZ3UZEvAsy7VQXt0OLnBov+n8WQxlyvxSorZVkMVViUml/oHZHFVJYhX6lei3aZZKkr2xKtymK4p2rvTTtl1PUPo7wW944jZYMjZ4EjYyv+l7HBlrPo/7lSDgR1XAjqeBDUccGvM4BJtQBmlYbgSlUdKwmYnTMTawF6eVvBcYAVnF6wIdOYWoDFZqHf8F7o62+PgpQypMTkIPtWER3g1jLTGFP3DsYT5zLcGJ6B/N4VAAAp5Ei2KgLeY4OdaAzOBTFY1YrRzZz8Ivx05Cx+OnIWXC4HLv0c4ershN52dnC0t0EvO2vY2VhCaGwEYyPDDq9hNOByMcjTAwPd+yOnoAAPMzKRmZdHn1ErpyiUlJWhpKwM95GmsJPFgtDICKZCE5iaCGFiaAiBgA9DvgCGAj4EfH7jqRxccLlccBpP7yD8felRDlpaWhqcnJxgbGyslN7kIKWnpzM6aHK5HBkZGZg8ebJKnpeXF27cuIHa2loYGRkhLU3xMHl6eiqV8/DwAJvNxqNHjzB+/HidyOxO5l4NRGl249oKpS9nZieDzm/PAWhRrz1ZCnmqEhgdAHUODYHwjLDYLBhZ8GFsIYCZgzEs+whh5WwKyz5CpSj4BO3CYrHg4G0FB28r1Nc2IPtWMbJuFqEgqRT1tVL0ybZCn2wrlFnWINU7H2keRagyFwNsFuRDBZC/wAcrpR6chDqwsqT054ZUKsOjtBw8SstR3zaPDTaPDRaXDXBYYLEb/ziNf/RGj1YnnCj+AQBw2WzYWVigl4U5rIRCmBkp79ylKApVNTWoqqkBUNTu/aAoCtKm+H9yuVLsQzkda5BiTGeUpyy87Xw1+vydkFFybFq+vFt16FEOWmlpKawYAgU2pT19+pSxXlVVFerr69ut26dPH5SWloLD4cDCQjk2koGBAUxNTVHauN1aFzKZePr0qVJ+eno6AMVUqjaRohIsQ9Wh+pZo9mOu8YgWhjpUc7ZaKA0aUs1mtXGlJpHV+lIloV0Z7d4OTe5XK2Pau8ed+UXd3v1iLNNenU74x+21wdxvbRdqTw0Wmw02hwU2lwUOhw2WARscDgssDhsGfA64Ag4M+BwYGHLBE3AhMOOBb8Jr1Ww9qvEU1fnMny8EHWEL9JlsjN4TjVCRX4OKPBEqC2tAFQDe8WZwv2gCkbAOhQ6VKLUWodRKBJGpDPJxXKCOA3a2FKzcBrCKZWBVqK4bVEIMyMVtF9GEKhQ1jpcBBlwOzM1MYGEhhJnQGEbGfBgZCmBgoL2vXRY69SgSNEAskeDhw4c6ke3s7AyBQNBuuR7loEkkEhgwrCXg8Xh0vrp6ADSqK5FI1C7u5PF4SuW0LZOJU6dO4eDBgyrpX375pdo6BAKB8LegGMDj5sv2I9x1LdXVQHVu++UI+snVM6d1IlfTNeQ9ykHj8/loaFBdG1JfX0/nq6sHQKO6fD4fUqlUpVxT2ZbltC2TialTp2LkyJH0dXV1NbKzs+Hu7k47gtoiOzsbX375JT777DM4Ozu3X6GHQezr+TzvNhL7ej7Pu43Pu32A7m3UVGaPctCsrKxQUlKikt40BWhtzRzZ2dTUFDwej3EqsXVdKysryGQylJeXK01JNjQ0oKqqip6+1IVMJqytrVXsGjZsmNry2sDZ2fm5jrFG7Ov5PO82Evt6Ps+7jc+7fUD329ij9vy6ubkhNzcXNTXKQSWTk5PpfCbYbDZcXFyQmpqqkpecnAwHBwcYNS7o7N+/PwColE1NTYVcLqfzdSGTQCAQCAQCAehhDlpwcDBkMhlOnTpFp9XX1yMyMhLe3t70Ds6ioiKVRfRBQUFITU1VcpJycnKQmJiI4OBgOm3IkCEwNTXFyZMnleqfPHkSAoEAL774ok5lEggEAoFAIPSoKU5vb2+EhIRg7969qKiogKOjI6Kjo1FYWIjVq1fT5TZs2IA7d+7gypUrdNqMGTNw5swZrF69GrNnzwaHw0FERAQsLCwwe/Zsuhyfz8e7776LHTt24PPPP4e/vz/u3r2L8+fPY8GCBTA1NdWpzO7EysoK8+fPb3PKtSdD7Ov5PO82Evt6Ps+7jc+7fYD+2NijThIAFDsim87iFIlEcHFxQXh4OPz9/ekyy5cvV3HQAKC4uFjl3MylS5fCyclJpZ3Tp0/j8OHDKCgogK2tLWbMmIGwsDCVMAe6kEkgEAgEAuHvTY9z0AgEAoFAIBCed3rUGjQCgUAgEAiEvwPEQSMQCAQCgUDQM4iDRiAQCAQCgaBn9KhdnAQFiYmJWLFiBWPe7t274ePjQ1/fv38fe/bswaNHj2BsbIyQkBAsWLCAjtHWRH19Pb35orq6Gq6urggPD4efn59GOpWUlKhslli2bBkcHBz0wsaUlBRER0cjMTERhYWFMDU1hY+PD8LDw9G7d+929YmKisLGjRsZ844fP97h3T7atq8j8tShzT7Utn1fffUVoqOj1bb3+++/w8bGRm3+gQMHGI9M4/F4iI2N1cAiVTS1MSEhARcvXkRKSgqys7Nha2uLiIgIxnpyuRy//fYbTpw4gbKyMjg5OeHNN9/E2LFjNdKpuroae/bswZUrVyCRSODl5YXFixd3Ktimtu3Lzs5GZGQkbty4gby8PBgaGsLd3R3vvPMOPD09taaPpmjbvoKCAsyaNYtR3hdffIExY8a0q5M2+w/Qvo3qnqMmdu3ahYEDB6rN747P0bq6OkRGRiI+Ph4ZGRkQi8VwcnJCaGgoQkNDweFwlOrp0zNIHLQezCuvvAIvLy+lNEdHR/r/tLQ0fPjhh3B2dsbSpUtRXFyMw4cPIzc3F1u2bFGqt3HjRsTFxSEsLAxOTk6IiorCqlWrsHPnTvj6+rapR21tLVasWIGamhq8+eab4HK5iIiIwLJly3DgwAGYmZl1u42//vor7t+/j5CQELi6uqK0tBTHjx9HeHg4du/eDRcXF430effdd9GrVy+lNBOTzp8AqM0+1ESeOnTVh9qyb+rUqSonaFAUhW3btsHe3r5N56wlH3/8MQwNDelrNvvZJxHaszE2NhYXL16Eu7t7u19A+/btwy+//ILQ0FB4enoiPj4e69atA4vFavcLXi6XY/Xq1Xj8+DFmz54NMzMznDhxAitWrMC+ffs0+iGiS/vOnDmDs2fPIigoCNOnT0dNTQ1OnTqFRYsWYcuWLRqfkNLZ93hn5XWk/wBg7NixGDFihFKaJs6jrvoP0J6NQUFBjBEK9u7dC7FYrJGjDXTt52h+fj527tyJoUOHYtasWTAyMkJCQgK2b9+OpKQk/N///Z9SPb16BilCj+P27dtUQEAAdenSpTbLrVy5kpo+fTolEonotNOnT1MBAQHU9evX6bSkpCQqICCA+vXXX+m0uro6avbs2dTChQvb1eeXX36hAgICqOTkZDotKyuLCg4Opn788ccOWNaMtm28d+8eVV9fr1Q3JyeHGjNmDLVu3bp29YmMjKQCAgKolJSUjhmiBm3bp6k8dWi7D7VtHxN3796lAgICqJ9++qldffbv308FBARQ5eXlmqivEZraWFJSQjU0NFAURVGrVq2iwsLCGMsVFxdTISEh1Pbt2+k0uVxOLVmyhJo5cyYllUrbbOfChQsq+pSXl1OTJk2i1q5dq5lRLdC2fampqVRNTY1SWkVFBRUaGkotXrxYa/poirbty8/PV/kc7Qja7j+K0r6NTBQWFlKBgYHU5s2b2y3bHZ+j5eXlVEZGhkr6xo0bqYCAAOrJkyd0mr49g2QNWg+ntraW8SD2mpoa3Lx5E+PHj4exsTGdPmHCBBgaGuLSpUt02uXLl8HhcDB16lQ6jc/nY8qUKUhKSkJRUVGbOsTFxcHT01PpF4yzszOGDBmi1E5n0YaNAwcOhIGBgVL93r17o2/fviqnTmiij0wm66AVbct7Vvs0kdcWuuxDbdvXRGxsLFgslsZTDy3bpbQcXaite25tbQ0ut/3Jivj4eEilUsyYMYNOY7FYmD59OkpKSpCUlNRm/cuXL8PS0hKBgYF0mrm5OUJCQhAfH4/6+noNrVFFG/Z5eHioLK0wMzODr69vp57Bjr7HOytPU/taIhaL0dDQ0KE6uuw/QPs2NnHhwgVQFIVx48Z1WJ+u+Bw1NzdHv379VNIDAgIAQOm9p2/PIJni7MFs3LgRYrEYHA4Hvr6+WLRoET3EnJGRAZlMpjLvbWBggP79+yMtLY1OS0tLg5OTk9KXJAD6yzo9PZ0+Rqs1crkcGRkZmDx5skqel5cXbty4gdraWpUP5q62kQmKolBeXo6+fftqrM+KFSsgFothYGAAPz8/LFmy5JmmHrRtX1vy1KHLPtRV/0mlUly6dAkDBgxQmSppi1mzZkEsFsPQ0BCjRo3CkiVLYGlp2WG7WtKZe85EWloaDA0N4ezsrJTe9BympaW1udzg0aNH6N+/v8q0rZeXF06fPo0nT57A1dW1w3ppyz51lJWVdWgKXdv6aFvewYMHsXv3brBYLHh4eKgEUleHrvoP0G0fxsTEwNbWFoMGDdK4Tld+jqqjrKwMAJTee/r2DBIHrQfC5XIRFBSEESNGwMzMDFlZWTh8+DCWLl2KH374Ae7u7igtLQUAxvUEVlZWuHv3Ln1dWlqqthwAPH36VK0uVVVVqK+vb7d+nz59utVGJmJiYlBSUoJ33nmnXX34fD4mTZqEwYMHw9jYGA8fPkRERAQWL16Mf//732od2K6yTxN56tBFH+q6/xISElBZWanxr3ahUIiZM2fCx8cHBgYGuHfvHo4fP46UlBTs27dP5ceJtmzsCKWlpbCwsFA5WUST5xBQfOEwfUk21S8tLe3Yl4OW7WPi7t27SEpKwty5c7tcH23LY7PZ8PPzQ2BgIKytrZGfn4+IiAisWrUKGzdubPfMZW33H6D7PszMzMTjx48xZ84cjU7E6Y7PUSYaGhpw5MgR9OrVS8mR07tnUOOSBL1h4MCBSjtlRo0aheDgYLz99tvYu3cvtm7dColEAgAq03qAYuday6FWiUSitlxTvjraa6e9+urQto2tyc7Oxo4dO+Dj44OJEye2q8/o0aMxevRo+jogIAD+/v5YtmwZfv75Z6xcubIj5mndPk3kqUMXfajr/ouNjQWXy0VISIhG+oSFhSldBwcHw8vLC+vXr8fx48fx5ptvaiSnJc9yz5l4luewKb+pbGfqt0bb9rWmvLwc69atQ69evTBnzpwu10fb8uzs7LBt2zaltAkTJmDu3LnYtWtXuw6atvsP0H0fxsTEAADGjx+vUfnu+Bxl4ptvvkFWVhY2bdqkNLWrb88gWYP2nODk5IRRo0YhMTERMpkMfD4fABjXQdTX1yu9ifh8vtpyTfnqaK+d9up3hGexsSWlpaVYvXo1jI2NsX79epVt1pri6+sLb29v3Lp1q1P1W6Mt+9TJU0dX9aG27KutrUV8fDz8/f2faYfwuHHjYGlpqbX+AzS/50w8y3PYlM/k1OqyDzuLWCzG6tWrIRaL8dVXX3V6CYS29NGVPFNTU0yaNAk5OTkoLi5us2xX9B+gPRspikJsbCz69evX6alXQPefo605dOgQTp8+jXfffVfFada3Z5A4aM8Rtra2aGhoQF1dndKQamtKS0thbW1NX1tZWaktB0CpbGtMTU3B4/E6Xb+jdNbGJkQiEVatWgWRSIStW7c+s262traoqqp6Jhmt5T2LfW3JU0dX9qE27IuPj0ddXV2HFyWr00eb/dcks717zoSVlRXKyspUNjBo2geWlpZt9mFHY0ypo7P2NdHQ0IDPPvsMGRkZ+OqrrzQOcaMrfbpCHqCIj9UWXdV/TTo9q433799HYWGhXj6H6uyLiorCnj17MG3aNMybN0+lnr49g8RBe47Iz88Hj8eDoaEh+vXrBw6Hg4cPHyqVaWhoQFpaGtzc3Og0Nzc35ObmoqamRqlscnIyna8ONpsNFxcXpKamquQlJyfDwcGh07+OmeisjYBiePmf//wnnjx5gq+//rpDmwPa0sfc3PyZ5bSU11n72pOnjq7sQ23YFxMTA0NDQ4wcOfKZdKEoCoWFhVrtP0Cze86Em5sb6urqVHY0avIcAqA3VsjlcqX0lJQUCASCZ1qE3ZLO2gcoNqRs2LABt2/fxpo1a/DCCy90qz5dJQ9Au6O9XdV/TTo9q40xMTFgsVhacdB0+TnaxNWrV7F582YEBgbiww8/ZKynb88gcdB6IBUVFSpp6enp+OOPP+Dn5wc2mw0TExMMGzYM58+fR21tLV3u3LlzEIvFSmt3goODIZPJcOrUKTqtvr4ekZGR8Pb2Vlq4WVRUpPLmDQoKQmpqqtIXfE5ODhITExEcHKwXNspkMvzrX/9CUlIS1q5diwEDBqht++nTp8jOzlbass2kz7Vr1/Dw4UONdmjp2j5N5DXRFX2obftayr158yYCAwMhEAgY22ayj0mfEydOoKKiAsOHD++YcW3IVHfPNWHUqFHgcrk4fvw4nUZRFE6ePAkbGxul9yzTezQoKAhlZWW4cuWKko6XLl3CSy+91O6UeGu0bR+gWPtz8eJFfPjhhwgKCmqz7ezsbKUREG3r0xXySkpKEBkZCVdXV6XRl67oP3U6PWsfAopd1HFxcRg4cKDahf368jkKAHfu3MHatWvh6+uLNWvWqLVb355BskmgB/LFF1+Az+djwIABsLCwQFZWFk6fPg2BQID333+fLhceHo4lS5Zg2bJlmDp1Kh2l3c/PT+lLydvbGyEhIdi7dy8qKirg6OiI6OhoFBYWYvXq1Uptb9iwAXfu3FF6A86YMQNnzpzB6tWrMXv2bHA4HERERMDCwgKzZ8/WCxt37dqFP/74Ay+99BKqq6tx/vx5pfZaLnLdu3cvoqOjcfjwYTqEw6JFi+Du7g4PDw8YGxvj0aNHiIyMhK2tLd56661ut09TeUDX9KG27WviwoULkMlkbf5qZ7IvLCwMo0ePhouLC3g8Hu7fv48LFy6gf//+SvH/dGHj48ePER8fDwDIy8uDSCTCf//7XwCKX+RNI4G2trYICwvDoUOHIJVK4eXlhatXr+LevXtYs2aN0lpJpvdocHAwjh49io0bNyIrK4uOYi6XyzXaqaxr+yIiInDixAn4+PhAIBCoPIMBAQH0iMexY8dw8OBB7Ny5E4MHD+6QPt1l3+7du5GXl4ehQ4fC2toahYWFOHXqFOrq6rB8+XKltrui/3RhYxOa7KLWl8/RwsJCfPrpp2CxWAgODkZcXJySDFdXV3oNnb49g8RB64EEBAQgJiYGERERqKmpgbm5OQIDAzF//nylYzg8PDywfft27NmzB9999x2MjIwwZcoUxg+zTz/9FHZ2djh37hxEIhFcXFywadMmjaYgjIyMsHPnTnz//ff46aef6HMcly5d2ulha23bmJ6eDgD4888/8eeff6q0194upNGjR+Ovv/7CjRs36PVToaGhmD9/fqfiaGnbPk3lqUPbfaiL9yig2L1pYWGBoUOHdkifcePG4cGDB7h8+TLq6+thZ2eHOXPmYO7cuWpH4rRl46NHj7B//36luk3XEydOVPrye//99yEUCnHq1ClER0fDyckJn332mUbTSBwOB5s3b8YPP/yA33//HRKJBJ6envjkk086HOZGF/Y1PYNJSUmMAT8PHz7c5pTbs77HdW2fn58f8vPzcfz4cVRXV8PExAS+vr6YO3euRucwarv/dGFjEzExMR3aRd1Ed3yOFhQUQCQSAQB27NihImP+/PlKmxz06RlkUdoOqU0gEAgEAoFAeCbIGjQCgUAgEAgEPYM4aAQCgUAgEAh6BnHQCAQCgUAgEPQM4qARCAQCgUAg6BnEQSMQCAQCgUDQM4iDRiAQCAQCgaBnEAeNQCAQCAQCQc8gDhqBQCAQCASCnkEcNAKBQOjhBAYGKv1JJBI6LyoqCoGBgYiKiupGDZs5efKkkq5fffVVd6tEIOgl5KgnAoGglxQUFGDWrFltlrG3t0dEREQXaaTf2NvbY+LEiQCgdGagLkhISMDKlSvh5+eHbdu2tVl23bp1iI2NxZo1azBu3Dh4eHhg/vz5EIlEOHr0qE71JBB6MsRBIxAIeo2jo6Pac/BMTEy6WBv9xd7evtOHaneUYcOGwc7ODrdu3UJRURHs7OwYy4lEIly9ehUmJiYIDAwEAHh6esLT0xMFBQXEQSMQ2oA4aAQCQa9xdHTsMseDoBlsNhuTJk3CwYMHER0djXnz5jGWi42NhUQiweTJk8Hn87tYSwKhZ0PWoBEIhOeGwMBALF++HGVlZdiwYQNCQ0MxduxYLFy4EImJiYx1amtrceDAAcydOxdjx47F5MmT8fHHH+PevXsqZZcvX06v8dq3bx9mz56NkJAQHDhwgC5z+fJlLFiwAGPHjsW0adOwefNmVFdX47XXXsNrr71Gl1u/fj0CAwORnJzMqNf+/fsRGBiI2NjYZ7wrzBQXF2PevHkYO3Ys4uLi6PTy8nJ89913mDNnDsaMGYPQ0FB89tlnyMjIUKo/efJksFgsREVFgaIoxjYiIyMBAFOmTNGJDQTC8wxx0AgEwnOFSCTCkiVLkJWVhfHjxyMwMBAPHz7EypUrVZyMqqoqLFq0CAcPHoRQKMS0adMQGBiIR48eYcWKFbh69SpjG2vWrEF0dDQGDx6MV199Fb169QIAnD17FmvWrEFubi4mTJiAiRMnIikpCR999BGkUqmSjKlTp9J1WiOTyRAZGQkzMzN6alCbZGVlYfHixSguLsaWLVsQHBwMAMjLy0N4eDiOHDkCBwcHzJw5EyNGjEBCQgIWLVqk5Eza29tj6NChyM/PZ3R+MzIykJqaiv79+8Pd3V3rNhAIzztkipNAIOg1eXl5SiNULfHx8cHw4cOV0tLT0zF9+nR88MEHYLMVv0GHDBmCzZs349ixY1i5ciVd9ptvvkFmZiZWrVqFl19+mU4vLy/HggULsGXLFvj7+6tMz5WWluI///kPTE1N6bTq6mp8++23MDQ0xN69e9G7d28AwIIFC7By5Uo8fPgQ9vb2dPlBgwahb9++uHDhApYuXQpDQ0M6LyEhASUlJQgLCwOPx+voLWuTpKQkrF69GlwuF9999x3c3NzovA0bNqCsrAxbt26Fv78/nT537lwsWLAAmzdvxsGDB+n0KVOm4ObNm4iMjMSQIUOU2iGjZwTCs0FG0AgEgl6Tl5eHgwcPMv5dv35dpbyhoSEWLlxIO2cAMHHiRHA4HKSmptJpFRUVuHTpEoYMGaLknAGAhYUF5syZg4qKCty6dUuljbffflvJOQOA+Ph4iMViTJ48mXbOAIDL5SI8PJzRtqlTp6K2thYXLlxQSj9z5gwAIDQ0VN1t6RTXrl3Dhx9+CKFQiB9++EHJOXv06BEePHiACRMmKDlnANC7d2+8/PLLyMjIUBqFDAgIgJmZGS5fvoyamho6XSqV4vz58+DxeGo3eBAIhLYhI2gEAkGv8ff3x9atWzUu7+TkBCMjI6U0LpcLS0tLiEQiOi01NRUymQwNDQ2MI3S5ubkAgOzsbLz00ktKeV5eXirlHz9+DADw9fVVyfP29mYMfTFhwgT8+OOPOHPmDO0klpWV4c8//8SAAQPQt2/fdqzVnEuXLuHGjRtwdXXFli1bYGFhoZTfNH1ZXl7OeD9ycnLoVxcXFwCgHbCjR48iNjYW06ZNAwD88ccfqKiowNixYyEUCrVmA4Hwd4I4aAQC4bnC2NiYMZ3D4UAul9PXVVVVAID79+/j/v37auXV1dWppFlaWqqkNY0gtXZ8AMWuRzMzM5V0oVCIkJAQREdHIyMjAy4uLoiKioJMJtP66FlSUhJkMhl8fX0ZdWy6H9euXcO1a9fUyhGLxUrXU6ZMwdGjRxEZGUk7aGR6k0B4doiDRiAQ/pY0OXKzZs3CkiVLOlSXxWKplVdeXq6SJ5fLUVlZCRsbG5W8adOmITo6GqdPn8aKFStw9uxZGBsbIyQkpEM6tcd7772H+Ph4HD16FBwOR8XmJv1XrFiBV155RWO5rq6u8PT0REpKCjIzMyEUCpGQkIBevXqprEsjEAiaQ9agEQiEvyWenp5gsVhISkrSijxXV1cAYByNS0lJgUwmY6zn4+MDV1dXxMTEICEhAbm5uRg3bhwEAoFW9GqCx+Nhw4YNePHFF3H48GF8//33SvlN07aduR9NI2Vnz57FuXPnIJPJ6DAcBAKhcxAHjUAg/C2xsrJCSEgIHjx4gEOHDjHG8kpOTmac4mRi1KhRMDQ0xNmzZ5GXl0enS6VS7N+/v826U6dORVVVFb7++msAUNm0oC14PB6+/PJLvPTSS4iIiMB3331H53l7e8Pb2xsXLlxQ2bQAKEYB79y5wyh37NixEAgEOH/+PCIjI8Fms+ljpwgEQucgU5wEAkGvaSvMBgC88cYbnY5S/9FHH+HJkyfYvXs3zp07Bx8fH5iYmKCkpASpqanIzc3F8ePHNRrNEgqFWLp0KbZs2YIFCxZg9OjRMDY2xl9//QUejwdra2u1I0rjx4/Hnj178PTpU3h4eOg0bpiBgQHWr1+Pzz//HEeOHAFFUVi+fDkA4PPPP8cHH3yAtWvX4ujRo+jfvz/4fD6Ki4vx4MEDVFZWMgbONTY2RlBQEM6dO4eKigoMHz5c7fFPBAJBM4iDRiAQ9JqmMBvqCAsL67SDZmpqih9++AHHjh3DxYsXERsbC7lcDktLS7i5uWHevHmMi/vVERoaCqFQiJ9//hnR0dEwNjbGyJEjsXDhQoSFhcHR0ZGxnrGxMQICAnD+/HmdjZ61pMlJ++KLL3D06FFQFIUVK1bAwcEB+/fvx+HDh3H16lVERUWBzWbDysoKgwYNogPaMjFlyhScO3cOgOKUAQKB8GywKHVndBAIBAJBK+Tm5uL1119HSEgI1q5dy1hm3rx5KCwsxLFjx9TuRFVHYGAgXnjhBXz77bfaULdLKCgowKxZszBx4kR8+umn3a0OgaB3kBE0AoFA0BLV1dXg8/lK0f8lEgm9ID8gIICx3l9//YXMzEyEhoZ22Dlr4s6dO/SxUDExMXp7OPnJkyexbdu27laDQNB7iINGIBAIWuLOnTvYtGkT/Pz8YGtri8rKSty+fRuFhYUYMmQIRo8erVT+xIkTKC4uxpkzZ8Dj8fDGG290qt358+crXTMFxdUXPDw8lPTt379/9ylDIOgxZIqTQCAQtMSTJ0+wf/9+PHjwABUVFQAAR0dHjB49GrNnz1YZ1XrttddQUlKC3r17Y+HChSonFhAIhL8vxEEjEAgEAoFA0DNIHDQCgUAgEAgEPYM4aAQCgUAgEAh6BnHQCAQCgUAgEPQM4qARCAQCgUAg6BnEQSMQCAQCgUDQM4iDRiAQCAQCgaBnEAeNQCAQCAQCQc8gDhqBQCAQCASCnkEcNAKBQCAQCAQ94/8BualtZF0TkPEAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -3715,7 +3636,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a92bbf0a",
    "metadata": {},
    "source": [
     "In summary, we fitted the flux and eccentricity of the disk only, with the all parameters of the bulge component fixed. Considering $b = a \\sqrt{(1-e^2)}$, we recovered the following fitted parameters:\n",

--- a/tests/spacecraftfile/test_spacecraftfile.py
+++ b/tests/spacecraftfile/test_spacecraftfile.py
@@ -113,6 +113,13 @@ def test_get_target_in_sc_frame():
                        np.array([46.733430, 46.687559, 46.641664, 46.595745, 46.549801, 46.503833,
                                  46.457841, 46.411825, 46.365785, 46.319722, 46.273634]))
 
+    # make sure we get right result regardless of source inertial frame
+    target_coord_icrs = target_coord.transform_to("icrs")
+
+    path_in_sc_icrs = ori.get_target_in_sc_frame(target_coord_icrs)
+
+    assert np.allclose(path_in_sc.lon.deg, path_in_sc_icrs.lon.deg)
+    assert np.allclose(path_in_sc.lat.deg, path_in_sc_icrs.lat.deg)
 
 def test_get_dwell_map():
 

--- a/tests/threeml/test_spectral_fitting.py
+++ b/tests/threeml/test_spectral_fitting.py
@@ -24,6 +24,14 @@ bkg_par = Parameter("background_cosi",                                         #
                     delta=0.05,                                                # initial step used by fitting engine
                     desc="Background parameter for cosi")
 
+# second copy for testing with ICRS source
+bkg_par_icrs = Parameter("background_cosi_icrs",                                    # background parameter
+                         1,                                                         # initial value of parameter
+                         min_value=0,                                               # minimum value of parameter
+                         max_value=50,                                              # maximum value of parameter
+                         delta=0.05,                                                # initial step used by fitting engine
+                         desc="Background parameter for cosi")
+
 l = 50
 b = -45
 
@@ -45,12 +53,19 @@ spectrum.xp.unit = xp.unit
 spectrum.K.unit = K.unit
 spectrum.piv.unit = piv.unit
 
+# source in galactic frame
 source = PointSource("source",                     # Name of source (arbitrary, but needs to be unique)
                      l = l,                        # Longitude (deg)
                      b = b,                        # Latitude (deg)
                      spectral_shape = spectrum)    # Spectral model
 
-model = Model(source)
+# same source, but specified in ICRS
+c = SkyCoord(l = l, b = b, unit=u.deg, frame = "galactic")
+c_icrs = c.transform_to("icrs")
+source_icrs = PointSource("source_icrs",
+                          ra  = c_icrs.ra.deg,
+                          dec = c_icrs.dec.deg,
+                          spectral_shape = spectrum)    # Spectral model
 
 def test_point_source_spectral_fit():
 
@@ -62,6 +77,8 @@ def test_point_source_spectral_fit():
                     nuisance_param = bkg_par)                                      # background parameter
 
     plugins = DataList(cosi)
+
+    model = Model(source)
 
     like = JointLikelihood(model, plugins, verbose = False)
 
@@ -77,6 +94,35 @@ def test_point_source_spectral_fit():
     assert np.allclose([cosi.get_log_like()],
                        [213.14242014103897],
                        atol=[1.0])
+
+    # verify that the result is the same regardless of how we specify the source position
+
+    cosi_icrs = COSILike("cosi",                                                       # COSI 3ML plugin
+                         dr = dr,                                                       # detector response
+                         data = data.binned_data.project('Em', 'Phi', 'PsiChi'),        # data (source+background)
+                         bkg = background.binned_data.project('Em', 'Phi', 'PsiChi'),   # background model
+                         sc_orientation = sc_orientation,                               # spacecraft orientation
+                         nuisance_param = bkg_par_icrs)                                 # background parameter
+
+    plugins = DataList(cosi_icrs)
+
+    model = Model(source_icrs)
+
+    like = JointLikelihood(model, plugins, verbose = False)
+
+    # avoid output- and sampling-related threeML crashes
+    like.fit(quiet=True, compute_covariance = False)
+
+    sp_icrs = source_icrs.spectrum.main.Band
+
+    # make sure result does not change (much -- bkg_par changes more than the rest)
+    assert np.allclose([sp.K.value, sp.alpha.value, sp.beta.value, sp.xp.value, bkg_par.value],
+                       [sp_icrs.K.value, sp_icrs.alpha.value, sp_icrs.beta.value, sp_icrs.xp.value, bkg_par_icrs.value],
+                       atol=[1e-8, 1e-8, 1e-8, 1e-8, 1e-3])
+
+    assert np.allclose([cosi.get_log_like()],
+                       [cosi_icrs.get_log_like()])
+
 
     # Test scatt map method:
     coord = SkyCoord(l=184.56*u.deg,b=-5.78*u.deg,frame="galactic")


### PR DESCRIPTION
We recently identified an issue where COSILike produced incorrect results for a point source whose location is specified in ICRS rather than galactic coordinates.  This is a particularly insidious instance of a more general issue, which is that functions that take a source location specified as a SkyCoord don't always check that the frame of the coordinate is what they expect (and transform it if needed).

This patch fixes the observed issue in three parts of cosipy: COSILike (spectral fitting), SpacecraftFile.get_target_in_sc_frame(), and ts_map.  I've added test cases for the first two to verify that changing a source's coordinate frame doesn't affect the output (at least, up to reasonable numerical precision).  I can't directly add a test case for ts_map, because enumerating a grid of source directions in (say) ICRS gives a different set of hypotheses than enumerating an equal-sized grid of them in galactic.  But I did verify visually that, if I load the orientation file in ICRS and then plot the map and the true source in ICRS, they align as expected.

As long as I have to touch COSILike, I went ahead and added my performance patches to that file for computing the likelihood and expectation.  I also changed the remaining use of ICRS in the diffuse_511_spectral_fit tutorial (Case 3) to galactic, to match the change that was already committed for Case 2.  Thankfully, after the fix to COSILike, this is now only a cosmetic change :-).

In the longer term, we should review all of cosipy to see where it assumes that the inertial coordinate system being used is always galactic, and either enforce this assumption at call time (which I understand will be a feature of the interface branch) or make the code able to handle other frames (my preference where possible).  Notably, we use a GalacticResponse in a few places that should probably be an InertialResponse that communicates its frame.  This would let us specify, e.g., extended source responses in whatever frame we want.