### PR TITLE
Back-compatibility patch for updated FITS orientation files in interfaces

### DIFF
--- a/cosipy/spacecraftfile/SpacecraftFile.py
+++ b/cosipy/spacecraftfile/SpacecraftFile.py
@@ -311,12 +311,16 @@ class SpacecraftFile():
 
         if 'Altitude' in t.colnames:
             altitude = t['Altitude']
+            if isinstance(altitude, u.Quantity):
+                altitude = altitude.value
         else:
             altitude = None
 
         if 'LiveTime' in t.colnames:
             # left end points, so remove last bin.
             livetime = t['LiveTime'][:-1]
+            if isinstance(livetime, u.Quantity):
+                livetime = livetime.value
         else:
             livetime = None
 

--- a/docs/tutorials/background_estimation/continuum_estimation/BG_estimation_example.ipynb
+++ b/docs/tutorials/background_estimation/continuum_estimation/BG_estimation_example.ipynb
@@ -310,7 +310,7 @@
    "outputs": [],
    "source": [
     "# DC3_final_530km_3_month_with_slew_15sbins_GalacticEarth_SAA.fits\n",
-    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_15sbins_GalacticEarth_SAA.fits', checksum = '603854cd315ad6e6ff999fa1f55942b6')"
+    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_15sbins_GalacticEarth_SAA.fits', checksum = 'e86df2407eb052cf0c1db4a8e7598727')"
    ]
   },
   {

--- a/docs/tutorials/image_deconvolution/optional/scatt_binned_data_w_local_coordinate/511keV-ScAtt-DataReduction.ipynb
+++ b/docs/tutorials/image_deconvolution/optional/scatt_binned_data_w_local_coordinate/511keV-ScAtt-DataReduction.ipynb
@@ -409,7 +409,7 @@
     "# Orientation file:\n",
     "# wasabi path: COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits\n",
     "# File size: 1.1G\n",
-    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = '29b8eef426efeba9f8cffcac715e94ea')         "
+    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = 'a9163ab4852c427d09bcfe02df71173a')         "
    ]
   },
   {

--- a/docs/tutorials/image_deconvolution/optional/time_binned_data_w_local_coordinate/GRB-ScAtt-ImageDeconvolution.ipynb
+++ b/docs/tutorials/image_deconvolution/optional/time_binned_data_w_local_coordinate/GRB-ScAtt-ImageDeconvolution.ipynb
@@ -436,7 +436,7 @@
     "# Orientation file:\n",
     "# wasabi path: COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits\n",
     "# File size: 1.1G\n",
-    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = '29b8eef426efeba9f8cffcac715e94ea')         "
+    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = 'a9163ab4852c427d09bcfe02df71173a')         "
    ]
   },
   {

--- a/docs/tutorials/polarization/ASAD_method.ipynb
+++ b/docs/tutorials/polarization/ASAD_method.ipynb
@@ -93,7 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = '29b8eef426efeba9f8cffcac715e94ea')"
+    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = 'a9163ab4852c427d09bcfe02df71173a')"
    ]
   },
   {

--- a/docs/tutorials/polarization/Stokes_method.ipynb
+++ b/docs/tutorials/polarization/Stokes_method.ipynb
@@ -72,7 +72,7 @@
    "source": [
     "fetch_wasabi_file('COSI-SMEX/cosipy_tutorials/polarization_fit/grb_background.fits.gz', checksum = '21b1d75891edc6aaf1ff3fe46e91cb49')\n",
     "fetch_wasabi_file('COSI-SMEX/develop/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5', checksum = '46b006a6b397fd777dc561d3b028357f')\n",
-    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = '29b8eef426efeba9f8cffcac715e94ea')"
+    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = 'a9163ab4852c427d09bcfe02df71173a')"
    ]
   },
   {

--- a/docs/tutorials/polarization/maximum_likelihood_method.ipynb
+++ b/docs/tutorials/polarization/maximum_likelihood_method.ipynb
@@ -121,12 +121,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "A file named DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits already exists with the specified checksum (29b8eef426efeba9f8cffcac715e94ea). Skipping.\n"
+      "A file named DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits already exists with the specified checksum (a9163ab4852c427d09bcfe02df71173a). Skipping.\n"
      ]
     }
    ],
    "source": [
-    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = '29b8eef426efeba9f8cffcac715e94ea')"
+    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = 'a9163ab4852c427d09bcfe02df71173a')"
    ]
   },
   {

--- a/docs/tutorials/response/DetectorResponse.ipynb
+++ b/docs/tutorials/response/DetectorResponse.ipynb
@@ -95,7 +95,7 @@
     "response_path = data_dir/\"SMEXv12.Continuum.HEALPixO3_10bins_log_flat.binnedimaging.imagingresponse.h5\"\n",
     "\n",
     "# download orientation file ~684.38 MB\n",
-    "fetch_wasabi_file(\"COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits\", ori_path, checksum = 'bf59c4b79bc95ab68bcd376357f7bd40')\n",
+    "fetch_wasabi_file(\"COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits\", ori_path, checksum = '5e69bc1d55fab9390f90635690f62896')\n",
     "\n",
     "# download response file ~596.06 MB\n",
     "fetch_wasabi_file(\"COSI-SMEX/develop/Data/Responses/SMEXv12.Continuum.HEALPixO3_10bins_log_flat.binnedimaging.imagingresponse.h5\", checksum = 'eb72400a1279325e9404110f909c7785')"

--- a/docs/tutorials/response/SpacecraftFile.ipynb
+++ b/docs/tutorials/response/SpacecraftFile.ipynb
@@ -114,7 +114,7 @@
    "outputs": [],
    "source": [
     "# download orientation file ~1.01 GB\n",
-    "fetch_wasabi_file(\"COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits\", ori_path, checksum = 'bf59c4b79bc95ab68bcd376357f7bd40')\n",
+    "fetch_wasabi_file(\"COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits\", ori_path, checksum = '5e69bc1d55fab9390f90635690f62896')\n",
     "\n",
     "# download response file ~596.06 MB\n",
     "fetch_wasabi_file(\"COSI-SMEX/develop/Data/Responses/SMEXv12.Continuum.HEALPixO3_10bins_log_flat.binnedimaging.imagingresponse.h5\", checksum = 'eb72400a1279325e9404110f909c7785')"

--- a/docs/tutorials/run_tutorials.yml
+++ b/docs/tutorials/run_tutorials.yml
@@ -45,7 +45,7 @@ tutorials:
       notebook: response/SpacecraftFile.ipynb
       wasabi_files:
         COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits:
-          checksum: bf59c4b79bc95ab68bcd376357f7bd40
+          checksum: 5e69bc1d55fab9390f90635690f62896
         COSI-SMEX/develop/Data/Responses/SMEXv12.Continuum.HEALPixO3_10bins_log_flat.binnedimaging.imagingresponse.h5:
           checksum: eb72400a1279325e9404110f909c7785
 
@@ -53,7 +53,7 @@ tutorials:
       notebook: response/DetectorResponse.ipynb
       wasabi_files:
         COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits:
-          checksum: bf59c4b79bc95ab68bcd376357f7bd40
+          checksum: 5e69bc1d55fab9390f90635690f62896
         COSI-SMEX/develop/Data/Responses/SMEXv12.Continuum.HEALPixO3_10bins_log_flat.binnedimaging.imagingresponse.h5:
           checksum: eb72400a1279325e9404110f909c7785
 
@@ -65,7 +65,7 @@ tutorials:
         COSI-SMEX/cosipy_tutorials/ts_maps/bkg_binned_data_local.hdf5:
           checksum: b842a7444e6fc1a5dd567b395c36ae7f
         COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits:
-          checksum: bf59c4b79bc95ab68bcd376357f7bd40
+          checksum: 5e69bc1d55fab9390f90635690f62896
         COSI-SMEX/cosipy_tutorials/ts_maps/Crab_galactic_CDS_binned.hdf5:
           checksum: 40bdc4bcf4dad040dca3bb0e203aad35
         COSI-SMEX/cosipy_tutorials/ts_maps/Albedo_galactic_CDS_binned.hdf5:
@@ -83,7 +83,7 @@ tutorials:
         - spectral_fits/continuum_fit/grb/grb.yaml
       wasabi_files:
         COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits:
-          checksum: bf59c4b79bc95ab68bcd376357f7bd40
+          checksum: 5e69bc1d55fab9390f90635690f62896
         COSI-SMEX/cosipy_tutorials/grb_spectral_fit_local_frame/grb_bkg_binned_data.hdf5:
           checksum: fce391a4b45624b25552c7d111945f60
         COSI-SMEX/cosipy_tutorials/grb_spectral_fit_local_frame/grb_binned_data.hdf5:
@@ -100,7 +100,7 @@ tutorials:
         - spectral_fits/continuum_fit/crab/crab.yaml
       wasabi_files:
         COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits:
-          checksum: bf59c4b79bc95ab68bcd376357f7bd40
+          checksum: 5e69bc1d55fab9390f90635690f62896
         COSI-SMEX/cosipy_tutorials/crab_spectral_fit_galactic_frame/crab_bkg_binned_data.hdf5:
           checksum: 85658e102414c4f746e64a7d29c607a4
         COSI-SMEX/cosipy_tutorials/crab_spectral_fit_galactic_frame/crab_binned_data.hdf5:
@@ -117,7 +117,7 @@ tutorials:
         - spectral_fits/extended_source_fit/OPsSpectrum.dat
       wasabi_files:
         COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits:
-          checksum: bf59c4b79bc95ab68bcd376357f7bd40
+          checksum: 5e69bc1d55fab9390f90635690f62896
         COSI-SMEX/DC2/Data/Backgrounds/cosmic_photons_3months_unbinned_data.fits.gz:
           checksum: faa82255b43d42a2b9c90621fabcb7d6
         COSI-SMEX/DC2/Data/Sources/511_Testing_3months_unbinned_data.fits.gz:
@@ -166,7 +166,7 @@ tutorials:
 #        COSI-SMEX/DC3/Data/Backgrounds/Ge/AlbedoPhotons_3months_unbinned_data_filtered_with_SAAcut.fits.gz:
 #          checksum: 191a451ee597fd2e4b1cf237fc72e6e2
 #        COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits:
-#          checksum: 29b8eef426efeba9f8cffcac715e94ea
+#          checksum: a9163ab4852c427d09bcfe02df71173a
 
     imaging_511_time_binning:
       notebook:
@@ -182,7 +182,7 @@ tutorials:
         COSI-SMEX/DC3/Data/Backgrounds/Ge/AlbedoPhotons_3months_unbinned_data_filtered_with_SAAcut.fits.gz:
          checksum: 191a451ee597fd2e4b1cf237fc72e6e2
         COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits:
-        checksum: 29b8eef426efeba9f8cffcac715e94ea
+        checksum: a9163ab4852c427d09bcfe02df71173a
 
     source_injector:
       notebook: source_injector/Point_source_injector.ipynb
@@ -192,7 +192,7 @@ tutorials:
         - source_injector/model_injected.h5
       wasabi_files:
         COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits:
-          checksum: bf59c4b79bc95ab68bcd376357f7bd40
+          checksum: 5e69bc1d55fab9390f90635690f62896
         COSI-SMEX/cosipy_tutorials/source_injector/crab_3months_unbinned_data.hdf5:
           checksum: 787f17ee7c23e5b94fb77cc52a117422
         COSI-SMEX/develop/Data/Responses/SMEXv12.Continuum.HEALPixO3_10bins_log_flat.binnedimaging.imagingresponse.h5:
@@ -212,7 +212,7 @@ tutorials:
       notebook: background_estimation/continuum_estimation/BG_estimation_example.ipynb
       wasabi_files:
         COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_15sbins_GalacticEarth_SAA.fits:
-          checksum: 603854cd315ad6e6ff999fa1f55942b6
+          checksum: e86df2407eb052cf0c1db4a8e7598727
         COSI-SMEX/cosipy_tutorials/background_estimation/crab_bkg_binned_data_galactic.hdf5:
           checksum: 7450f8ecdf6bf14bffe22d0046d47d49
         COSI-SMEX/cosipy_tutorials/background_estimation/inputs_crab.yaml:
@@ -242,7 +242,7 @@ tutorials:
         COSI-SMEX/cosipy_tutorials/polarization_fit/grb_background.fits.gz:
           checksum: 21b1d75891edc6aaf1ff3fe46e91cb49
         COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits:
-          checksum: 29b8eef426efeba9f8cffcac715e94ea
+          checksum: a9163ab4852c427d09bcfe02df71173a
         COSI-SMEX/develop/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5:
           checksum: 46b006a6b397fd777dc561d3b028357f
 
@@ -257,7 +257,7 @@ tutorials:
         COSI-SMEX/cosipy_tutorials/polarization_fit/grb_background.fits.gz:
           checksum: 21b1d75891edc6aaf1ff3fe46e91cb49
         COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits:
-          checksum: 29b8eef426efeba9f8cffcac715e94ea
+          checksum: a9163ab4852c427d09bcfe02df71173a
         COSI-SMEX/develop/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5:
           checksum: 46b006a6b397fd777dc561d3b028357f
 
@@ -272,7 +272,7 @@ tutorials:
         COSI-SMEX/cosipy_tutorials/polarization_fit/grb_background.fits.gz:
           checksum: 21b1d75891edc6aaf1ff3fe46e91cb49
         COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits:
-          checksum: 29b8eef426efeba9f8cffcac715e94ea
+          checksum: a9163ab4852c427d09bcfe02df71173a
         COSI-SMEX/develop/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5:
           checksum: 46b006a6b397fd777dc561d3b028357f
 
@@ -282,7 +282,7 @@ tutorials:
         - spectral_fits/galactic_diffuse_continuum/galdiff.yaml
       wasabi_files:
         COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_15sbins_GalacticEarth_SAA.fits:
-          checksum: 603854cd315ad6e6ff999fa1f55942b6
+          checksum: e86df2407eb052cf0c1db4a8e7598727
           COSI-SMEX/DC3/Data/Backgrounds/Ge/AlbedoPhotons_3months_unbinned_data_filtered_with_SAAcut.fits.gz:
           checksum: 191a451ee597fd2e4b1cf237fc72e6e2
         COSI-SMEX/DC3/Data/Sources/GalTotal_SA100_F98_3months_unbinned_data_filtered_with_SAAcut.fits.gz:

--- a/docs/tutorials/source_injector/Point_source_injector.ipynb
+++ b/docs/tutorials/source_injector/Point_source_injector.ipynb
@@ -103,7 +103,7 @@
     "orientation_path = data_dir/\"20280301_3_month_with_orbital_info.fits\"\n",
     "\n",
     "# download orientation file ~596.06 MB\n",
-    "fetch_wasabi_file(\"COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits\", orientation_path, checksum = 'bf59c4b79bc95ab68bcd376357f7bd40')"
+    "fetch_wasabi_file(\"COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits\", orientation_path, checksum = '5e69bc1d55fab9390f90635690f62896')"
    ]
   },
   {

--- a/docs/tutorials/spectral_fits/continuum_fit/crab/SpectralFit_Crab.ipynb
+++ b/docs/tutorials/spectral_fits/continuum_fit/crab/SpectralFit_Crab.ipynb
@@ -132,12 +132,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "A file named 20280301_3_month_with_orbital_info.fits already exists with the specified checksum (bf59c4b79bc95ab68bcd376357f7bd40). Skipping.\n"
+      "A file named 20280301_3_month_with_orbital_info.fits already exists with the specified checksum (5e69bc1d55fab9390f90635690f62896). Skipping.\n"
      ]
     }
    ],
    "source": [
-    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits', output = data_path / '20280301_3_month_with_orbital_info.fits', checksum = 'bf59c4b79bc95ab68bcd376357f7bd40')"
+    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits', output = data_path / '20280301_3_month_with_orbital_info.fits', checksum = '5e69bc1d55fab9390f90635690f62896')"
    ]
   },
   {

--- a/docs/tutorials/spectral_fits/continuum_fit/grb/SpectralFit_GRB.ipynb
+++ b/docs/tutorials/spectral_fits/continuum_fit/grb/SpectralFit_GRB.ipynb
@@ -134,12 +134,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "A file named 20280301_3_month_with_orbital_info.fits already exists with the specified checksum (bf59c4b79bc95ab68bcd376357f7bd40). Skipping.\n"
+      "A file named 20280301_3_month_with_orbital_info.fits already exists with the specified checksum (5e69bc1d55fab9390f90635690f62896). Skipping.\n"
      ]
     }
    ],
    "source": [
-    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits', output = data_path / '20280301_3_month_with_orbital_info.fits', checksum = 'bf59c4b79bc95ab68bcd376357f7bd40')"
+    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits', output = data_path / '20280301_3_month_with_orbital_info.fits', checksum = '5e69bc1d55fab9390f90635690f62896')"
    ]
   },
   {

--- a/docs/tutorials/spectral_fits/extended_source_fit/diffuse_511_spectral_fit.ipynb
+++ b/docs/tutorials/spectral_fits/extended_source_fit/diffuse_511_spectral_fit.ipynb
@@ -91,7 +91,7 @@
     "# ori file:\n",
     "# wasabi path: COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits\n",
     "# File size: 684 MB\n",
-    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits', checksum = 'bf59c4b79bc95ab68bcd376357f7bd40')"
+    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits', checksum = '5e69bc1d55fab9390f90635690f62896')"
    ]
   },
   {

--- a/docs/tutorials/spectral_fits/galactic_diffuse_continuum/galdiff_continuum.ipynb
+++ b/docs/tutorials/spectral_fits/galactic_diffuse_continuum/galdiff_continuum.ipynb
@@ -59,7 +59,7 @@
    "outputs": [],
    "source": [
     "# ori file\n",
-    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_15sbins_GalacticEarth_SAA.fits', checksum = '603854cd315ad6e6ff999fa1f55942b6')"
+    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_15sbins_GalacticEarth_SAA.fits', checksum = 'e86df2407eb052cf0c1db4a8e7598727')"
    ]
   },
   {

--- a/docs/tutorials/ts_map/TS_map_fitting.ipynb
+++ b/docs/tutorials/ts_map/TS_map_fitting.ipynb
@@ -284,7 +284,7 @@
     "orientation_path = data_dir/\"20280301_3_month_with_orbital_info.fits\"\n",
     "\n",
     "# download orientation file ~684.38 MB\n",
-    "fetch_wasabi_file(\"COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits\", orientation_path, checksum = 'bf59c4b79bc95ab68bcd376357f7bd40')"
+    "fetch_wasabi_file(\"COSI-SMEX/develop/Data/Orientation/20280301_3_month_with_orbital_info.fits\", orientation_path, checksum = '5e69bc1d55fab9390f90635690f62896')"
    ]
   },
   {


### PR DESCRIPTION
The FITS orientation files created by the interfaces branch add units to every column; this was the subject of the recent PR #19 to interfaces.  This patch ensures that develop can use these new FITS files without trouble by having open() strip units from quantities that did not have them in the older FITS files.

The bulk of the patch updates the tutorials with the correct md5 checksums for the new versions of the FITS orientation files in the develop subtree of wasabi.