### PR TITLE
Add tests for MacOS with M chip

### DIFF
--- a/.github/workflows/unit_tests_macos.yml
+++ b/.github/workflows/unit_tests_macos.yml
@@ -1,0 +1,34 @@
+name: unit_tests_macos
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Tests
+        run: |
+          pip install pytest pytest-cov
+          pytest tests --junitxml=junit/test-results.xml --cov=cosipy --cov-report=xml --cov-report=html
+      - name: Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          

--- a/.github/workflows/unit_tests_ml_macos.yml
+++ b/.github/workflows/unit_tests_ml_macos.yml
@@ -1,0 +1,34 @@
+name: unit_tests_ml_macos
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[ml]"
+      - name: Tests
+        run: |
+          pip install pytest pytest-cov
+          pytest tests --junitxml=junit/test-results.xml --cov=cosipy --cov-report=xml --cov-report=html
+      - name: Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          


### PR DESCRIPTION
This add the macos-latest runner for the units tests, which uses and M chip:
https://docs.github.com/en/actions/reference/runners/github-hosted-runners

This is motivated by the different backends pytorch can use, but it's a good idea in general to check multiple systems.