### PR TITLE
Enable overflow/underflow tracking and dense/sparse binning

### DIFF
--- a/cosipy/data_io/BinnedData.py
+++ b/cosipy/data_io/BinnedData.py
@@ -30,7 +30,7 @@ class BinnedData(UnBinnedData):
     def get_binned_data(self, unbinned_data=None, output_name=None,
                         make_binning_plots=False, show_plots=False,
                         psichi_binning="galactic", event_range=None,
-                        weights=None):
+                        weights=None, sparse=None, track_overflow=None):
 
         """Bin the data using histpy and mhealpy.
 
@@ -54,6 +54,11 @@ class BinnedData(UnBinnedData):
         weights : value or array of values, optional
             weight to use when filling the Histogram, if not set histpy will
             use weight of 1
+        sparse : bool, optional
+            'True' for sparse binning, or
+            'False' for dense binning (default is False).
+        track_overflow: bool, optional
+            option to track under/overflow bin (default is False).
 
         Returns
         -------
@@ -124,7 +129,7 @@ class BinnedData(UnBinnedData):
                      Axis(energy_bin_edges, unit=u.keV, label='Em'),
                      Axis(phi_bin_edges, unit=u.deg, label='Phi'),
                      psichi_axis], copy_axes=False)
-        self.binned_data = Histogram(axes, sparse=True)
+        self.binned_data = Histogram(axes, sparse=sparse, track_overflow=track_overflow)
 
         # Fill histogram:
         if event_range is None:
@@ -193,7 +198,7 @@ class BinnedData(UnBinnedData):
             logger.info(f"{each.label} unit: {each.unit}")
 
         # Get time binning information:
-        self.time_hist = self.binned_data.project('Time').contents.todense()
+        self.time_hist = self.binned_data.project('Time').todense().contents
         self.num_time_bins = self.binned_data.axes['Time'].nbins
         self.time_bin_centers = self.binned_data.axes['Time'].centers
         self.time_bin_edges = self.binned_data.axes['Time'].edges
@@ -201,21 +206,21 @@ class BinnedData(UnBinnedData):
         self.total_time = self.time_bin_edges[-1] - self.time_bin_edges[0]
 
         # Get energy binning information:
-        self.energy_hist = self.binned_data.project('Em').contents.todense()
+        self.energy_hist = self.binned_data.project('Em').todense().contents
         self.num_energy_bins = self.binned_data.axes['Em'].nbins
         self.energy_bin_centers = self.binned_data.axes['Em'].centers
         self.energy_bin_edges = self.binned_data.axes['Em'].edges
         self.energy_bin_widths = self.binned_data.axes['Em'].widths
 
         # Get Phi binning information:
-        self.phi_hist = self.binned_data.project('Phi').contents.todense()
+        self.phi_hist = self.binned_data.project('Phi').todense().contents
         self.num_phi_bins = self.binned_data.axes['Phi'].nbins
         self.phi_bin_centers = self.binned_data.axes['Phi'].centers
         self.phi_bin_edges = self.binned_data.axes['Phi'].edges
         self.phi_bin_widths = self.binned_data.axes['Phi'].widths
 
         # Get PsiChi binning information:
-        self.psichi_hist = self.binned_data.project('PsiChi').contents.todense()
+        self.psichi_hist = self.binned_data.project('PsiChi').todense().contents
         self.num_psichi_bins = self.binned_data.axes['PsiChi'].nbins
         self.psichi_bin_centers = self.binned_data.axes['PsiChi'].centers
         self.psichi_bin_edges = self.binned_data.axes['PsiChi'].edges
@@ -326,7 +331,7 @@ class BinnedData(UnBinnedData):
 
         # Make healpix map with binned data slice:
         h = self.binned_data.project('Em', 'Phi', 'PsiChi').slice[{'Em':Em, 'Phi':phi}].project('PsiChi')
-        m = HealpixMap(base = HealpixBase(npix = h.nbins), data = h.contents.todense())
+        m = HealpixMap(base = HealpixBase(npix = h.nbins), data = h.todense().contents)
 
         # Plot standard view:
         plot,ax = m.plot('mollview')

--- a/cosipy/data_io/BinnedData.py
+++ b/cosipy/data_io/BinnedData.py
@@ -198,7 +198,7 @@ class BinnedData(UnBinnedData):
             logger.info(f"{each.label} unit: {each.unit}")
 
         # Get time binning information:
-        self.time_hist = self.binned_data.project('Time').todense().contents
+        self.time_hist = self.binned_data.project('Time').todense(copy=False).contents
         self.num_time_bins = self.binned_data.axes['Time'].nbins
         self.time_bin_centers = self.binned_data.axes['Time'].centers
         self.time_bin_edges = self.binned_data.axes['Time'].edges
@@ -206,21 +206,21 @@ class BinnedData(UnBinnedData):
         self.total_time = self.time_bin_edges[-1] - self.time_bin_edges[0]
 
         # Get energy binning information:
-        self.energy_hist = self.binned_data.project('Em').todense().contents
+        self.energy_hist = self.binned_data.project('Em').todense(copy=False).contents
         self.num_energy_bins = self.binned_data.axes['Em'].nbins
         self.energy_bin_centers = self.binned_data.axes['Em'].centers
         self.energy_bin_edges = self.binned_data.axes['Em'].edges
         self.energy_bin_widths = self.binned_data.axes['Em'].widths
 
         # Get Phi binning information:
-        self.phi_hist = self.binned_data.project('Phi').todense().contents
+        self.phi_hist = self.binned_data.project('Phi').todense(copy=False).contents
         self.num_phi_bins = self.binned_data.axes['Phi'].nbins
         self.phi_bin_centers = self.binned_data.axes['Phi'].centers
         self.phi_bin_edges = self.binned_data.axes['Phi'].edges
         self.phi_bin_widths = self.binned_data.axes['Phi'].widths
 
         # Get PsiChi binning information:
-        self.psichi_hist = self.binned_data.project('PsiChi').todense().contents
+        self.psichi_hist = self.binned_data.project('PsiChi').todense(copy=False).contents
         self.num_psichi_bins = self.binned_data.axes['PsiChi'].nbins
         self.psichi_bin_centers = self.binned_data.axes['PsiChi'].centers
         self.psichi_bin_edges = self.binned_data.axes['PsiChi'].edges
@@ -331,7 +331,7 @@ class BinnedData(UnBinnedData):
 
         # Make healpix map with binned data slice:
         h = self.binned_data.project('Em', 'Phi', 'PsiChi').slice[{'Em':Em, 'Phi':phi}].project('PsiChi')
-        m = HealpixMap(base = HealpixBase(npix = h.nbins), data = h.todense().contents)
+        m = HealpixMap(base = HealpixBase(npix = h.nbins), data = h.todense(copy=False).contents)
 
         # Plot standard view:
         plot,ax = m.plot('mollview')

--- a/cosipy/polarization_fitting/polarization_asad.py
+++ b/cosipy/polarization_fitting/polarization_asad.py
@@ -268,9 +268,7 @@ class PolarizationASAD():
             # source is in inertial frame
             scattering_dirs = psichi_axis.pix2skycoord(pix).transform_to('icrs')
 
-        # sparse contents has no unit
-        assert binned_data.is_sparse
-        weights = binned_data.project('PsiChi').todense().contents
+        weights = binned_data.project('PsiChi').todense(copy=False).contents
 
         return scattering_dirs, weights
 


### PR DESCRIPTION
Enable overflow/underflow tracking and dense/sparse binning. swapped .todense() and contents to enable both dense/sparse binning. (issue #358)