### PR TITLE
Faster TimeSelector and SpacecraftHistory

### DIFF
--- a/cosipy/event_selection/time_selection.py
+++ b/cosipy/event_selection/time_selection.py
@@ -9,12 +9,12 @@ from astropy.time import Time
 
 from cosipy.interfaces import TimeTagEventInterface, EventInterface, TimeTagEventDataInterface
 from cosipy.interfaces.event_selection import EventSelectorInterface
-from cosipy.util.iterables import itertools_batched
+from cosipy.util.iterables import itertools_batched, asarray
 
 
 class TimeSelector(EventSelectorInterface):
 
-    def __init__(self, tstart:Time = None, tstop:Time = None, batch_size:int = 10000):
+    def __init__(self, tstart:Time = None, tstop:Time = None, batch_size:int = None):
         """
         Assumes events are time-ordered
         
@@ -31,11 +31,15 @@ class TimeSelector(EventSelectorInterface):
         Parameters
         ----------
         tstart: Time, scalar Time, or None
-            Start time(s). If list, tstop must also be a list of same length.
+            Start time(s) [inclusive]. If list, tstop must also be a list of same length.
         tstop: Time, scalar Time, or None
-            Stop time(s). If list, tstart must also be a list of same length.
-        batch_size: int, default 10000
+            Stop time(s) [exclusive]. If list, tstart must also be a list of same length.
+        batch_size: int, default None
             Number of events to process at once
+            If None, all values are processed in a single batch.
+            This parameter only affects iteration when the expectation density
+            is provided as an iterator that is not a numpy array. If it is already
+            an array batching is not applied.
         """
         if tstart is not None and tstop is not None:
             if not tstart.isscalar == tstop.isscalar:
@@ -67,11 +71,30 @@ class TimeSelector(EventSelectorInterface):
                 logger.error(f"tstart and tstop must have same length.")
                 raise ValueError
 
-        self._tstart_list = tstart
-        self._tstop_list = tstop
+        # Convert to relative time with respect to earlier time
+        # It's faster to compare a single number than an astropy Time objects,
+        # at the expense of loosing sub-ns precision for year-long durations
+        # e.g. us precision for 10 years
+        if tstart is not None:
+            self._t0 = tstart[0]
+        elif tstop is not None:
+            self._t0 = tstop[0]
+        else:
+            self._t0 = None
+
+        if self._t0 is None:
+            self._tstart_list = None
+            self._tstop_list = None
+        else:
+            self._tstart_list = self._get_dt_jd(tstart) if tstart is not None else None
+            self._tstop_list = self._get_dt_jd(tstop)if tstop is not None else None
 
         self._batch_size = batch_size
