### PR TITLE
Update spectral/polarization tutorials

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -34,42 +34,38 @@ List of tutorials and contents, as a link to the corresponding Python notebook i
   - Meaning of the TS map and how to compute confidence contours
   - Computing a TS map, getting the best location and estimating the error
     
-5. Fitting the spectrum of a GRB `(ipynb) <https://github.com/cositools/cosipy/blob/main/docs/tutorials/spectral_fits/continuum_fit/grb/SpectralFit_GRB.ipynb>`_
+5. Fitting the spectrum of the Crab `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/spectral_fits/continuum_fit/crab/SpectralFit_Crab.ipynb>`_
   
   - Introduction to 3ML and astromodels
   - Likelihood analysis. 
   - Mechanics of background estimation.
-  - Fitting a simple power law, assuming you know the time of the GRB
   - Plotting the result
   - Comparing the result with the data
-    
-6. Fitting the spectrum of the Crab `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/spectral_fits/continuum_fit/crab/SpectralFit_Crab.ipynb>`_
-  
   - Analysing a continuous source transiting in the sky.
 
-7. Extended source model fitting `(ipynb) <https://github.com/cositools/cosipy/blob/main/docs/tutorials/spectral_fits/extended_source_fit/diffuse_511_spectral_fit.ipynb>`_
+6. Extended source model fitting `(ipynb) <https://github.com/cositools/cosipy/blob/main/docs/tutorials/spectral_fits/extended_source_fit/diffuse_511_spectral_fit.ipynb>`_
    
   - Obtaining the extended source response as a convolution of multiple point sources
   - Pre-computing a response in galactic coordinates for all-sky
   - Fitting an extended source
     
-8. Image deconvolution `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/image_deconvolution/511keV-Galactic-ImageDeconvolution.ipynb>`_
+7. Image deconvolution `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/image_deconvolution/511keV-Galactic-ImageDeconvolution.ipynb>`_
   - Explain the RL algorithm. Reference the previous example. Explain the difference with a TS map.
   - Fitting the 511 diffuse emission.
   - Analyze data in the Compton data space with galactic coordinates.
   - Link to a notebook using Scatt binning which shows its advantages/disadvantages.
     
-9. Source injector `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/source_injector/Point_source_injector.ipynb>`_
+8. Source injector `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/source_injector/Point_source_injector.ipynb>`_
   - Convolve the response, point source model and orientation to obtain the mock data.
   - More types of source (e,g. extended source and polarization) will be suppored.
 
-10. Continuum background estimation `(ipynb) <https://github.com/cositools/cosipy/blob/develop/docs/tutorials/background_estimation/continuum_estimation/BG_estimationNN_example.ipynb>`_
+9. Continuum background estimation `(ipynb) <https://github.com/cositools/cosipy/blob/develop/docs/tutorials/background_estimation/continuum_estimation/BG_estimationNN_example.ipynb>`_
   - Estimating the continuum background from the data. 
 
-11. Line background estimation `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/background_estimation/line_background/line_background_estimation_example_notebook.ipynb>`_
+10. Line background estimation `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/background_estimation/line_background/line_background_estimation_example_notebook.ipynb>`_
   - Estimating the background from neighboring energy bins.
 
-12. Polarization (ASAD method) `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/polarization/ASAD_method.ipynb>`_
+11. Polarization (ASAD method) `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/polarization/ASAD_method.ipynb>`_
   - Estimating the polarization degree and angle of a GRB using the Azimuthal Scattering Angle Distribution (ASAD)
 
 .. warning::
@@ -82,7 +78,6 @@ List of tutorials and contents, as a link to the corresponding Python notebook i
    response/SpacecraftHistory.ipynb
    Detector response and signal expectation <response/DetectorResponse.ipynb>
    TS Map: localizing a GRB <ts_map/Parallel_TS_map_computation.ipynb>
-   Fitting the spectrum of a GRB <spectral_fits/continuum_fit/grb/SpectralFit_GRB.ipynb>
    Fitting the spectrum of the Crab <spectral_fits/continuum_fit/crab/SpectralFit_Crab.ipynb>
    Extended source model fitting <spectral_fits/extended_source_fit/diffuse_511_spectral_fit.ipynb>
    Image deconvolution <image_deconvolution/511keV-Galactic-ImageDeconvolution.ipynb>

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -68,6 +68,9 @@ List of tutorials and contents, as a link to the corresponding Python notebook i
 11. Polarization (ASAD method) `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/polarization/ASAD_method.ipynb>`_
   - Estimating the polarization degree and angle of a GRB using the Azimuthal Scattering Angle Distribution (ASAD)
 
+12. Polarization (Stokes parameters method) `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/polarization/Stokes_method.ipynb>`_
+  - Estimating the polarization of a GRB using Stokes parameters
+
 .. warning::
    Under construction. Some of the explanations described above might be missing. However, the notebooks are fully functional. If you have a question not yet covered by the tutorials, please discuss `issue <https://github.com/cositools/cosipy/discussions>`_ so we can prioritize it.
     
