### PR TITLE
Modify ori file reader to deal with absence of EN (or not) at the end of the file

### DIFF
--- a/cosipy/spacecraftfile/spacecraft_file.py
+++ b/cosipy/spacecraftfile/spacecraft_file.py
@@ -410,7 +410,9 @@ class SpacecraftHistory:
         df = pd.read_csv(file, sep=r"\s+", skiprows=1,
                          usecols=tuple(range(1,10)),
                          header = None, comment = '#')
-        vals = df.values[:-1].transpose()
+        #if there is EN at the end of the ori file, then the last line will
+        #contain NaN values.
+        vals = df.dropna()
 
         # assign units to read values
         time_stamps = Time(vals[0], format="unix", copy=False)

--- a/cosipy/spacecraftfile/spacecraft_file.py
+++ b/cosipy/spacecraftfile/spacecraft_file.py
@@ -412,7 +412,7 @@ class SpacecraftHistory:
                          header = None, comment = '#')
         #if there is EN at the end of the ori file, then the last line will
         #contain NaN values.
-        vals = df.dropna()
+        vals = df.dropna().transpose()
 
         # assign units to read values
         time_stamps = Time(vals[0], format="unix", copy=False)

--- a/cosipy/spacecraftfile/spacecraft_file.py
+++ b/cosipy/spacecraftfile/spacecraft_file.py
@@ -412,7 +412,7 @@ class SpacecraftHistory:
                          header = None, comment = '#')
         #if there is EN at the end of the ori file, then the last line will
         #contain NaN values.
-        vals = df.dropna().transpose()
+        vals = df.dropna().values.transpose()
 
         # assign units to read values
         time_stamps = Time(vals[0], format="unix", copy=False)


### PR DESCRIPTION
This pr is for solving #503 .

If there is EN at the end of the ori file, `dropna` will remove it. If not , nothing will change 