-    
+
+    def _get_dt_jd(self, time: Time):
+        time = time - self._t0
+        return time.jd1 + time.jd2
+
     @classmethod
     def from_gti(cls, gti, batch_size:int = 10000):
         """
@@ -93,39 +116,60 @@ class TimeSelector(EventSelectorInterface):
 
     def _select(self, events:TimeTagEventDataInterface, early_stop:bool = True) -> Iterable[bool]:
 
-        # Working in chunks/batches.
-        # This can optimized based on the system and if events is pre-cached
-        # (e.g. events.jd1 and events.jd2 are numpy arrays)
+        def process_chunk(jd1: np.ndarray, jd2:np.ndarray):
 
-        for chunk in itertools_batched(events, self._batch_size):
+            if self._t0 is None:
+                # Means tstart=tstop=None
+                return np.ones_like(jd1, dtype=bool), True
 
-            jd1 = []
-            jd2 = []
+            # Relative time to t0
+            time = Time(jd1, jd2, format = 'jd', copy = False)
+            time = self._get_dt_jd(time)
 
-            for event in chunk:
-                jd1.append(event.jd1)
-                jd2.append(event.jd2)
-
-            time = Time(jd1, jd2, format = 'jd')
-
-            if self._tstart_list is None and self._tstop_list is None:
-                result = np.ones(len(time), dtype=bool)
-
-            elif self._tstart_list is None:
-                result = time <= self._tstop_list[0]
+            if self._tstart_list is None:
+                result = time < self._tstop_list[0]
 
             elif self._tstop_list is None:
-                result = time > self._tstart_list[0]
+                result = time >= self._tstart_list[0]
 
             else:
                 indices = np.searchsorted(self._tstart_list, time, side='right') - 1
                 valid = (indices >= 0) & (indices < len(self._tstop_list))
                 result = np.zeros(len(time), dtype=bool)
-                result[valid] = time[valid] <= self._tstop_list[indices[valid]]
+                result[valid] = time[valid] < self._tstop_list[indices[valid]]
 
-            for sel in result:
-                yield sel
+            # Stop further loading of event
+            stop = early_stop and (self._tstop_list is not None and len(time) > 0) and time[-1] > self._tstop_list[-1]
 
-            if early_stop and (self._tstop_list is not None and len(time) > 0) and time[-1] > self._tstop_list[-1]:
-                # Stop further loading of event
-                return
+            return result, stop
+
+        def process_in_chunks(events):
+
+            for chunk in itertools_batched(events, self._batch_size):
+
+                jd1 = []
+                jd2 = []
+
+                for event in chunk:
+                    jd1.append(event.jd1)
+                    jd2.append(event.jd2)
+
+                # Cache in memory
+                jd1 = asarray(jd1, dtype=np.float64, force_dtype=False)
+                jd2 = asarray(jd2, dtype=np.float64, force_dtype=False)
+
+                result, stop = process_chunk(jd1, jd2)
+
+                yield from result
+
+                if stop:
+                    return
+
+        if (self._batch_size is None) or (isinstance(events.jd1, np.ndarray) and isinstance(events.jd2, np.ndarray)):
+            results, _ = process_chunk(events.jd1, events.jd2)
+            return results
+        else:
+            return process_in_chunks(events)
+
+
+

--- a/cosipy/event_selection/time_selection.py
+++ b/cosipy/event_selection/time_selection.py
@@ -86,14 +86,10 @@ class TimeSelector(EventSelectorInterface):
             self._tstart_list = None
             self._tstop_list = None
         else:
-            self._tstart_list = self._get_dt_jd(tstart) if tstart is not None else None
-            self._tstop_list = self._get_dt_jd(tstop)if tstop is not None else None
+            self._tstart_list = (tstart - self._t0).jd if tstart is not None else None
+            self._tstop_list = (tstop - - self._t0).jd if tstop is not None else None
 
         self._batch_size = batch_size
-
-    def _get_dt_jd(self, time: Time):
-        time = time - self._t0
-        return time.jd1 + time.jd2
 
     @classmethod
     def from_gti(cls, gti, batch_size:int = 10000):
@@ -124,7 +120,7 @@ class TimeSelector(EventSelectorInterface):
 
             # Relative time to t0
             time = Time(jd1, jd2, format = 'jd', copy = False)
-            time = self._get_dt_jd(time)
+            time = (time - self._t0).jd
 
             if self._tstart_list is None:
                 result = time < self._tstop_list[0]

--- a/cosipy/event_selection/time_selection.py
+++ b/cosipy/event_selection/time_selection.py
@@ -129,10 +129,13 @@ class TimeSelector(EventSelectorInterface):
                 result = time >= self._tstart_list[0]
 
             else:
-                indices = np.searchsorted(self._tstart_list, time, side='right') - 1
-                valid = (indices >= 0) & (indices < len(self._tstop_list))
+
                 result = np.zeros(len(time), dtype=bool)
-                result[valid] = time[valid] < self._tstop_list[indices[valid]]
+
+                lo_idx,hi_idx = np.searchsorted(time, [self._tstart_list, self._tstop_list], side='left')
+
+                for lo,hi in zip(lo_idx,hi_idx):
+                    result[lo:hi] = True
 
             # Stop further loading of event
             stop = early_stop and (self._tstop_list is not None and len(time) > 0) and time[-1] > self._tstop_list[-1]

--- a/cosipy/event_selection/time_selection.py
+++ b/cosipy/event_selection/time_selection.py
@@ -87,7 +87,7 @@ class TimeSelector(EventSelectorInterface):
             self._tstop_list = None
         else:
             self._tstart_list = (tstart - self._t0).jd if tstart is not None else None
-            self._tstop_list = (tstop - - self._t0).jd if tstop is not None else None
+            self._tstop_list = (tstop - self._t0).jd if tstop is not None else None
 
         self._batch_size = batch_size
 

--- a/cosipy/spacecraftfile/spacecraft_file.py
+++ b/cosipy/spacecraftfile/spacecraft_file.py
@@ -297,14 +297,9 @@ class SpacecraftHistory:
         else:
             t0 = time[0]
 
-        time = time - t0
-        time = time.jd1 + time.jd2
-
-        tstart = tstart - t0
-        tstart = tstart.jd1 + tstart.jd2
-
-        tstop = tstop - t0
-        tstop = tstop.jd1 + tstop.jd2
+        time = (time - t0).jd
+        tstart = (tstart - t0).jd
+        tstop = (tstop - t0).jd
 
         if tstart is not None:
             if tstop is not None:

--- a/cosipy/spacecraftfile/spacecraft_file.py
+++ b/cosipy/spacecraftfile/spacecraft_file.py
@@ -291,8 +291,7 @@ class SpacecraftHistory:
     @staticmethod
     def _find_time_index(time:Time, tstart:Time, tstop:Time):
 
-        if time.shape == ():
-            # Scalar
+        if time.isscalar:
             t0 = time
         else:
             t0 = time[0]

--- a/cosipy/spacecraftfile/spacecraft_file.py
+++ b/cosipy/spacecraftfile/spacecraft_file.py
@@ -318,7 +318,7 @@ class SpacecraftHistory:
 
         # Include the full bin, but prevent an index error
         start_idx = max(0, start_idx - 1)
-        start_idx = min(time.size, stop_idx + 1)
+        stop_idx = min(time.size, stop_idx + 1)
 
         return start_idx, stop_idx
 

--- a/cosipy/spacecraftfile/spacecraft_file.py
+++ b/cosipy/spacecraftfile/spacecraft_file.py
@@ -70,7 +70,11 @@ class SpacecraftHistory:
 
         """
 
