### PR TITLE
Remove test case detritus from continuum background estimation

### DIFF
--- a/tests/background_estimation/test_continuum_background_estimationNN.py
+++ b/tests/background_estimation/test_continuum_background_estimationNN.py
@@ -12,7 +12,8 @@ def test_continuum_background_estimation_interp(tmp_path, monkeypatch):
     psr_file = test_data.path / "test_precomputed_response.h5"
 
     instance = ContinuumEstimationInterp()
-    instance.estimate_bg(input_data, psr_file)
+    instance.estimate_bg(input_data, psr_file,
+                         prefix=str(tmp_path) + "/inpainted")
 
 def test_continuum_background_estimation_nn(tmp_path,monkeypatch):
 
@@ -23,17 +24,17 @@ def test_continuum_background_estimation_nn(tmp_path,monkeypatch):
 
     monkeypatch.chdir(tmp_path)
 
-    instance = ContinuumEstimationNN() 
-     
+    instance = ContinuumEstimationNN()
+
     # Test main method:
     input_data = test_data.path / "crab_bkg_binned_data_for_continuum_bg_testing.hdf5"
     psr_file = test_data.path / "test_precomputed_response.h5"
-   
+
     instance.estimate_bg(input_data, psr_file, background_model=None,
             training_mode="self", containment=0.6, epochs=1, model_type="gcn",
             nn_model="new", nn_model_file=None, nn_model_savename="inpainting_nn_model",
             lr=1e-3, self_mask_fraction=0.1, lambda_sup=0.5, lambda_self=0.5,
-            prefix="inpainted", visualize=False, em_bin=1, phi_bin=1,
+            prefix=str(tmp_path) + "/inpainted", visualize=False, em_bin=1, phi_bin=1,
             evaluate_only=False, inpainted_file=None,
             evaluate=False, show_plots=False)
 
@@ -51,5 +52,5 @@ def test_continuum_background_estimation_nn(tmp_path,monkeypatch):
 
     instance.estimate_bg(input_data, psr_file, background_model=input_data,
         training_mode="hybrid", containment=0.6, epochs=1, em_bin=1, phi_bin=1)
-    
+
     instance.plot_training_loss("inpainting_nn_model_training_loss.npy",1,"training_loss",show_plot=False)


### PR DESCRIPTION
Continuum background estimation writes a Histogram, inpainted_estimated_bg.h5, whenever it runs.  The default behavior is to leave this file in the current working directory.  For testing, it should be directed to the temporary directory so as not to pollute the CWD.

This patch redirects where the write happens in the two relevant test cases.