### PR TITLE
Add tests for MacOS with M chip

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   tests:
 
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macos-latest]
     strategy:
       matrix:
         python-version: ["3.12"]

--- a/.github/workflows/unit_tests_ml.yml
+++ b/.github/workflows/unit_tests_ml.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   tests:
 
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, macos-latest]
     strategy:
       matrix:
         python-version: ["3.12"]


### PR DESCRIPTION
This add the macos-latest runner for the units tests, which uses and M chip:
https://docs.github.com/en/actions/reference/runners/github-hosted-runners

This is motivated by the different backends pytorch can use, but it's a good idea in general to check multiple systems. 
