### PR TITLE
Explicitly check for "EN" at end of .ori files

### DIFF
--- a/cosipy/spacecraftfile/spacecraft_file.py
+++ b/cosipy/spacecraftfile/spacecraft_file.py
@@ -402,10 +402,25 @@ class SpacecraftHistory:
         # Type OrientationsGalactic
         # ...
         # EN
-        # Using [:-1] instead of skipfooter=1 because otherwise it's
-        # slow and you get ParserWarning: Falling back to the 'python'
-        # engine because the 'c' engine does not support skipfooter;
-        # you can avoid this warning by specifying engine='python'.
+
+        # Check that the EN line is present (and throw an error if
+        # not), lest we accidentally drop the last line of orientation
+        # data!
+        with open(file, "rb") as ori_file:
+            ori_file.seek(-4, 2)
+            s = ori_file.read(4)
+
+            # allow for possibility of missing EOL at end of file
+            if s[-1] == ord('\n'):
+                s = s[:-1]
+
+            if s != b'\nEN':
+                raise ValueError(".ori file must end with final line 'EN'!")
+
+        # now read the full file, skipping the first and last line.
+        # Use [:-1] instead of skipfooter=1; the latter causes a
+        # fallback to the slow Python CSV reading engine instead of
+        # faster C engine.
 
         df = pd.read_csv(file, sep=r"\s+", skiprows=1,
                          usecols=tuple(range(1,10)),
@@ -1141,7 +1156,7 @@ class SpacecraftHistory:
             # do not interpolate
             pixels = base.ang2pix(theta=theta,
                                   phi=phi,
-                                  lonlat=lonlat)
+                                  lonlat=False)
             weighted_duration = duration
 
         unique_pixels, unique_weights = \

--- a/tests/spacecraftfile/test_spacecraftfile.py
+++ b/tests/spacecraftfile/test_spacecraftfile.py
@@ -5,6 +5,8 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.time import Time
 
+from mhealpy import HealpixBase
+
 from cosipy import test_data
 from cosipy import SpacecraftHistory
 
@@ -184,6 +186,27 @@ def test_interp_location():
     assert np.allclose(loc,
                        ori.location[1].cartesian.xyz.to_value(u.km))
 
+
+def test_get_exposure():
+    ori_path = test_data.path / "20280301_first_10sec.fits"
+    ori = SpacecraftHistory.open(ori_path)
+
+    target_coord = SkyCoord(l=184.5551, b = -05.7877,
+                            unit = u.deg, frame = "galactic")
+
+    b = HealpixBase(nside=1)
+    pix, weights = ori.get_exposure(target_coord, b,
+                                    interp = True, earth_occ = False)
+
+    assert np.array_equal(pix, [0, 1, 2, 3])
+    assert np.allclose(weights,
+                       [1.89505713, 7.61558445, 0.24467921, 0.24467921] * u.s)
+
+    pix, weights = ori.get_exposure(target_coord, b,
+                                    interp = False, earth_occ = False)
+
+    assert np.array_equal(pix, [1])
+    assert np.allclose(weights, [10.] * u.s)
 
 def test_get_dwell_map():
 


### PR DESCRIPTION
MEGAlib .ori files end with the tag "EN" on a line by itself.  This tag is removed when the file is read in.  Recently, we discovered that some .ori files in cosipy were missing that terminal EN; those files were fixed, but we still need to properly detect the missing EN.

This patch chooses to reject files without the terminal EN, rather than attempt to work around them, because trying to "do the right thing" would need to handle all sorts of cases.  For example, there might be multiple lines of garbage at the end of the file.

This PR is intended to supersede #516.

Since I was editing this file anyway, I also included a one-line fix for issue #527 with a suitable test case.