-        time_axis = TimeAxis(obstime, copy = False, label= 'obstime')
+        self._obstime = obstime
+        self._t0 = self._obstime[0]
+        self._obstime_dt_jd = self._get_dt_jd(obstime)
+
+        time_axis = Axis(self._obstime_dt_jd, copy = False, label= 'obstime_dt_jd')
 
         if livetime is None:
             livetime = time_axis.widths.to(u.s)
@@ -90,37 +94,41 @@ class SpacecraftHistory:
 
         self._cache_earth_occ = False
 
+    def _get_dt_jd(self, time: Time):
+        time = time - self._t0
+        return time.jd1 + time.jd2
+
     @property
     def nintervals(self):
         return self._livetime_hist.nbins
 
     @property
     def intervals_duration(self):
-        return self._livetime_hist.axis.widths.to(self._livetime_hist.unit)
+        return Quantity(self._livetime_hist.axis.widths, u.day, copy = False)
 
     @property
     def intervals_tstart(self):
-        return self._livetime_hist.axis.lower_bounds
+        return self._obstime[:-1]
 
     @property
     def intervals_tstop(self):
-        return self._livetime_hist.axis.upper_bounds
+        return self._obstime[1:]
 
     @property
     def tstart(self):
-        return self._livetime_hist.axis.lo_lim
+        return self._obstime[0]
 
     @property
     def tstop(self):
