### PR TITLE
Fixes for recent notebook testing failures

### DIFF
--- a/cosipy/spacecraftfile/spacecraft_file.py
+++ b/cosipy/spacecraftfile/spacecraft_file.py
@@ -291,28 +291,25 @@ class SpacecraftHistory:
     @staticmethod
     def _find_time_index(time:Time, tstart:Time, tstop:Time):
 
-        if time.isscalar:
-            t0 = time
-        else:
-            t0 = time[0]
+        t0 = time if time.isscalar else time[0]
 
         time = (time - t0).jd
-        tstart = (tstart - t0).jd
-        tstop = (tstop - t0).jd
 
         if tstart is not None:
-            if tstop is not None:
-                start_idx, stop_idx = np.searchsorted(time, [tstart, tstop], side='right')
-            else:
-                start_idx = np.searchsorted(time, tstart, side='right')
-                stop_idx = time.size
+            tstart = (tstart - t0).jd
+            start_idx = np.searchsorted(time, tstart, side='right')
         else:
             start_idx = 0
+
+        if tstop is not None:
+            tstop = (tstop - t0).jd
             stop_idx = np.searchsorted(time, tstop, side='right')
+        else:
+            stop_idx = time.size
 
         # Include the full bin, but prevent an index error
         start_idx = max(0, start_idx - 1)
-        stop_idx = min(time.size, stop_idx + 1)
+        stop_idx  = min(time.size, stop_idx + 1)
 
         return start_idx, stop_idx
 

--- a/docs/tutorials/polarization/ASAD_method.ipynb
+++ b/docs/tutorials/polarization/ASAD_method.ipynb
@@ -70,7 +70,7 @@
    "source": [
     "fetch_wasabi_file('COSI-SMEX/cosipy_tutorials/polarization_fit/grb_background.fits.gz', checksum = '21b1d75891edc6aaf1ff3fe46e91cb49')\n",
     "fetch_wasabi_file('COSI-SMEX/develop/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5', checksum = '46b006a6b397fd777dc561d3b028357f')\n",
-    "fetch_wasabi_file('COSI-SMEX/DC3/Data/Orientation/COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = '1b851c042acf4c909798e2401e9d2e38')"
+    "fetch_wasabi_file('COSI-SMEX/develop/Data/Orientation/DC3_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = '1b851c042acf4c909798e2401e9d2e38')"
    ]
   },
   {


### PR DESCRIPTION
This patch fixes two failures observed when testing the tutorial notebooks:

(1) SpacecraftHistory fails to load an orientation file if one but not both of tstart and tstop is specified.  Make sure we don't try to use these values in arithmetic if they are None.

(2) The path to the FITS orientation file in ASAD_method.py was updated incorrectly by the recent .notebook fixing PR.