### PR TITLE
Fix the IRFAdaptive folding class currently calling the private density and effective area methods.

### DIFF
--- a/cosipy/response/ml/NFResponse.py
+++ b/cosipy/response/ml/NFResponse.py
@@ -60,8 +60,6 @@ class AreaApproximation:
         return self._model.evaluate_effective_area(*list_context, progress_callback=progress_callback)
 
 def update_response_worker_settings(args: Tuple[str, Union[int, CompileMode]]):
-    update_density_worker_settings(args)
-    
     attr, value = args
     
     if attr == 'area_batch_size':
@@ -69,7 +67,7 @@ def update_response_worker_settings(args: Tuple[str, Union[int, CompileMode]]):
     elif attr == 'area_compile_mode':
         NFWorkerState.area_module._model.compile_mode = value
     else:
-        raise ValueError(f"Unknown attribute: {attr}")
+        update_density_worker_settings(args)
 
 def init_response_worker(device_queue: mp.Queue, progress_queue: mp.Queue, major_version: int, area_input: Dict,
                          density_input: Dict, area_batch_size: int, density_batch_size: int,

--- a/cosipy/threeml/ml/optimized_unbinned_folding.py
+++ b/cosipy/threeml/ml/optimized_unbinned_folding.py
@@ -459,7 +459,7 @@ class UnbinnedThreeMLPointSourceResponseIRFAdaptive(CachedUnbinnedThreeMLSourceR
                 batch_energies_buffer[:current_total]
                 )
             
-            eff_areas_flat = asarray(self._irf._effective_area_cm2(photons), dtype=np.float32)
+            eff_areas_flat = asarray(self._irf.effective_area_cm2(photons), dtype=np.float32)
             eff_areas_grid = eff_areas_flat.reshape(current_n_time, n_energy)
 
             total_area += np.einsum('ij,i,j->j', 
@@ -738,8 +738,8 @@ class UnbinnedThreeMLPointSourceResponseIRFAdaptive(CachedUnbinnedThreeMLSourceR
                 batch_phi_buffer[:current_total],
             )
             
-            eff_areas_flat = torch.as_tensor(asarray(self._irf._effective_area_cm2(photons), dtype=np.float32))
-            densities_flat = torch.as_tensor(asarray(self._irf._event_probability(photons, events), dtype=np.float32))
+            eff_areas_flat = torch.as_tensor(asarray(self._irf.effective_area_cm2(photons), dtype=np.float32))
+            densities_flat = torch.as_tensor(asarray(self._irf.event_probability(photons, events), dtype=np.float32))
 
             res_block = (densities_flat * eff_areas_flat).view(current_n, n_energy)
 

--- a/docs/tutorials/spectral_fits/continuum_fit/grb/example_grb_fit_normalizing_flows.ipynb
+++ b/docs/tutorials/spectral_fits/continuum_fit/grb/example_grb_fit_normalizing_flows.ipynb
@@ -482,7 +482,7 @@
     "                                          bkg_norm,\n",
     "                                          unit = u.Hz,\n",
     "                                          min_value=0,\n",
-    "                                          max_value=100,\n",
+    "                                          max_value=150,\n",
     "                                          delta=0.05,\n",
     "                                          )\n",
     "print(f\"The average background flux is {bkg_norm:.2f} Hz\")"
@@ -676,6 +676,16 @@
     "    flux_median[i] = flux.median\n",
     "    flux_lo[i], flux_hi[i] = flux.equal_tail_interval(cl=0.68)\n",
     "    flux_inj[i] = spectrum_inj.evaluate_at(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea12c94c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline"
    ]
   },
   {

--- a/tests/response/test_nfresponse.py
+++ b/tests/response/test_nfresponse.py
@@ -72,11 +72,16 @@ def test_update_response_worker_settings(mock_update_density):
     
     update_response_worker_settings(('area_batch_size', 500_000))
     assert NFWorkerState.area_module._model.batch_size == 500_000
-    mock_update_density.assert_called_with(('area_batch_size', 500_000))
+    mock_update_density.assert_not_called()
     
     update_response_worker_settings(('area_compile_mode', 'default'))
     assert NFWorkerState.area_module._model.compile_mode == 'default'
+    mock_update_density.assert_not_called()
     
+    update_response_worker_settings(('density_batch_size', 100))
+    mock_update_density.assert_called_with(('density_batch_size', 100))
+
+    mock_update_density.side_effect = ValueError("Unknown attribute: unknown")
     with pytest.raises(ValueError, match="Unknown attribute"):
         update_response_worker_settings(('unknown', 'value'))
     

--- a/tests/threeml/test_optimized_unbinned_folding.py
+++ b/tests/threeml/test_optimized_unbinned_folding.py
@@ -51,8 +51,8 @@ def mock_sc_history():
 def mock_irf():
     """Mocks FarFieldSpectralInstrumentResponseFunctionInterface"""
     irf = MagicMock(spec=FarFieldSpectralInstrumentResponseFunctionInterface)
-    irf._effective_area_cm2.return_value = np.ones(3)
-    irf._event_probability.return_value = np.ones(3)
+    irf.effective_area_cm2.return_value = np.ones(3)
+    irf.event_probability.return_value = np.ones(3)
     irf.active_pool = True 
     return irf
 
@@ -692,7 +692,7 @@ class TestUnbinnedThreeMLPointSourceResponseIRFAdaptive:
         irf_adaptive._sc_ori.livetime.to_value.return_value = np.ones(1)
         irf_adaptive._get_target_in_sc_frame = MagicMock(return_value=SkyCoord(l=[0,], b=[0,], unit='deg', frame='galactic').spherical)
         irf_adaptive._earth_occ = MagicMock(return_value=np.ones(1))
-        irf_adaptive._irf._effective_area_cm2 = MagicMock(return_value=np.ones(10))
+        irf_adaptive._irf.effective_area_cm2 = MagicMock(return_value=np.ones(10))
 
         with patch("cosipy.threeml.ml.optimized_unbinned_folding.tqdm") as mock_tqdm:
 
@@ -724,7 +724,7 @@ class TestUnbinnedThreeMLPointSourceResponseIRFAdaptive:
         
         irf_adaptive._earth_occ = MagicMock(return_value=np.zeros(n_time))
         
-        irf_adaptive._irf._effective_area_cm2 = MagicMock(return_value=np.ones(10) * 100.0)
+        irf_adaptive._irf.effective_area_cm2 = MagicMock(return_value=np.ones(10) * 100.0)
 
         irf_adaptive._compute_area()
 
@@ -753,7 +753,7 @@ class TestUnbinnedThreeMLPointSourceResponseIRFAdaptive:
         def side_effect(photons):
             return np.ones(len(photons.energy)) * 50.0
         
-        irf_adaptive._irf._effective_area_cm2 = MagicMock(side_effect=side_effect)
+        irf_adaptive._irf.effective_area_cm2 = MagicMock(side_effect=side_effect)
 
         irf_adaptive._compute_area()
 
@@ -761,7 +761,7 @@ class TestUnbinnedThreeMLPointSourceResponseIRFAdaptive:
         assert np.all(irf_adaptive._area_energy_node_cache >= 10.0)
         assert np.all(irf_adaptive._area_energy_node_cache <= 100.0)
 
-        assert irf_adaptive._irf._effective_area_cm2.call_count == 5
+        assert irf_adaptive._irf.effective_area_cm2.call_count == 5
         
         assert isinstance(irf_adaptive._area_cache, np.ndarray)
         assert irf_adaptive._area_cache.shape == (n_energy,)
@@ -799,8 +799,8 @@ class TestUnbinnedThreeMLPointSourceResponseIRFAdaptive:
         
         irf_adaptive._get_nodes = MagicMock(side_effect=mock_get_nodes)
         
-        irf_adaptive._irf._effective_area_cm2 = MagicMock(return_value=np.ones(batch_size))
-        irf_adaptive._irf._event_probability = MagicMock(return_value=np.ones(batch_size))
+        irf_adaptive._irf.effective_area_cm2 = MagicMock(return_value=np.ones(batch_size))
+        irf_adaptive._irf.event_probability = MagicMock(return_value=np.ones(batch_size))
 
         irf_adaptive._compute_density()
 
@@ -810,8 +810,8 @@ class TestUnbinnedThreeMLPointSourceResponseIRFAdaptive:
         assert irf_adaptive._irf_energy_node_cache.shape == (n_events, n_energy)
         assert np.all(irf_adaptive._irf_energy_node_cache == 50.0)
 
-        assert irf_adaptive._irf._effective_area_cm2.call_count == 3
-        assert irf_adaptive._irf._event_probability.call_count == 3
+        assert irf_adaptive._irf.effective_area_cm2.call_count == 3
+        assert irf_adaptive._irf.event_probability.call_count == 3
 
     def test_compute_density_memory_modes(self, irf_adaptive, mock_source):
         """Verify that reduce_memory correctly toggles between float32 and float64."""
@@ -828,8 +828,8 @@ class TestUnbinnedThreeMLPointSourceResponseIRFAdaptive:
         irf_adaptive._get_CDS_coordinates = MagicMock(return_value=(np.zeros(2), np.zeros(2)))
         irf_adaptive._get_nodes = MagicMock(return_value=(np.ones((2,2)), torch.ones((2,2))))
         irf_adaptive._earth_occ = MagicMock(return_value=np.ones(2))
-        irf_adaptive._irf._effective_area_cm2 = MagicMock(return_value=np.ones(4))
-        irf_adaptive._irf._event_probability = MagicMock(return_value=np.ones(4))
+        irf_adaptive._irf.effective_area_cm2 = MagicMock(return_value=np.ones(4))
+        irf_adaptive._irf.event_probability = MagicMock(return_value=np.ones(4))
 
         irf_adaptive._reduce_memory = True
         irf_adaptive._compute_density()
@@ -853,8 +853,8 @@ class TestUnbinnedThreeMLPointSourceResponseIRFAdaptive:
         
         irf_adaptive._get_CDS_coordinates = MagicMock(return_value=(np.zeros(1), np.zeros(1)))
         irf_adaptive._get_nodes = MagicMock(return_value=(np.ones((1,1)), torch.ones((1,1))))
-        irf_adaptive._irf._effective_area_cm2 = MagicMock(return_value=np.ones(1))
-        irf_adaptive._irf._event_probability = MagicMock(return_value=np.ones(1))
+        irf_adaptive._irf.effective_area_cm2 = MagicMock(return_value=np.ones(1))
+        irf_adaptive._irf.event_probability = MagicMock(return_value=np.ones(1))
         
         irf_adaptive._earth_occ = MagicMock(return_value=np.array([0.0]))
 


### PR DESCRIPTION
Thanks to @Yong2Sheng for discovering this! Currently `UnbinnedThreeMLPointSourceResponseIRFAdaptive` calls the private `_event_probability` and `_effective_area_cm2` methods and not the public ones. This results in conflics with response implementations other than mine. In addition:
- I increased the background parameter limits in the tutorial notebook to reduce thrown away samples during fitting
- There was a bug in `update_response_worker_settings` which prevented changing the effective area` batch_size` and `compile_mode` beyond the initialization
- I modified the tests accordingly