-        return self._livetime_hist.axis.hi_lim
+        return self._obstime[-1]
 
     @property
     def npoints(self):
-        return self._livetime_hist.nbins + 1
+        return self._obstime.size
 
     @property
     def obstime(self):
-        return self._livetime_hist.axis.edges
+        return self._obstime
 
     @property
     def livetime(self):
@@ -279,18 +287,34 @@ class SpacecraftHistory:
     @staticmethod
     def _find_time_index(time:Time, tstart:Time, tstop:Time):
 
-        # TimeAxis optimizes searchsorted for 128bit precision
-        time_axis = TimeAxis(time, copy=False)
+        if time.shape == ():
+            # Scalar
+            t0 = time
+        else:
+            t0 = time[0]
+
+        time = time - t0
+        time = time.jd1 + time.jd2
+
+        tstart = tstart - t0
+        tstart = tstart.jd1 + tstart.jd2
+
+        tstop = tstop - t0
+        tstop = tstop.jd1 + tstop.jd2
 
         if tstart is not None:
-            start_idx = time_axis.find_bin(tstart)
+            if tstop is not None:
+                start_idx, stop_idx = np.searchsorted(time, [tstart, tstop], side='right')
+            else:
+                start_idx = np.searchsorted(time, tstart, side='right')
+                stop_idx = time.size
         else:
             start_idx = 0
+            stop_idx = np.searchsorted(time, tstop, side='right')
 
-        if tstop is not None:
-            stop_idx = time_axis.find_bin(tstop) + 2
-        else:
-            stop_idx = time.size
+        # Include the full bin, but prevent an index error
+        start_idx = max(0, start_idx - 1)
+        start_idx = min(time.size, stop_idx + 1)
 
         return start_idx, stop_idx
 
@@ -723,6 +747,7 @@ class SpacecraftHistory:
         return self._cumulative_livetime(points, weights)
 
     def interp_weights(self, times: Time):
+        times = self._get_dt_jd(times)
         return self._livetime_hist.axis.interp_weights_edges(times)
 
     def interp(self, times: Time) -> 'SpacecraftHistory':

