### PR TITLE
Fix breakage caused by recent polarization-related merge

### DIFF
--- a/cosipy/threeml/COSILike.py
+++ b/cosipy/threeml/COSILike.py
@@ -10,7 +10,12 @@ from cosipy.response import (
     FullDetectorResponse,
     ExtendedSourceResponse
 )
-from cosipy.polarization.conventions import IAUPolarizationConvention, MEGAlibRelativeX, MEGAlibRelativeY, MEGAlibRelativeZ
+from cosipy.polarization.conventions import (
+    IAUPolarizationConvention,
+    MEGAlibRelativeX,
+    MEGAlibRelativeY,
+    MEGAlibRelativeZ
+)
 
 import logging
 logger = logging.getLogger(__name__)
@@ -50,8 +55,8 @@ class COSILike(PluginPrototype):
     earth_occ : bool, optional
         Option to include Earth occultation in fit (default is True).
     response_pa_convention : str, optional
-        Polarization reference convention of response ('RelativeX', 
-        'RelativeY', or 'RelativeZ'). Required if response contains 
+        Polarization reference convention of response ('RelativeX',
+        'RelativeY', or 'RelativeZ'). Required if response contains
         polarization angle axis
 
     """
@@ -139,12 +144,13 @@ class COSILike(PluginPrototype):
         if 'Pol' in self._dr.axes.labels:
             self._response_pa_convention = response_pa_convention
             if self._coordsys == 'spacecraftframe':
+                att = self._sc_orientation.get_attitude()[0]
                 if self._response_pa_convention == 'RelativeX':
-                    self._pa_convention = MEGAlibRelativeX(attitude=self._sc_orientation.get_attitude()[0])
+                    self._pa_convention = MEGAlibRelativeX(attitude=att)
                 elif self._response_pa_convention == 'RelativeY':
-                    self._pa_convention = MEGAlibRelativeY(attitude=self._sc_orientation.get_attitude()[0])
+                    self._pa_convention = MEGAlibRelativeY(attitude=att)
                 elif self._response_pa_convention == 'RelativeZ':
-                    self._pa_convention = MEGAlibRelativeZ(attitude=self._sc_orientation.get_attitude()[0])
+                    self._pa_convention = MEGAlibRelativeZ(attitude=att)
                 else:
                     raise RuntimeError("Response convention must be 'RelativeX', 'RelativeY', or 'RelativeZ'")
             elif self._coordsys == 'galactic':
@@ -294,7 +300,7 @@ class COSILike(PluginPrototype):
                         total_expectation = this_expectation
                     else:
                         total_expectation += this_expectation
-                    
+
                     component_counter += 1
 
             # Save expected counts for each source,
@@ -387,8 +393,7 @@ class COSILike(PluginPrototype):
         src_path = self._sc_orientation.get_target_in_sc_frame(coord)
         dwell_time_map = \
             self._sc_orientation.get_dwell_map(base = self._dr,
-                                               src_path = src_path,
-                                               pa_convention = self._response_pa_convention)
+                                               src_path = src_path)
 
         return dwell_time_map
 

--- a/docs/tutorials/spectral_fits/continuum_fit/grb/SpectralFit_GRB.ipynb
+++ b/docs/tutorials/spectral_fits/continuum_fit/grb/SpectralFit_GRB.ipynb
@@ -906,7 +906,7 @@
    "source": [
     "results = like.results\n",
     "\n",
-    "print(results.display())\n",
+    "results.display()\n",
     "\n",
     "parameters = {par.name:results.get_variates(par.path)\n",
     "              for par in results.optimized_model[\"source\"].parameters.values()\n",


### PR DESCRIPTION
A recent change to COSILike to support polarization info now calls SpacecraftFile.get_dwell_map() with a polarization argument.  There is no support for such in SpacecraftFile.  This patch restores the original call to get_dwell_map().

We also fix one line in the GRB spectral fitting notebook with a broken print call around a 3ML display call.

Ideally, the test suite would have caught this, but to do so, we'd need a COSILike test case that uses spacecraft-local rather than inertial coordinates, which requires some new data files.  This is related to the fact that I'm getting complaints about this patch being all uncovered lines of code. (It passes the test suite, but the "fail" status is based on the low coverage)