### PR TITLE
CHG: Add example on how to install optional packages

### DIFF
--- a/cosipy/response/ml/__init__.py
+++ b/cosipy/response/ml/__init__.py
@@ -1,7 +1,7 @@
 import cosipy
 
 if not cosipy.with_ml:
-    raise ImportError("Install cosipy with [ml] optional packages to use these features.")
+    raise ImportError("Install cosipy with [ml] optional packages to use these features, e.g., \"pip install cosipy[ml]\".")
 
 from .NFResponse import NFResponse
 from .nf_instrument_response_function import UnpolarizedNFFarFieldInstrumentResponseFunction


### PR DESCRIPTION
Mini output string change to make it obvious how to fix the error message:
Install cosipy with [ml] optional packages to use these features.
-->
Install cosipy with [ml] optional packages to use these features, e.g., \"pip install cosipy[ml]\".