### PR TITLE
asarray force_dtype options

### DIFF
--- a/cosipy/util/iterables.py
+++ b/cosipy/util/iterables.py
@@ -1,4 +1,6 @@
 import itertools
+from typing import Union, Iterable, Optional
+import numpy.typing as npt
 
 import numpy as np
 
@@ -18,8 +20,30 @@ def itertools_batched(iterable, n, *, strict=False):
             raise ValueError('batched(): incomplete batch')
         yield batch
 
-def asarray(a, dtype):
+def asarray(a : Union[npt.ArrayLike, Iterable], dtype:npt.DTypeLike, force_dtype = True):
+    """
+    Convert an iterable or an array-like object into a numpy array.
+
+    Parameters
+    ----------
+    a: Iterable or array-like object
+    dtype: Desired type (e.g. np.float64)
+    force_dtype: If True, it is guaranteed that the output will have the specified dtype. If False,
+        we will attempt to infer the data-type from the input data, and dtype will be considered a fallback option.
+        Relaxing the dtype requirement can prevent an unnecessary copy if the input type does not exactly match the
+        requested dtype (e.g. np.float32 vs np.float64)
+
+    Returns
+    -------
+
+    """
     if hasattr(a, "__len__"):
+        # np.asarray does not work with an object without __len__
+        if not force_dtype:
+            # the data-type is inferred from the input data.
+            dtype = None
+
         return np.asarray(a, dtype = dtype)
     else:
+        # fromiter needs a dtype
         return np.fromiter(a, dtype = dtype)

--- a/tests/util/test_iterables.py
+++ b/tests/util/test_iterables.py
@@ -1,0 +1,65 @@
+from cosipy.util.iterables import asarray
+import numpy as np
+
+def test_asarray():
+
+    # From array
+    a = np.asarray([1,2,3], dtype = int)
+
+    # Same dtype. No copy
+    b = asarray(a, int)
+    assert isinstance(b, np.ndarray)
+    assert b.dtype == int
+    assert np.shares_memory(a, b)
+    assert np.allclose(b, a)
+
+    # Different dtype
+    b = asarray(a, np.float64)
+    assert isinstance(b, np.ndarray)
+    assert b.dtype == np.float64
+    assert np.allclose(b, a)
+
+    # Soft dtype requirement. No copy
+    b = asarray(a, np.float64, force_dtype=False)
+    assert isinstance(b, np.ndarray)
+    assert b.dtype == int
+    assert np.shares_memory(a,b)
+    assert np.allclose(b, a)
+
+    # From array-like
+    a = [1,2,3]
+
+    # With force dtype
+    b = asarray(a, np.float64)
+    assert isinstance(b, np.ndarray)
+    assert b.dtype == np.float64
+    assert np.allclose(b, a)
+
+    b = asarray(a, np.int32)
+    assert isinstance(b, np.ndarray)
+    assert b.dtype == np.int32
+    assert np.allclose(b, a)
+
+    # Relax dtype. No copy
+    b = asarray(a, np.float64, force_dtype=False)
+    assert isinstance(b, np.ndarray)
+    assert b.dtype == np.asarray(a).dtype # numpy infers int64
+    assert np.allclose(b, a)
+
+    # From generator w/o len
+    a_list = [1,2,3]
+    def gen():
+        for i in a_list:
+            yield i
+
+    a = gen()
+    b = asarray(a, np.float64)
+    assert isinstance(b, np.ndarray)
+    assert b.dtype == np.float64
+    assert np.allclose(b, a_list)
+
+    a = gen()
+    b = asarray(a, np.int32)
+    assert isinstance(b, np.ndarray)
+    assert b.dtype == np.int32
+    assert np.allclose(b, a_list)


### PR DESCRIPTION
Allows to relax the dtype requirement to prevent unnecessary copy of the data.