### PR TITLE
Restore default unit inference behavior in spectral integration

### DIFF
--- a/cosipy/response/functions.py
+++ b/cosipy/response/functions.py
@@ -101,9 +101,12 @@ def get_spectrum_unit(spectrum):
             case Band_Eflux():
                 spectrum_unit = spectrum.K.unit / spectrum.a.unit
             case _:
-                try:
-                    spectrum_unit = spectrum.k.unit
-                except:
+                spectrum_unit = None
+                for pname in ('K', 'k'):
+                    if pname in spectrum.parameters:
+                        spectrum_unit = spectrum.parameters[pname].unit
+
+                if spectrum_unit is None:
                     raise RuntimeError("Spectrum not yet supported because units are unknown.")
 
     return spectrum_unit

--- a/tests/response/test_integrals.py
+++ b/tests/response/test_integrals.py
@@ -23,7 +23,7 @@ from astromodels import (
 
 from cosipy.threeml.custom_functions import Band_Eflux
 
-
+from cosipy.response.functions import get_spectrum_unit
 from cosipy.response.integrals import get_integral_values
 
 def test_integrate():
@@ -190,3 +190,35 @@ def test_integrate():
 
     v = get_integral_values(delta, x, force_quad=True) # ignored for Delta
     assert np.allclose(v, v0)
+
+
+def test_spectrum_unit():
+
+    from astromodels import Function1D, FunctionMeta
+    import astropy.units as u
+
+    # test that we can get the unit from a custom function that
+    # has never been seen before, provided that the unit is assigned
+    # to the K parameter
+
+    class MyFunction(Function1D, metaclass=FunctionMeta):
+        r"""
+        description :
+            a silly function
+        parameters:
+            K :
+              desc: Normalization
+              initial value : 1.0
+              is_normalization : True
+              unit : keV
+        """
+        def _set_units(self, x_unit, y_unit):
+            # this is never actually called during setup
+            pass
+
+        def evaluate(self, x, K):
+            return K * x
+
+    f = MyFunction()
+    unit = get_spectrum_unit(f)
+    assert unit == u.keV

--- a/tests/response/test_integrals.py
+++ b/tests/response/test_integrals.py
@@ -23,7 +23,6 @@ from astromodels import (
 
 from cosipy.threeml.custom_functions import Band_Eflux
 
-from cosipy.response.functions import get_spectrum_unit
 from cosipy.response.integrals import get_integral_values
 
 def test_integrate():
@@ -190,35 +189,3 @@ def test_integrate():
 
     v = get_integral_values(delta, x, force_quad=True) # ignored for Delta
     assert np.allclose(v, v0)
-
-
-def test_spectrum_unit():
-
-    from astromodels import Function1D, FunctionMeta
-    import astropy.units as u
-
-    # test that we can get the unit from a custom function that
-    # has never been seen before, provided that the unit is assigned
-    # to the K parameter
-
-    class MyFunction(Function1D, metaclass=FunctionMeta):
-        r"""
-        description :
-            a silly function
-        parameters:
-            K :
-              desc: Normalization
-              initial value : 1.0
-              is_normalization : True
-              unit : keV
-        """
-        def _set_units(self, x_unit, y_unit):
-            # this is never actually called during setup
-            pass
-
-        def evaluate(self, x, K):
-            return K * x
-
-    f = MyFunction()
-    unit = get_spectrum_unit(f)
-    assert unit == u.keV

--- a/tests/response/test_point_source_response.py
+++ b/tests/response/test_point_source_response.py
@@ -12,7 +12,7 @@ from mhealpy import HealpixMap
 from cosipy import test_data
 from cosipy.response import FullDetectorResponse
 
-from threeML import DiracDelta, Constant, Line, Quadratic, Cubic, Quartic 
+from threeML import DiracDelta, Constant, Line, Quadratic, Cubic, Quartic
 from threeML import StepFunction, StepFunctionUpper, GenericFunction
 
 import pytest
@@ -148,3 +148,56 @@ def test_get_expectation():
     assert exp0 == exp_none
 
 
+def test_spectrum_unit_generic():
+
+    from astromodels import Function1D, FunctionMeta
+    import astropy.units as u
+    from cosipy.response.functions import get_spectrum_unit
+
+    # test that we can get the unit from a custom function that
+    # has never been seen before, provided that the unit is assigned
+    # to the K or k parameter
+
+    class MyFunction(Function1D, metaclass=FunctionMeta):
+        r"""
+        description :
+            a silly function
+        parameters:
+            K :
+              desc: Normalization
+              initial value : 1.0
+              is_normalization : True
+              unit : keV
+        """
+        def _set_units(self, x_unit, y_unit):
+            # this is never actually called during setup
+            pass
+
+        def evaluate(self, x, K):
+            return K * x
+
+    f = MyFunction()
+    unit = get_spectrum_unit(f)
+    assert unit == u.keV
+
+    class MyFunction2(Function1D, metaclass=FunctionMeta):
+        r"""
+        description :
+            another silly function
+        parameters:
+            k :
+              desc: Normalization
+              initial value : 1.0
+              is_normalization : True
+              unit : keV
+        """
+        def _set_units(self, x_unit, y_unit):
+            # this is never actually called during setup
+            pass
+
+        def evaluate(self, x, k):
+            return k * x
+
+    f = MyFunction()
+    unit = get_spectrum_unit(f)
+    assert unit == u.keV

--- a/tests/response/test_point_source_response.py
+++ b/tests/response/test_point_source_response.py
@@ -166,7 +166,6 @@ def test_spectrum_unit_generic():
             K :
               desc: Normalization
               initial value : 1.0
-              is_normalization : True
               unit : keV
         """
         def _set_units(self, x_unit, y_unit):
@@ -188,7 +187,6 @@ def test_spectrum_unit_generic():
             k :
               desc: Normalization
               initial value : 1.0
-              is_normalization : True
               unit : keV
         """
         def _set_units(self, x_unit, y_unit):


### PR DESCRIPTION
Some time after the DC3 release, the behavior of response/functions.py:get_spectrum_unit() changed, probably unintentionally.  For a spectrum function that is not one of a few well-known ones, get_spectrum_unit() would check if the spectrum had a "K" parameter and return the unit of that parameter; otherwise, it would throw an exception.  After DC3, the code was changed to check for a "k" parameter.  This change broke use of TemplateModel spectra, which use "K", as documented in issue #540 .

Unfortunately, there does not appear to be a "right" way to get the output unit of an arbitrary Astromodels function, so we are stuck with the best-effort behavior of get_spectrum_unit().  Also unfortunately, there is no consistent naming convention for normalization parameters; while TemplateModel uses "K", GenericFunction (which was used in test cases added during DC4 development) uses "k", so just reverting to checking for "K" breaks those other test cases.

This patch checks for both "k" and "K" and adds test cases to explicitly exercise that behavior.  I'm open to ideas about a more robust way to handle this, but it doesn't seem possible without an API change to Astromodels.  I can't tell that Function1d ever sets its y_unit parameter in a useful way.