--- a/cosipy/spacecraftfile/spacecraft_file.py
+++ b/cosipy/spacecraftfile/spacecraft_file.py
@@ -71,6 +71,10 @@ class SpacecraftHistory:
         """
 
         self._obstime = obstime
+
+        if obstime.size < 2:
+            raise ValueError("SpacecraftHistory needs at least two timestamps.")
+
         self._t0 = self._obstime[0]
         self._obstime_dt_jd = self._get_dt_jd(obstime)
 

--- a/tests/event_selection/test_time_selector.py
+++ b/tests/event_selection/test_time_selector.py
@@ -1,0 +1,145 @@
+from typing import Iterable
+
+import numpy as np
+import pytest
+from astropy.time import Time
+from astropy.utils.metadata.utils import dtype
+
+from cosipy.event_selection import GoodTimeInterval
+from cosipy.event_selection.time_selection import TimeSelector
+from cosipy.interfaces import TimeTagEventInterface, TimeTagEventDataInterface
+from cosipy.util.iterables import asarray
+
+# Dummy events
+times = Time(60000 + np.arange(0,15), format = 'jd')
+
+class DummyTimeTagEventData(TimeTagEventDataInterface):
+
+    @property
+    def jd1(self) -> Iterable[float]:
+        return times.jd1
+
+    @property
+    def jd2(self) -> Iterable[float]:
+        return times.jd2
+
+class DummyTimeTagEvent(TimeTagEventInterface):
+
+    def __init__(self, jd1, jd2):
+        self._jd1 = jd1
+        self._jd2 = jd2
+
+    @property
+    def jd1(self) -> float:
+        return self._jd1
+
+    @property
+    def jd2(self) -> float:
+        return self._jd2
+
+class DummyTimeTagEventDataIterable(TimeTagEventDataInterface):
+
+    def __iter__(self):
+        for jd2, jd1 in zip(times.jd1, times.jd2):
+            yield DummyTimeTagEvent(jd1, jd2)
+
+events = DummyTimeTagEventData()
+events_iter = DummyTimeTagEventDataIterable()
+
+def test_time_selector():
+
+    tstart = Time(60000. + np.asarray([0, 5]), format='jd')
+    tstop = Time(60000. + np.asarray([1, 10]), format='jd')
+    selected = np.asarray(
+        [True, False, False, False, False, True, True, True, True, True, False, False, False, False, False])
+
+    # From array
+    selector = TimeSelector(tstart, tstop)
+
+    mask = selector.select(events) # Returned as array
+
+    assert np.all(mask == selected)
+
+    # From iter. early_stop by default
+    selector = TimeSelector(tstart, tstop, batch_size=2)
+
+    mask = asarray(selector.select(events_iter), dtype=bool)  # Yield another iterator
+
+    assert np.all(mask == selected[:12])
+
+    # From iter. no early_stop
+    selector = TimeSelector(tstart, tstop, batch_size=2)
+
+    mask = asarray(selector.select(events_iter, early_stop=False), dtype=bool) # Yield another iterator
+
+    assert np.all(mask == selected)
+
+    # From GTI
+    gti = GoodTimeInterval(tstart, tstop)
+    selector = TimeSelector.from_gti(gti, batch_size=2)
+
+    mask = asarray(selector.select(events_iter), dtype=bool)  # Yield another iterator
+
+    assert np.all(mask == selected[:12])
+
+    # Only tstart
+    tstart = Time(60000. + 5, format='jd')
+    tstop = None
+    selected = np.asarray(
+        [False, False, False, False, False, True, True, True, True, True, True, True, True, True, True])
+
+    selector = TimeSelector(tstart, tstop)
+
+    mask = selector.select(events) # Returned as array
+
+    assert np.all(mask == selected)
+
+    # Only tstop
+    tstart = None
+    tstop = Time(60000. + 5, format='jd')
+    selected = np.asarray(
+        [True, True, True, True, True, False, False, False, False, False, False, False, False, False, False])
+
+    selector = TimeSelector(tstart, tstop)
+
+    mask = selector.select(events) # Returned as array
+
+    assert np.all(mask == selected)
+
+    # All selected
+    tstart = None
+    tstop = None
+    selected = np.asarray(
+        [True, True, True, True, True, True, True, True, True, True, True, True, True, True, True])
+
+    selector = TimeSelector(tstart, tstop)
+
+    mask = selector.select(events) # Returned as array
+
+    assert np.all(mask == selected)
+
+    # Bad init
+
+    tstart = Time(60000. + np.asarray([0, 5]), format='jd')
+    tstop = Time(60000. + np.asarray([1, 10]), format='jd')
+
+    # tstart and tstop must both be scalar or both be list.
+    with pytest.raises(ValueError):
+        TimeSelector(tstart[0], tstop)
+
+    with pytest.raises(ValueError):
+        TimeSelector(tstart, tstop[0])
+
+    # tstart and tstop must have same length.
+    with pytest.raises(ValueError):
+        TimeSelector(tstart, tstop[:-1])
+
+    # If one is None, the other must be a scalar
+    with pytest.raises(ValueError):
+        TimeSelector(None, tstop)
+
+    with pytest.raises(ValueError):
+        TimeSelector(tstart, None)
+
+
+


### PR DESCRIPTION
TimeSelector:
- Faster, using only 64bit precision
- Add unit tests
- Be consistent about tstart inclusive, stop exclusive.

I'll work on a similar trick (64bit precision) for SpacecraftHistory (I'll abandon histpy.TimeAxis in favor of a regular Axis since COSI doesn't need <1us precision).