### PR TITLE
Proactively add **kwargs to Histogram subclasses' _open() and ._write() methods

### DIFF
--- a/cosipy/response/DetectorResponse.py
+++ b/cosipy/response/DetectorResponse.py
@@ -45,15 +45,15 @@ class DetectorResponse(Histogram):
 
         return new
 
-    def _write(self, file, group_name):
-        group = super()._write(file, group_name)
+    def _write(self, file, group_name, **kwargs):
+        group = super()._write(file, group_name, **kwargs)
 
         # do not write _spec and _aeff, as they
         # can be recomputed after load later on
 
     @classmethod
-    def _open(cls, hist_group):
-        new = super()._open(hist_group)
+    def _open(cls, hist_group, **kwargs):
+        new = super()._open(hist_group, **kwargs)
 
         new._spec = None
         new._aeff = None

--- a/cosipy/response/ExtendedSourceResponse.py
+++ b/cosipy/response/ExtendedSourceResponse.py
@@ -52,7 +52,7 @@ class ExtendedSourceResponse(Histogram):
         self._exp_unit = (u.s * u.cm**2 * u.sr)**(-1)
 
     @classmethod
-    def _open(cls, name='hist'):
+    def _open(cls, name='hist', **kwargs):
         """
         Load response from an HDF5 group.
 
@@ -72,7 +72,7 @@ class ExtendedSourceResponse(Histogram):
             If the shape of the contents does not match the axes.
         """
 
-        resp = super()._open(name)
+        resp = super()._open(name, **kwargs)
 
         resp.track_overflow(False)
 


### PR DESCRIPTION
This patch changes the two response classes that subclass Histogram and override its _open and/or _write methods to accept **kwargs and pass them on to the superclass.  This change is harmless right now and will support planned extension of the base Histogram class's _open/_write to support compression.