@@ -85,3 +88,4 @@ List of tutorials and contents, as a link to the corresponding Python notebook i
    Continuum Background Estimation <background_estimation/continuum_estimation/BG_estimationNN_example.ipynb>
    Line background estimation <background_estimation/line_background/line_background_estimation_example_notebook.ipynb>
    Polarization (ASAD method) <polarization/ASAD_method.ipynb>
+   Polarization (Stokes parameters method) <polarization/Stokes_method.ipynb>

--- a/docs/tutorials/other_examples.rst
+++ b/docs/tutorials/other_examples.rst
@@ -5,6 +5,8 @@ Other examples
    :maxdepth: 1
    
    Point source response with Earth occultation <response/PSR_with_Earth_occultation_example.ipynb>
+
+   Fitting the spectrum of a GRB <spectral_fits/continuum_fit/grb/SpectralFit_GRB.ipynb>
   
    Galactic diffuse continuum spectral fit <spectral_fits/galactic_diffuse_continuum/galdiff_continuum.ipynb> 
 

--- a/docs/tutorials/other_examples.rst
+++ b/docs/tutorials/other_examples.rst
@@ -6,7 +6,7 @@ Other examples
    
    Point source response with Earth occultation <response/PSR_with_Earth_occultation_example.ipynb>
 
-   Fitting the spectrum of a GRB (binned) <spectral_fits/continuum_fit/grb/SpectralFit_GRB.ipynb>
+   Fitting the spectrum of a GRB (binned, inertial coordinates) <spectral_fits/continuum_fit/grb/SpectralFit_GRB.ipynb>
 
    Fitting the spectrum of a GRB (unbinned) <spectral_fits/continuum_fit/grb/example_grb_fit_normalizing_flows.ipynb>
   

--- a/docs/tutorials/other_examples.rst
+++ b/docs/tutorials/other_examples.rst
@@ -13,3 +13,5 @@ Other examples
    Good time intervals <event_selection/GTI.ipynb>
 
    Extended source injector <source_injector/Extended_source_injector.ipynb>
+
+   Polarization (maximum likelihood method) <polarization/maximum_likelihood_method.ipynb>

--- a/docs/tutorials/other_examples.rst
+++ b/docs/tutorials/other_examples.rst
@@ -6,7 +6,9 @@ Other examples
    
    Point source response with Earth occultation <response/PSR_with_Earth_occultation_example.ipynb>
 
-   Fitting the spectrum of a GRB <spectral_fits/continuum_fit/grb/SpectralFit_GRB.ipynb>
+   Fitting the spectrum of a GRB (binned) <spectral_fits/continuum_fit/grb/SpectralFit_GRB.ipynb>
+
+   Fitting the spectrum of a GRB (unbinned) <spectral_fits/continuum_fit/grb/example_grb_fit_normalizing_flows.ipynb>
   
    Galactic diffuse continuum spectral fit <spectral_fits/galactic_diffuse_continuum/galdiff_continuum.ipynb> 
 

