### PR TITLE
Add light curve tutorial to other examples 

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,4 +35,4 @@ The preferred communication channel is the GitHub repository:: if you find a pro
    tutorials/other_examples
    api/index
    dev/index
-   
+   tutorials/apps/apps

--- a/docs/tutorials/other_examples.rst
+++ b/docs/tutorials/other_examples.rst
@@ -17,3 +17,5 @@ Other examples
    Extended source injector <source_injector/Extended_source_injector.ipynb>
 
    Polarization (maximum likelihood method) <polarization/maximum_likelihood_method.ipynb>
+
+   Light curve (flux light curve of a GRB) <light_curves/speclc_grbdc3.ipynb>


### PR DESCRIPTION
Addressing #542 this pull request adds the light curve tutorial to other examples. 
@israelmcmc regarding the apps, @ldigesu has already added an rst file (see docs/tutorials/apps/apps.rst). However, we don't know how to add it to the docs. 