### PR TITLE
Update TS map and add transient background tutorials

### DIFF
--- a/docs/tutorials/background_estimation/transient_background/Transient_background_example.ipynb
+++ b/docs/tutorials/background_estimation/transient_background/Transient_background_example.ipynb
@@ -7,11 +7,11 @@
     "tags": []
    },
    "source": [
-    "## Transient Background Modeling in CDS\n",
+    "# Transient Background Modeling in CDS\n",
     "\n",
     "This notebook demonstrates a background-modeling method for transients. Traditionally, one models the background by fitting the light curve before and after the burst. However, that approach only uses the count information after projecting to the `Time` axis. `cosipy` operates in Compton Data Space (CDS), so the background must be modeled in CDS as well. We therefore need a different approach that preserves the multi-dimensional structure of the data.\n",
     "\n",
-    "### Overview\n",
+    "## Overview\n",
     "\n",
     "The general idea is the same:\n",
     "\n",
@@ -20,14 +20,14 @@
     "\n",
     "We provide two scaling methods: `duration` and `fitting`.\n",
     "\n",
-    "### Scaling Methods\n",
+    "## Scaling Methods\n",
     "\n",
-    "#### `duration`\n",
+    "### `duration`\n",
     "\n",
     "1. Convert the summed background model into a unit-rate background (i.e., a 1 s background).\n",
     "2. Multiply by the burst duration so the expected total counts scale to the burst interval.\n",
     "\n",
-    "#### `fitting`\n",
+    "### `fitting`\n",
     "**This will be supported in the future.**\n",
     "\n",
     "1. Fit the burst background level in a light curve using the background windows.\n",
@@ -40,6 +40,10 @@
    "execution_count": 1,
    "id": "4e8581d7-558c-405a-af36-f5b8eccaa424",
    "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
     "tags": []
    },
    "outputs": [
@@ -670,9 +674,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "cosipy_yong_dev",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "cosipy_yong_dev"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -684,7 +688,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.19"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -29,7 +29,7 @@ List of tutorials and contents, as a link to the corresponding Python notebook i
   - Visualizing the response
   - Convolving the detector response with a point source model (location + spectrum) + spacecraft file to obtain the expected signal counts. Both in SC and galactic coordinates.
     
-4. TS Map: localizing a GRB `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/ts_map/Parallel_TS_map_computation.ipynb>`_
+4. TS Map: localizing a GRB `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/ts_map/TS_map_fitting.ipynb>`_
   - TS calculation
   - Meaning of the TS map and how to compute confidence contours
   - Computing a TS map, getting the best location and estimating the error
@@ -70,7 +70,12 @@ List of tutorials and contents, as a link to the corresponding Python notebook i
   - Estimating the background from neighboring energy bins.
 
 12. Polarization (ASAD method) `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/polarization/ASAD_method.ipynb>`_
-  - Estimating the polarization degree and angle of a GRB using the Azimuthal Scattering Angle Distribution (ASAD)
+  - Estimating the polarization degree and angle of a GRB using the Azimuthal Scattering Angle Distribution (ASAi)
+
+
+13. Transient background estimation `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/background_estimation/transient_background/Transient_background_example.ipynb>`_
+    
+  - Estimating the background for transients.
 
 .. warning::
    Under construction. Some of the explanations described above might be missing. However, the notebooks are fully functional. If you have a question not yet covered by the tutorials, please discuss `issue <https://github.com/cositools/cosipy/discussions>`_ so we can prioritize it.
@@ -90,3 +95,4 @@ List of tutorials and contents, as a link to the corresponding Python notebook i
    Continuum Background Estimation <background_estimation/continuum_estimation/BG_estimationNN_example.ipynb>
    Line background estimation <background_estimation/line_background/line_background_estimation_example_notebook.ipynb>
    Polarization (ASAD method) <polarization/ASAD_method.ipynb>
+   Transient background estimation <background_estimation/transient_background/Transient_background_example.ipynb>


### PR DESCRIPTION
## Descriptions
In the generated HTML documentation, the link to the TS map tutorial was outdated. In addition, the transient background tutorial notebook had been added to the tutorials directory, but it was not included in the rendered HTML documentation because it was missing from the tutorial index (`index.rst`). 

## What is changed
- Updated the TS map tutorial link in the tutorial index file to use the current notebook name.
- Added the transient background tutorial notebook to the index file.
- Adjusted the heading structure in the transient background tutorial so the top-level title starts with #, matching the expected document title structure used by Sphinx