--- a/docs/tutorials/spectral_fits/continuum_fit/crab/SpectralFit_Crab.ipynb
+++ b/docs/tutorials/spectral_fits/continuum_fit/crab/SpectralFit_Crab.ipynb
@@ -15,7 +15,7 @@
    "id": "f1b5e8e3",
    "metadata": {},
    "source": [
-    "This notebook fits the spectrum of a Crab simulated using MEGAlib and combined with background.\n",
+    "This notebook fits the spectrum of a COSI observation of the Crab simulated using MEGAlib and combined with background.\n",
     "\n",
     "[3ML](https://threeml.readthedocs.io/) is a high-level interface that allows multiple datasets from different instruments to be used coherently to fit the parameters of source model. A source model typically consists of a list of sources with parametrized spectral shapes, sky locations and, for extended sources, shape. Polarization is also possible. A \"coherent\" analysis, in this context, means that the source model parameters are fitted using all available datasets simultanously, rather than performing individual fits and finding a well-suited common model a posteriori. \n",
     "\n",
@@ -44,9 +44,7 @@
     "\\lambda_i(\\mathbf{x}) = B*b_i + s_i(\\mathbf{x})\n",
     "$$\n",
     "\n",
-    "where $B*b_i$ are the estimated counts due to background in each bin with $B$ the amplitude and $b_i$ the shape of the background, and $s_i$ are the corresponding expected counts from the source, the goal is then to find the values of $\\mathbf{x} = [K, \\alpha, \\beta, x_p]$ and $B$ that maximize $\\mathcal{L}$. These are the best estimations of the parameters.\n",
-    "\n",
-    "The final module needs to also fit the time-dependent background, handle multiple point-like and extended sources, as well as all the spectral models supported by 3ML. Eventually, it will also fit the polarization angle. However, this simple example already contains all the necessary pieces to do a fit."
+    "where $B*b_i$ are the estimated counts due to background in each bin with $B$ the amplitude and $b_i$ the shape of the background, and $s_i$ are the corresponding expected counts from the source, the goal is then to find the values of $\\mathbf{x} = [K, \\alpha, \\beta, x_p]$ and $B$ that maximize $\\mathcal{L}$. These are the best estimations of the parameters."
    ]
   },
   {
@@ -1772,14 +1770,6 @@
     "\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8314a112-89fe-4c06-9284-b36fcc072c90",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/tutorials/spectral_fits/continuum_fit/grb/SpectralFit_GRB.ipynb
+++ b/docs/tutorials/spectral_fits/continuum_fit/grb/SpectralFit_GRB.ipynb
@@ -20,7 +20,7 @@
     "- binned data (grb_binned_data.hdf5 & bkg_binned_data_1s_local.hdf5)     \n",
     "- detector response (SMEXv12.Continuum.HEALPixO3_10bins_log_flat.binnedimaging.imagingresponse.h5)     \n",
     "\n",
-    "**The binned data are simulations of GRB090206620 and albedo photon background produced using the COSI SMEX mass model. The detector response needs to be unzipped before running the notebook.**"
+    "**The binned data are simulations of GRB090206620 and albedo photon background produced using the COSI SMEX mass model.**"
    ]
   },
   {
@@ -28,39 +28,7 @@
    "id": "b39db505",
    "metadata": {},
    "source": [
-    "This notebook fits the spectrum of a GRB simulated using MEGAlib and combined with background.\n",
-    "\n",
-    "[3ML](https://threeml.readthedocs.io/) is a high-level interface that allows multiple datasets from different instruments to be used coherently to fit the parameters of source model. A source model typically consists of a list of sources with parametrized spectral shapes, sky locations and, for extended sources, shape. Polarization is also possible. A \"coherent\" analysis, in this context, means that the source model parameters are fitted using all available datasets simultanously, rather than performing individual fits and finding a well-suited common model a posteriori. \n",
-    "\n",
-    "In order for a dataset to be included in 3ML, each instrument needs to provide a \"plugin\". Each plugin is responsible for reading the data, convolving the source model (provided by 3ML) with the instrument response, and returning a likelihood. In our case, we'll compute a binned Poisson likelihood:\n",
-    "\n",
-    "$$\n",
-    "\\log \\mathcal{L}(\\mathbf{x}) = \\sum_i \\log \\frac{\\lambda_i(\\mathbf{x})^{d_i} \\exp (-\\lambda_i)}{d_i!}\n",
-    "$$\n",
-    "\n",
-    "where $d_i$ are the counts on each bin and $\\lambda_i$ are the expected counts given a source model with parameters $\\mathbf{x}$. \n",
-    "\n",
-    "In this example, we will fit a single point source with a known location. We'll assume the background is known and fixed up to a scaling factor. Finally, we will fit a Band function:\n",
-    "\n",
-    "$$\n",
-    "f(x) = K \\begin{cases} \\left(\\frac{x}{E_{piv}}\\right)^{\\alpha} \\exp \\left(-\\frac{(2+\\alpha)\n",
-    "       * x}{x_{p}}\\right) & x \\leq (\\alpha-\\beta) \\frac{x_{p}}{(\\alpha+2)} \\\\ \\left(\\frac{x}{E_{piv}}\\right)^{\\beta}\n",
-    "       * \\exp (\\beta-\\alpha)\\left[\\frac{(\\alpha-\\beta) x_{p}}{E_{piv}(2+\\alpha)}\\right]^{\\alpha-\\beta}\n",
-    "       * &x>(\\alpha-\\beta) \\frac{x_{p}}{(\\alpha+2)} \\end{cases}\n",
-    "$$\n",
-    "\n",
-    "\n",
-    "where $K$ (normalization), $\\alpha$ & $\\beta$ (spectral indeces), and $x_p$ (peak energy) are the free parameters, while $E_{piv}$ is the pivot energy which is fixed (and arbitrary).\n",
-    "\n",
-    "Considering these assumptions:\n",
-    "\n",
-    "$$\n",
-    "\\lambda_i(\\mathbf{x}) = B*b_i + s_i(\\mathbf{x})\n",
-    "$$\n",
-    "\n",
-    "where $B*b_i$ are the estimated counts due to background in each bin of the Compton data space with $B$ the amplitude and $b_i$ the shape of the background, and $s_i$ are the corresponding expected counts from the source, the goal is then to find the values of $\\mathbf{x} = [K, \\alpha, \\beta, x_p]$ and $B$ that maximize $\\mathcal{L}$. These are the best estimations of the parameters.\n",
-    "\n",
-    "The final module needs to also fit the time-dependent background, handle multiple point-like and extended sources, as well as all the spectral models supported by 3ML. Eventually, it will also fit the polarization angle. However, this simple example already contains all the necessary pieces to do a fit."
+    "This notebook fits the spectrum of a GRB simulated using MEGAlib and combined with background. The data are binned in inertial coordinates, which only works for short-duration transients such as GRBs. See the Crab spectral fitting tutorial for a more comprehensive description of the spectral analysis method."
    ]
   },
   {


### PR DESCRIPTION
This adds the missing spectral analysis and polarization tutorials to the documentation (addressing #542), and cleans up the GRB/Crab spectral fitting examples