### PR TITLE
Recommend editable install of ml packages when installing from source

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -48,9 +48,9 @@ specify the ``[ml]`` extra packages during the installation. e.g.::
 
     pip install cosipy[ml]
 
-or, if you are installing from from source::
+or, if you are installing from source::
 
-    pip install '.[ml]'
+    pip install -e '.[ml]'
 
 If you do not install these optional dependencies, then some imports in the
 ``.ml`` submodules will fail. For example::


### PR DESCRIPTION
This is a 2 insert PR that changes the optional ml package install docs, inspired by discussion in #577 

Currently the docs recommend that users installing optional ml packages from source use

`pip install '.[ml]'`

Most users who install from source will likely be upgrading by git pulling new releases. We already recommend using `-e` when installing the rest of the library from source. When users install the optional packages from source we should recommend they also use the `-e` flag. 