### PR TITLE
close subfigures after plotting

### DIFF
--- a/cosipy/pipeline/src/plotting.py
+++ b/cosipy/pipeline/src/plotting.py
@@ -133,6 +133,7 @@ def plot_fit(sou, cts_exp, figname):
     ax[1].set_ylabel("Obs-Model/Err")
     ax[1].set_xlabel("Energy (keV)")
     #
-    # plt.show()
     plt.savefig(figname)
+    # plt.show()
+    plt.close(fig)
     return ()

--- a/cosipy/spacecraftfile/SpacecraftFile.py
+++ b/cosipy/spacecraftfile/SpacecraftFile.py
@@ -1311,7 +1311,8 @@ class SpacecraftFile():
         ax.set_ylabel(r"Effective area [$cm^2$]")
         ax.set_xscale("log")
         fig.savefig(f"Effective_area_for_{save_name}.png", bbox_inches = "tight", pad_inches=0.1, dpi=dpi)
-
+        plt.show()
+        plt.close(fig)
 
     def plot_rmf(self, file_name = None, save_name = None, dpi = 300):
 

--- a/cosipy/ts_map/fast_ts_fit.py
+++ b/cosipy/ts_map/fast_ts_fit.py
@@ -400,6 +400,9 @@ class FastTSMap():
         if save_plot:
             fig.savefig(Path(save_dir)/save_name, dpi = dpi)
 
+        plt.show()
+        plt.close(fig)
+
     @staticmethod
     def get_chi_critical_value(containment = 0.90):
         """

--- a/cosipy/ts_map/moc_ts_fit.py
+++ b/cosipy/ts_map/moc_ts_fit.py
@@ -325,3 +325,6 @@ class MOCTSMap(FastTSMap):
 
         if save_plot:
             fig.savefig(Path(save_dir)/save_name, dpi = dpi)
+
+        plt.show()
+        plt.close(fig)


### PR DESCRIPTION
Certain plotting functions in cosipy create subplots via pyplot.subplots() or similar.  Each such call generates a new figure to hold the subplots, whose lifetime does not exceed that of the calling function.  If these figures are not closed after use, they may stay around indefinitely, triggering a warning from matplotlib about "too many open figures" and presumably consuming memory until they are garbage-collected (if that is even possible).  I encountered this issue while generating thousands of likelihood map plots for GRBs with the ts_map code; the warning kicks in after producing 20 such plots over a few seconds.

This patch ensures that the figures created by functions using subplot are explicitly closed.  If the function might be called to display a plot in a notebook, it is necessary to call plt.show() *after* any savefig() call (to avoid disrupting the saved figure) but *before* plt.close(); otherwise, the figure is never displayed.

I patched the ts_map code and one subplot use in the XSpec support code.  I also put an explicit close() into the plotting function in the pipeline code, but that function had plt.show() commented out, so I did not re-enable it (though I did move it after the savefig() call).

I don't believe this is an issue for plotting uses that do not generate a new figure each time; in any case, many such uses in cosipy already have a correspnding close() call.