### PR TITLE
Add ML polarization notebook to auto-runnable tutorials

### DIFF
--- a/docs/tutorials/polarization/maximum_likelihood_method.ipynb
+++ b/docs/tutorials/polarization/maximum_likelihood_method.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "2bcdf955",
    "metadata": {},
    "source": [
     "# Polarization example - maximum likelihood method"
@@ -9,6 +10,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f6c9219c",
    "metadata": {},
    "source": [
     "This notebook fits the polarization fraction and angle of a Data Challenge 3 GRB (GRB 080802386) simulated using MEGAlib and combined with albedo photon background. It's assumed that the start time, duration, localization, and spectrum of the GRB are already known. The GRB was simulated with 80% polarization at an angle of 90 degrees in the IAU convention, and was 20 degrees off-axis. "
@@ -16,10 +18,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
+   "id": "9946365e",
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%capture\n",
     "from cosipy import BinnedData, COSILike\n",
     "from cosipy.spacecraftfile import SpacecraftFile\n",
     "from cosipy.threeml.custom_functions import Band_Eflux\n",
@@ -33,6 +37,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6efdce51",
    "metadata": {},
    "source": [
     "### Download and read in data"
@@ -40,6 +45,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "87669a80",
    "metadata": {},
    "source": [
     "This will download the files needed to run this notebook. If you have already downloaded these files, you can skip this."
@@ -47,6 +53,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "03845b0e",
    "metadata": {},
    "source": [
     "Download the unbinned data (660.58 KB)"
@@ -54,15 +61,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
+   "id": "4b12c604",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "A file named grb_background.fits.gz already exists with the specified checksum (21b1d75891edc6aaf1ff3fe46e91cb49). Skipping.\n"
+     ]
+    }
+   ],
    "source": [
     "fetch_wasabi_file('COSI-SMEX/cosipy_tutorials/polarization_fit/grb_background.fits.gz', checksum = '21b1d75891edc6aaf1ff3fe46e91cb49')"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "d4df5f37",
    "metadata": {},
    "source": [
     "Download the polarization response (217.47 MB)"
@@ -70,15 +87,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
+   "id": "444d31c2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "A file named ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5 already exists with the specified checksum (46b006a6b397fd777dc561d3b028357f). Skipping.\n"
+     ]
+    }
+   ],
    "source": [
     "fetch_wasabi_file('COSI-SMEX/develop/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5', checksum = '46b006a6b397fd777dc561d3b028357f')"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "780f93a0",
    "metadata": {},
    "source": [
     "Download the orientation file (1.10 GB)"
@@ -86,15 +113,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
+   "id": "9527501d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "A file named DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits already exists with the specified checksum (29b8eef426efeba9f8cffcac715e94ea). Skipping.\n"
+     ]
+    }
+   ],
    "source": [
     "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = '29b8eef426efeba9f8cffcac715e94ea')"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "ccbe09c0",
    "metadata": {},
    "source": [
     "Read in and bin the data, which is a GRB placed within albedo photon background. A time cut is done for the duration of the GRB to produce the GRB+background data to fit. The time intervals before and after the GRB are used to produce a background model."
@@ -102,9 +139,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
+   "id": "32f94da6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "fill() discarded one or more values due to out-of-bounds coordinate in a dimension without under/overflow tracking\n",
+      "fill() discarded one or more values due to out-of-bounds coordinate in a dimension without under/overflow tracking\n",
+      "fill() discarded one or more values due to out-of-bounds coordinate in a dimension without under/overflow tracking\n"
+     ]
+    }
+   ],
    "source": [
     "data_path = Path(\"\") # Update to your path\n",
     "\n",
@@ -119,13 +167,14 @@
     "background_before.load_binned_data_from_hdf5(data_path/'background_before_binned_galactic.hdf5')\n",
     "\n",
     "background_after = BinnedData(data_path/'background_after.yaml') # e.g. background_after.yaml\n",
-    "#background_after.select_data_time(unbinned_data=data_path/'grb_background.fits.gz', output_name=data_path/'background_after')\n",
-    "#background_after.get_binned_data(unbinned_data=data_path/'background_after.fits.gz', output_name=data_path/'background_after_binned_galactic', psichi_binning='galactic')\n",
+    "background_after.select_data_time(unbinned_data=data_path/'grb_background.fits.gz', output_name=data_path/'background_after')\n",
+    "background_after.get_binned_data(unbinned_data=data_path/'background_after.fits.gz', output_name=data_path/'background_after_binned_galactic', psichi_binning='galactic')\n",
     "background_after.load_binned_data_from_hdf5(data_path/'background_after_binned_galactic.hdf5')"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "b188a60e",
    "metadata": {},
    "source": [
     "Define the path to the detector response and read in the orientation file. The orientation is cut down to the time interval of the source."
@@ -133,7 +182,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
+   "id": "fa953728",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,6 +195,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "90aa0f59",
    "metadata": {},
    "source": [
     "Define the GRB position and spectrum."
@@ -152,7 +203,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
+   "id": "9eba638f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 8,
    "id": "e942447f",
    "metadata": {},
    "outputs": [],
@@ -211,6 +263,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "90d6d112",
    "metadata": {},
    "source": [
     "### Polarization fit in ICRS frame"
@@ -226,18 +279,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "id": "7f853caa",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">14:58:58 </span><span style=\"color: #00ffaf; text-decoration-color: #00ffaf\">INFO    </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> set the minimizer to minuit                                             </span><a href=\"file:///Users/eneights/software/miniforge3/envs/cosipy-fork/lib/python3.10/site-packages/threeML/classicMLE/joint_likelihood.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">joint_likelihood.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/eneights/software/miniforge3/envs/cosipy-fork/lib/python3.10/site-packages/threeML/classicMLE/joint_likelihood.py#1045\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">1045</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">15:35:44 </span><span style=\"color: #00ffaf; text-decoration-color: #00ffaf\">INFO    </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> set the minimizer to minuit                                              </span><a href=\"file:///project/cassini/miniconda3/envs/cosipy/lib/python3.10/site-packages/threeML/classicMLE/joint_likelihood.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">joint_likelihood.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///project/cassini/miniconda3/envs/cosipy/lib/python3.10/site-packages/threeML/classicMLE/joint_likelihood.py#994\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">994</span></a>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[38;5;46m14:58:58\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;49mINFO    \u001b[0m \u001b[1;38;5;251m set the minimizer to minuit                                            \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=596975;file:///Users/eneights/software/miniforge3/envs/cosipy-fork/lib/python3.10/site-packages/threeML/classicMLE/joint_likelihood.py\u001b\\\u001b[2mjoint_likelihood.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=647829;file:///Users/eneights/software/miniforge3/envs/cosipy-fork/lib/python3.10/site-packages/threeML/classicMLE/joint_likelihood.py#1045\u001b\\\u001b[2m1045\u001b[0m\u001b]8;;\u001b\\\n"
+       "\u001b[38;5;46m15:35:44\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;49mINFO    \u001b[0m \u001b[1;38;5;251m set the minimizer to minuit                                             \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=249778;file:///project/cassini/miniconda3/envs/cosipy/lib/python3.10/site-packages/threeML/classicMLE/joint_likelihood.py\u001b\\\u001b[2mjoint_likelihood.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=315603;file:///project/cassini/miniconda3/envs/cosipy/lib/python3.10/site-packages/threeML/classicMLE/joint_likelihood.py#994\u001b\\\u001b[2m994\u001b[0m\u001b]8;;\u001b\\\n"
       ]
      },
      "metadata": {},
@@ -253,12 +306,12 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">14:59:06 </span><span style=\"color: #af5fd7; text-decoration-color: #af5fd7\">WARNING </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> get_number_of_data_points not implemented, values for statistical        </span><a href=\"file:///Users/eneights/software/miniforge3/envs/cosipy-fork/lib/python3.10/site-packages/threeML/plugin_prototype.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">plugin_prototype.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/eneights/software/miniforge3/envs/cosipy-fork/lib/python3.10/site-packages/threeML/plugin_prototype.py#130\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">130</span></a>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #00ff00; text-decoration-color: #00ff00\">15:35:45 </span><span style=\"color: #af5fd7; text-decoration-color: #af5fd7\">WARNING </span> <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\"> get_number_of_data_points not implemented, values for statistical        </span><a href=\"file:///project/cassini/miniconda3/envs/cosipy/lib/python3.10/site-packages/threeML/plugin_prototype.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">plugin_prototype.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///project/cassini/miniconda3/envs/cosipy/lib/python3.10/site-packages/threeML/plugin_prototype.py#119\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">119</span></a>\n",
        "<span style=\"color: #00ff00; text-decoration-color: #00ff00\">         </span>         <span style=\"color: #c6c6c6; text-decoration-color: #c6c6c6; font-weight: bold\">measurements such as AIC or BIC are unreliable                            </span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">                       </span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[38;5;46m14:59:06\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;134mWARNING \u001b[0m \u001b[1;38;5;251m get_number_of_data_points not implemented, values for statistical       \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=818515;file:///Users/eneights/software/miniforge3/envs/cosipy-fork/lib/python3.10/site-packages/threeML/plugin_prototype.py\u001b\\\u001b[2mplugin_prototype.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=821737;file:///Users/eneights/software/miniforge3/envs/cosipy-fork/lib/python3.10/site-packages/threeML/plugin_prototype.py#130\u001b\\\u001b[2m130\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[38;5;46m15:35:45\u001b[0m\u001b[38;5;46m \u001b[0m\u001b[38;5;134mWARNING \u001b[0m \u001b[1;38;5;251m get_number_of_data_points not implemented, values for statistical       \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b]8;id=245001;file:///project/cassini/miniconda3/envs/cosipy/lib/python3.10/site-packages/threeML/plugin_prototype.py\u001b\\\u001b[2mplugin_prototype.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=651919;file:///project/cassini/miniconda3/envs/cosipy/lib/python3.10/site-packages/threeML/plugin_prototype.py#119\u001b\\\u001b[2m119\u001b[0m\u001b]8;;\u001b\\\n",
        "\u001b[38;5;46m         \u001b[0m         \u001b[1;38;5;251mmeasurements such as AIC or BIC are unreliable                           \u001b[0m\u001b[1;38;5;251m \u001b[0m\u001b[2m                       \u001b[0m\n"
       ]
      },
@@ -355,7 +408,7 @@
     {
      "data": {
       "text/html": [
-       "<div><table id=\"table13612674512\">\n",
+       "<div><table id=\"table140529137338688\">\n",
        "<tr><td>1.00</td><td>0.00</td></tr>\n",
        "<tr><td>0.00</td><td>1.00</td></tr>\n",
        "</table></div>"
@@ -412,11 +465,11 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>cosi</th>\n",
-       "      <td>19260.057111</td>\n",
+       "      <td>19258.307907</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>total</th>\n",
-       "      <td>19260.057111</td>\n",
+       "      <td>19258.307907</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -424,8 +477,8 @@
       ],
       "text/plain": [
        "       -log(likelihood)\n",
-       "cosi       19260.057111\n",
-       "total      19260.057111"
+       "cosi       19258.307907\n",
+       "total      19258.307907"
       ]
      },
      "metadata": {},
@@ -475,11 +528,11 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>AIC</th>\n",
-       "      <td>38518.114221</td>\n",
+       "      <td>38514.615814</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>BIC</th>\n",
-       "      <td>38520.114221</td>\n",
+       "      <td>38516.615814</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -487,31 +540,12 @@
       ],
       "text/plain": [
        "     statistical measures\n",
-       "AIC          38518.114221\n",
-       "BIC          38520.114221"
+       "AIC          38514.615814\n",
+       "BIC          38516.615814"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "(                                             value  negative_error  \\\n",
-       " source.spectrum.grb.polarization.degree  27.984015       -2.817586   \n",
-       " source.spectrum.grb.polarization.angle   90.001559       -0.000649   \n",
-       " \n",
-       "                                          positive_error     error unit  \n",
-       " source.spectrum.grb.polarization.degree        2.726043  2.771814       \n",
-       " source.spectrum.grb.polarization.angle         0.000627  0.000638  deg  ,\n",
-       "        -log(likelihood)\n",
-       " cosi       19260.057111\n",
-       " total      19260.057111)"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -526,15 +560,15 @@
     "\n",
     "like = JointLikelihood(model, plugins, verbose=False)\n",
     "\n",
-    "like.fit()"
+    "like.fit();"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cosipy-fork",
+   "display_name": "cosipy",
    "language": "python",
-   "name": "python3"
+   "name": "cosipy"
   },
   "language_info": {
    "codemirror_mode": {
@@ -546,7 +580,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.19"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/run_tutorials.yml
+++ b/docs/tutorials/run_tutorials.yml
@@ -231,9 +231,23 @@ tutorials:
         COSI-SMEX/DC3/Data/Backgrounds/Ge/PrimaryProtons_3months_unbinned_data_filtered_with_SAAcut.fits.gz:
           checksum: 3264e6bf520f4c20e06aaaed5d57abf0
 
-    polarization:
+    polarization_asad:
       notebook:
         - polarization/ASAD_method.ipynb
+      ancillary_files:
+        - polarization/background_after.yaml
+        - polarization/background_before.yaml
+        - polarization/grb.yaml
+      wasabi_files:
+        COSI-SMEX/cosipy_tutorials/polarization_fit/grb_background.fits.gz:
+          checksum: 21b1d75891edc6aaf1ff3fe46e91cb49
+        COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits:
+          checksum: 29b8eef426efeba9f8cffcac715e94ea
+        COSI-SMEX/develop/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5:
+          checksum: 46b006a6b397fd777dc561d3b028357f
+
+    polarization_ml:
+      notebook:
         - polarization/maximum_likelihood_method.ipynb
       ancillary_files:
         - polarization/background_after.yaml

--- a/docs/tutorials/run_tutorials.yml
+++ b/docs/tutorials/run_tutorials.yml
@@ -231,8 +231,10 @@ tutorials:
         COSI-SMEX/DC3/Data/Backgrounds/Ge/PrimaryProtons_3months_unbinned_data_filtered_with_SAAcut.fits.gz:
           checksum: 3264e6bf520f4c20e06aaaed5d57abf0
 
-    polarization_asad:
-      notebook: polarization/ASAD_method.ipynb
+    polarization:
+      notebook:
+        - polarization/ASAD_method.ipynb
+        - polarization/maximum_likelihood_method.ipynb
       ancillary_files:
         - polarization/background_after.yaml
         - polarization/background_before.yaml


### PR DESCRIPTION
This patch adds the new maximum likelihood polarization tutorial to the list runnable from tutorials.yml.  I just run both it and the ASAD tutorial together, rather than creating separate entries for each.

I had to fix one issue with the tutorial notebook where there was some stuff commented out that should not have been.  I also did some very minor cosmetic cleanup and am checking in the expected output.