### PR TITLE
Add ARMSelector event selection class

### DIFF
--- a/cosipy/event_selection/__init__.py
+++ b/cosipy/event_selection/__init__.py
@@ -1,1 +1,3 @@
 from .good_time_interval import GoodTimeInterval
+
+from .arm_selection import ARMSelector

--- a/cosipy/event_selection/arm_selection.py
+++ b/cosipy/event_selection/arm_selection.py
@@ -1,12 +1,26 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# In[1]:
+
+
 import logging
 
 logger = logging.getLogger(__name__)
 
+from typing import Iterable
+
 import numpy as np
 import astropy.units as u
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import Angle, SkyCoord
+from scoords import SpacecraftFrame
 
+from cosipy.interfaces.data_interface import (
+    ComptonDataSpaceInSCFrameEventDataInterface,
+)
 from cosipy.interfaces.event_selection import EventSelectorInterface
+from cosipy.polarization import PolarizationConvention
+from cosipy.response.relative_coordinates import RelativeCDSCoordinates
 
 
 class ARMSelector(EventSelectorInterface):
@@ -19,220 +33,176 @@ class ARMSelector(EventSelectorInterface):
 
     where:
 
-        ARM = angular_separation(source_direction, event_axis) - Phi
+        ARM = angular_distance(source_direction, scattered_direction) - Phi
 
-    Current validated FITS-table implementation
-    -------------------------------------------
-    This implementation uses the event-axis columns:
+    In this implementation:
 
-        - Chi galactic
-        - Psi galactic
-        - Phi
+        - scattered_direction is obtained from the input event-data object via
+          events.scattered_direction_sc
+        - Phi is obtained from the input event-data object via
+          events.scattering_angle_rad
+        - the angular distance is computed using RelativeCDSCoordinates
 
-    Units assumed from the validated FITS files:
+    This follows the EventSelectorInterface pattern: _select() accepts an
+    EventDataInterface object and returns one Boolean value per event.
 
-        - Chi galactic: radians
-        - Psi galactic: radians
-        - Phi: radians
+    Notes
+    -----
+    The input event data must satisfy the
+    ComptonDataSpaceInSCFrameEventDataInterface protocol.
 
-    The source position is provided as an astropy SkyCoord and is internally
-    converted to Galactic coordinates. The ARM values are returned in degrees.
-
-    Parameters
-    ----------
-    spacecraft_history
-        Spacecraft history object. Stored for compatibility with the requested
-        ARMSelector interface. In this validated FITS-column implementation,
-        the event-axis direction is already available in Galactic coordinates
-        through Chi/Psi columns.
-
-    target_coord : astropy.coordinates.SkyCoord
-        Source position.
-
-    arm_cut : astropy.units.Quantity
-        Symmetric ARM half-width, for example 13.0 * u.deg.
-
-    chi_col : str
-        FITS/event-table column containing the Galactic longitude-like event
-        axis angle. Validated value: "Chi galactic".
-
-    psi_col : str
-        FITS/event-table column containing the Galactic latitude-like event
-        axis angle. Validated value: "Psi galactic".
-
-    phi_col : str
-        FITS/event-table column containing the Compton scatter angle Phi.
-        Validated value: "Phi".
-
-    batch_size : int or None
-        Optional batch size. Stored for future extension.
+    The target coordinate is expected to be in the spacecraft frame for this
+    selector version, because the event scattered directions are also in the
+    spacecraft frame.
     """
+
+    event_data_type = ComptonDataSpaceInSCFrameEventDataInterface
 
     def __init__(
         self,
-        spacecraft_history,
         target_coord: SkyCoord,
         arm_cut: u.Quantity,
-        chi_col: str = "Chi galactic",
-        psi_col: str = "Psi galactic",
-        phi_col: str = "Phi",
-        batch_size: int = None,
+        polarization_convention="RelativeX",
     ):
-        self._spacecraft_history = spacecraft_history
-        self._target_coord = target_coord.galactic
-        self._arm_cut = arm_cut.to(u.deg)
-
-        self._chi_col = chi_col
-        self._psi_col = psi_col
-        self._phi_col = phi_col
-        self._batch_size = batch_size
-
-        # Precompute source quantities in radians for fast vectorized selection.
-        self._src_l_rad = self._target_coord.l.to_value(u.rad)
-        self._src_b_rad = self._target_coord.b.to_value(u.rad)
-
-        self._sin_src_b = np.sin(self._src_b_rad)
-        self._cos_src_b = np.cos(self._src_b_rad)
-
-    @property
-    def arm_cut(self):
         """
-        ARM selection half-width.
+        Parameters
+        ----------
+        target_coord : astropy.coordinates.SkyCoord
+            Source direction. For this selector version, this should be given
+            in SpacecraftFrame, because events.scattered_direction_sc is in
+            SpacecraftFrame.
 
-        Returns
-        -------
-        astropy.units.Quantity
-            ARM cut in degrees.
+        arm_cut : astropy.units.Quantity
+            Maximum absolute ARM value accepted by the selector.
+            Example: 13.0 * u.deg
+
+        polarization_convention : str or PolarizationConvention, optional
+            Polarization convention used by RelativeCDSCoordinates.
+            Default is "RelativeX", matching the MEGAlib-style relative
+            coordinate convention.
         """
-        return self._arm_cut
+
+        if not isinstance(target_coord, SkyCoord):
+            raise TypeError(
+                "target_coord must be an astropy.coordinates.SkyCoord object."
+            )
+
+        if not isinstance(target_coord.frame, SpacecraftFrame):
+            raise ValueError(
+                "target_coord must be in SpacecraftFrame for this "
+                "ARMSelector version. The input events provide scattered "
+                "directions in spacecraft coordinates, so the source direction "
+                "must be in the same frame."
+            )
+
+        self._target_coord = target_coord
+        self._arm_cut = Angle(arm_cut).to(u.deg)
+
+        if isinstance(polarization_convention, str):
+            polarization_convention = PolarizationConvention.get_convention(
+                polarization_convention
+            )
+        elif not isinstance(polarization_convention, PolarizationConvention):
+            raise TypeError(
+                "polarization_convention must be either a string registered "
+                "with PolarizationConvention or a PolarizationConvention object."
+            )
+
+        self._polarization_convention = polarization_convention
+
+        self._relative_cds = RelativeCDSCoordinates(
+            source_direction=self._target_coord,
+            pol_convention=self._polarization_convention,
+        )
 
     @property
     def target_coord(self):
         """
-        Target/source coordinate.
-
-        Returns
-        -------
-        astropy.coordinates.SkyCoord
-            Source coordinate in the Galactic frame.
+        Source direction used for the ARM calculation.
         """
+
         return self._target_coord
 
     @property
-    def spacecraft_history(self):
+    def arm_cut(self):
         """
-        Spacecraft history input.
+        Maximum accepted absolute ARM value.
+        """
 
-        Returns
-        -------
-        object
-            Stored spacecraft history object.
-        """
-        return self._spacecraft_history
+        return self._arm_cut
 
     @property
-    def chi_col(self):
+    def polarization_convention(self):
         """
-        Name of the Chi Galactic event-axis column.
+        Polarization convention used by RelativeCDSCoordinates.
+        """
 
-        Returns
-        -------
-        str
-            Chi column name.
-        """
-        return self._chi_col
+        return self._polarization_convention
 
-    @property
-    def psi_col(self):
+    def _compute_arm(
+        self,
+        events: ComptonDataSpaceInSCFrameEventDataInterface,
+    ):
         """
-        Name of the Psi Galactic event-axis column.
-
-        Returns
-        -------
-        str
-            Psi column name.
-        """
-        return self._psi_col
-
-    @property
-    def phi_col(self):
-        """
-        Name of the Phi column.
-
-        Returns
-        -------
-        str
-            Phi column name.
-        """
-        return self._phi_col
-
-    def _compute_arm(self, events):
-        """
-        Compute ARM values.
+        Compute ARM values for Compton event data.
 
         Parameters
         ----------
-        events : table-like
-            Event table containing:
-                self._chi_col
-                self._psi_col
-                self._phi_col
+        events : ComptonDataSpaceInSCFrameEventDataInterface
+            Event data object providing:
+
+                - events.scattered_direction_sc
+                - events.scattering_angle_rad
 
         Returns
         -------
-        astropy.units.Quantity
+        astropy.coordinates.Angle
             ARM values in degrees.
         """
 
-        chi_rad = np.asarray(events[self._chi_col], dtype=np.float64)
-        psi_rad = np.asarray(events[self._psi_col], dtype=np.float64)
-        phi_rad = np.asarray(events[self._phi_col], dtype=np.float64)
+        scattered_direction = events.scattered_direction_sc
+        scattering_angle = Angle(events.scattering_angle_rad, unit=u.rad)
 
-        if chi_rad.shape != psi_rad.shape:
-            raise ValueError(
-                "Chi and Psi columns must have the same shape, "
-                f"got {chi_rad.shape} and {psi_rad.shape}."
-            )
-
-        if chi_rad.shape != phi_rad.shape:
-            raise ValueError(
-                "Chi/Psi and Phi columns must have the same shape, "
-                f"got {chi_rad.shape} and {phi_rad.shape}."
-            )
-
-        cos_sep = (
-            self._sin_src_b * np.sin(psi_rad)
-            + self._cos_src_b
-            * np.cos(psi_rad)
-            * np.cos(chi_rad - self._src_l_rad)
+        angular_distance, _ = self._relative_cds.to_relative(
+            scattered_direction
         )
 
-        cos_sep = np.clip(cos_sep, -1.0, 1.0)
+        arm = angular_distance - scattering_angle
 
-        sep_rad = np.arccos(cos_sep)
-        arm_rad = sep_rad - phi_rad
+        return arm.to(u.deg)
 
-        return np.rad2deg(arm_rad) * u.deg
-
-    def _select(self, events):
+    def _select(
+        self,
+        events: ComptonDataSpaceInSCFrameEventDataInterface,
+        early_stop: bool = True,
+    ) -> Iterable[bool]:
         """
-        Return boolean event-selection mask.
+        Return Boolean event-selection mask.
 
         Parameters
         ----------
-        events : table-like
-            Event table containing:
-                self._chi_col
-                self._psi_col
-                self._phi_col
+        events : ComptonDataSpaceInSCFrameEventDataInterface
+            Compton event data in spacecraft frame.
+
+        early_stop : bool, optional
+            Kept for compatibility with EventSelectorInterface. This selector
+            does not use early stopping because ARM selection is independent
+            for each event.
 
         Returns
         -------
         numpy.ndarray
-            Boolean mask. True for events inside the ARM cut and False for
-            events outside the ARM cut.
+            Boolean mask. True means the event is accepted. False means the
+            event is rejected.
         """
 
         arm = self._compute_arm(events)
 
         return np.abs(arm.to_value(u.deg)) <= self._arm_cut.to_value(u.deg)
+
+
+# In[ ]:
+
+
+
+

--- a/cosipy/event_selection/arm_selection.py
+++ b/cosipy/event_selection/arm_selection.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-# coding: utf-8
-
-# In[1]:
 
 
 import logging

--- a/cosipy/event_selection/arm_selection.py
+++ b/cosipy/event_selection/arm_selection.py
@@ -1,4 +1,5 @@
 import logging
+
 logger = logging.getLogger(__name__)
 
 import numpy as np
@@ -12,26 +13,38 @@ class ARMSelector(EventSelectorInterface):
     """
     ARM event selector.
 
-    Selects events satisfying:
+    Selects Compton events satisfying:
 
         |ARM| <= arm_cut
 
-    with:
+    where:
 
         ARM = angular_separation(source_direction, event_axis) - Phi
 
-    Current validated FITS-table implementation:
-        - event axis: Xpointings (glon,glat)
-        - pointings unit: radians
-        - Phi unit: radians
-        - source coordinate: SkyCoord
+    Current validated FITS-table implementation
+    -------------------------------------------
+    This implementation uses the event-axis columns:
+
+        - Chi galactic
+        - Psi galactic
+        - Phi
+
+    Units assumed from the validated FITS files:
+
+        - Chi galactic: radians
+        - Psi galactic: radians
+        - Phi: radians
+
+    The source position is provided as an astropy SkyCoord and is internally
+    converted to Galactic coordinates. The ARM values are returned in degrees.
 
     Parameters
     ----------
     spacecraft_history
         Spacecraft history object. Stored for compatibility with the requested
-        ARMSelector interface. In this validated FITS-table implementation,
-        event pointings are already available in Galactic coordinates.
+        ARMSelector interface. In this validated FITS-column implementation,
+        the event-axis direction is already available in Galactic coordinates
+        through Chi/Psi columns.
 
     target_coord : astropy.coordinates.SkyCoord
         Source position.
@@ -39,13 +52,17 @@ class ARMSelector(EventSelectorInterface):
     arm_cut : astropy.units.Quantity
         Symmetric ARM half-width, for example 13.0 * u.deg.
 
-    pointing_col : str
-        FITS/event-table column containing event pointing directions.
-        Validated value: "Xpointings (glon,glat)"
+    chi_col : str
+        FITS/event-table column containing the Galactic longitude-like event
+        axis angle. Validated value: "Chi galactic".
+
+    psi_col : str
+        FITS/event-table column containing the Galactic latitude-like event
+        axis angle. Validated value: "Psi galactic".
 
     phi_col : str
-        FITS/event-table column containing Phi.
-        Validated value: "Phi"
+        FITS/event-table column containing the Compton scatter angle Phi.
+        Validated value: "Phi".
 
     batch_size : int or None
         Optional batch size. Stored for future extension.
@@ -56,7 +73,8 @@ class ARMSelector(EventSelectorInterface):
         spacecraft_history,
         target_coord: SkyCoord,
         arm_cut: u.Quantity,
-        pointing_col: str = "Xpointings (glon,glat)",
+        chi_col: str = "Chi galactic",
+        psi_col: str = "Psi galactic",
         phi_col: str = "Phi",
         batch_size: int = None,
     ):
@@ -64,7 +82,8 @@ class ARMSelector(EventSelectorInterface):
         self._target_coord = target_coord.galactic
         self._arm_cut = arm_cut.to(u.deg)
 
-        self._pointing_col = pointing_col
+        self._chi_col = chi_col
+        self._psi_col = psi_col
         self._phi_col = phi_col
         self._batch_size = batch_size
 
@@ -77,15 +96,75 @@ class ARMSelector(EventSelectorInterface):
 
     @property
     def arm_cut(self):
+        """
+        ARM selection half-width.
+
+        Returns
+        -------
+        astropy.units.Quantity
+            ARM cut in degrees.
+        """
         return self._arm_cut
 
     @property
     def target_coord(self):
+        """
+        Target/source coordinate.
+
+        Returns
+        -------
+        astropy.coordinates.SkyCoord
+            Source coordinate in the Galactic frame.
+        """
         return self._target_coord
 
     @property
     def spacecraft_history(self):
+        """
+        Spacecraft history input.
+
+        Returns
+        -------
+        object
+            Stored spacecraft history object.
+        """
         return self._spacecraft_history
+
+    @property
+    def chi_col(self):
+        """
+        Name of the Chi Galactic event-axis column.
+
+        Returns
+        -------
+        str
+            Chi column name.
+        """
+        return self._chi_col
+
+    @property
+    def psi_col(self):
+        """
+        Name of the Psi Galactic event-axis column.
+
+        Returns
+        -------
+        str
+            Psi column name.
+        """
+        return self._psi_col
+
+    @property
+    def phi_col(self):
+        """
+        Name of the Phi column.
+
+        Returns
+        -------
+        str
+            Phi column name.
+        """
+        return self._phi_col
 
     def _compute_arm(self, events):
         """
@@ -95,38 +174,43 @@ class ARMSelector(EventSelectorInterface):
         ----------
         events : table-like
             Event table containing:
-                self._pointing_col
+                self._chi_col
+                self._psi_col
                 self._phi_col
 
         Returns
         -------
-        arm : astropy.units.Quantity
+        astropy.units.Quantity
             ARM values in degrees.
         """
 
-        pointing_rad = np.asarray(events[self._pointing_col])
-        phi_rad = np.asarray(events[self._phi_col])
+        chi_rad = np.asarray(events[self._chi_col], dtype=np.float64)
+        psi_rad = np.asarray(events[self._psi_col], dtype=np.float64)
+        phi_rad = np.asarray(events[self._phi_col], dtype=np.float64)
 
-        if pointing_rad.ndim != 2 or pointing_rad.shape[1] != 2:
+        if chi_rad.shape != psi_rad.shape:
             raise ValueError(
-                f"Expected pointing column with shape (N, 2), "
-                f"got {pointing_rad.shape}"
+                "Chi and Psi columns must have the same shape, "
+                f"got {chi_rad.shape} and {psi_rad.shape}."
             )
 
-        event_l_rad = pointing_rad[:, 0].astype(np.float64)
-        event_b_rad = pointing_rad[:, 1].astype(np.float64)
+        if chi_rad.shape != phi_rad.shape:
+            raise ValueError(
+                "Chi/Psi and Phi columns must have the same shape, "
+                f"got {chi_rad.shape} and {phi_rad.shape}."
+            )
 
         cos_sep = (
-            self._sin_src_b * np.sin(event_b_rad)
+            self._sin_src_b * np.sin(psi_rad)
             + self._cos_src_b
-            * np.cos(event_b_rad)
-            * np.cos(event_l_rad - self._src_l_rad)
+            * np.cos(psi_rad)
+            * np.cos(chi_rad - self._src_l_rad)
         )
 
         cos_sep = np.clip(cos_sep, -1.0, 1.0)
 
         sep_rad = np.arccos(cos_sep)
-        arm_rad = sep_rad - phi_rad.astype(np.float64)
+        arm_rad = sep_rad - phi_rad
 
         return np.rad2deg(arm_rad) * u.deg
 
@@ -134,11 +218,19 @@ class ARMSelector(EventSelectorInterface):
         """
         Return boolean event-selection mask.
 
+        Parameters
+        ----------
+        events : table-like
+            Event table containing:
+                self._chi_col
+                self._psi_col
+                self._phi_col
+
         Returns
         -------
-        mask : numpy.ndarray
-            True for events inside the ARM cut.
-            False for events outside the ARM cut.
+        numpy.ndarray
+            Boolean mask. True for events inside the ARM cut and False for
+            events outside the ARM cut.
         """
 
         arm = self._compute_arm(events)

--- a/cosipy/event_selection/arm_selection.py
+++ b/cosipy/event_selection/arm_selection.py
@@ -1,0 +1,146 @@
+import logging
+logger = logging.getLogger(__name__)
+
+import numpy as np
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+from cosipy.interfaces.event_selection import EventSelectorInterface
+
+
+class ARMSelector(EventSelectorInterface):
+    """
+    ARM event selector.
+
+    Selects events satisfying:
+
+        |ARM| <= arm_cut
+
+    with:
+
+        ARM = angular_separation(source_direction, event_axis) - Phi
+
+    Current validated FITS-table implementation:
+        - event axis: Xpointings (glon,glat)
+        - pointings unit: radians
+        - Phi unit: radians
+        - source coordinate: SkyCoord
+
+    Parameters
+    ----------
+    spacecraft_history
+        Spacecraft history object. Stored for compatibility with the requested
+        ARMSelector interface. In this validated FITS-table implementation,
+        event pointings are already available in Galactic coordinates.
+
+    target_coord : astropy.coordinates.SkyCoord
+        Source position.
+
+    arm_cut : astropy.units.Quantity
+        Symmetric ARM half-width, for example 13.0 * u.deg.
+
+    pointing_col : str
+        FITS/event-table column containing event pointing directions.
+        Validated value: "Xpointings (glon,glat)"
+
+    phi_col : str
+        FITS/event-table column containing Phi.
+        Validated value: "Phi"
+
+    batch_size : int or None
+        Optional batch size. Stored for future extension.
+    """
+
+    def __init__(
+        self,
+        spacecraft_history,
+        target_coord: SkyCoord,
+        arm_cut: u.Quantity,
+        pointing_col: str = "Xpointings (glon,glat)",
+        phi_col: str = "Phi",
+        batch_size: int = None,
+    ):
+        self._spacecraft_history = spacecraft_history
+        self._target_coord = target_coord.galactic
+        self._arm_cut = arm_cut.to(u.deg)
+
+        self._pointing_col = pointing_col
+        self._phi_col = phi_col
+        self._batch_size = batch_size
+
+        # Precompute source quantities in radians for fast vectorized selection.
+        self._src_l_rad = self._target_coord.l.to_value(u.rad)
+        self._src_b_rad = self._target_coord.b.to_value(u.rad)
+
+        self._sin_src_b = np.sin(self._src_b_rad)
+        self._cos_src_b = np.cos(self._src_b_rad)
+
+    @property
+    def arm_cut(self):
+        return self._arm_cut
+
+    @property
+    def target_coord(self):
+        return self._target_coord
+
+    @property
+    def spacecraft_history(self):
+        return self._spacecraft_history
+
+    def _compute_arm(self, events):
+        """
+        Compute ARM values.
+
+        Parameters
+        ----------
+        events : table-like
+            Event table containing:
+                self._pointing_col
+                self._phi_col
+
+        Returns
+        -------
+        arm : astropy.units.Quantity
+            ARM values in degrees.
+        """
+
+        pointing_rad = np.asarray(events[self._pointing_col])
+        phi_rad = np.asarray(events[self._phi_col])
+
+        if pointing_rad.ndim != 2 or pointing_rad.shape[1] != 2:
+            raise ValueError(
+                f"Expected pointing column with shape (N, 2), "
+                f"got {pointing_rad.shape}"
+            )
+
+        event_l_rad = pointing_rad[:, 0].astype(np.float64)
+        event_b_rad = pointing_rad[:, 1].astype(np.float64)
+
+        cos_sep = (
+            self._sin_src_b * np.sin(event_b_rad)
+            + self._cos_src_b
+            * np.cos(event_b_rad)
+            * np.cos(event_l_rad - self._src_l_rad)
+        )
+
+        cos_sep = np.clip(cos_sep, -1.0, 1.0)
+
+        sep_rad = np.arccos(cos_sep)
+        arm_rad = sep_rad - phi_rad.astype(np.float64)
+
+        return np.rad2deg(arm_rad) * u.deg
+
+    def _select(self, events):
+        """
+        Return boolean event-selection mask.
+
+        Returns
+        -------
+        mask : numpy.ndarray
+            True for events inside the ARM cut.
+            False for events outside the ARM cut.
+        """
+
+        arm = self._compute_arm(events)
+
+        return np.abs(arm.to_value(u.deg)) <= self._arm_cut.to_value(u.deg)

--- a/tests/event_selection/test_arm_selector.py
+++ b/tests/event_selection/test_arm_selector.py
@@ -2,65 +2,105 @@ import numpy as np
 import pytest
 import astropy.units as u
 from astropy.coordinates import SkyCoord
+from scoords import SpacecraftFrame
 
 from cosipy.event_selection import ARMSelector
+from cosipy.data_io.EmCDSUnbinnedData import EmCDSEventDataInSCFrameFromArrays
 
 
-CHI_COL = "Chi galactic"
-PSI_COL = "Psi galactic"
-PHI_COL = "Phi"
+def make_source_sc(lon_deg=0.0, lat_deg=0.0):
+    return SkyCoord(
+        lon=lon_deg * u.deg,
+        lat=lat_deg * u.deg,
+        frame=SpacecraftFrame(),
+    )
 
 
-def make_events(chi_rad, psi_rad, phi_rad):
-    return {
-        CHI_COL: np.asarray(chi_rad, dtype=np.float64),
-        PSI_COL: np.asarray(psi_rad, dtype=np.float64),
-        PHI_COL: np.asarray(phi_rad, dtype=np.float64),
-    }
+def make_events(scattered_lon_deg, scattered_lat_deg, phi_deg):
+    scattered_lon_deg = np.asarray(scattered_lon_deg, dtype=np.float64)
+    scattered_lat_deg = np.asarray(scattered_lat_deg, dtype=np.float64)
+    phi_deg = np.asarray(phi_deg, dtype=np.float64)
+
+    return EmCDSEventDataInSCFrameFromArrays(
+        energy_keV=np.full(scattered_lon_deg.size, 1000.0),
+        scattered_lon_rad_sc=np.deg2rad(scattered_lon_deg),
+        scattered_lat_rad_sc=np.deg2rad(scattered_lat_deg),
+        scatt_angle_rad=np.deg2rad(phi_deg),
+    )
 
 
 def test_arm_selector_initialization():
-    source = SkyCoord(l=0.0 * u.deg, b=0.0 * u.deg, frame="galactic")
-    spacecraft_history = object()
+    source = make_source_sc()
 
     selector = ARMSelector(
-        spacecraft_history=spacecraft_history,
         target_coord=source,
         arm_cut=13.0 * u.deg,
-        chi_col=CHI_COL,
-        psi_col=PSI_COL,
-        phi_col=PHI_COL,
     )
 
-    assert selector.spacecraft_history is spacecraft_history
+    assert selector.target_coord is source
     assert selector.arm_cut == 13.0 * u.deg
-    assert selector.chi_col == CHI_COL
-    assert selector.psi_col == PSI_COL
-    assert selector.phi_col == PHI_COL
-    assert np.isclose(selector.target_coord.l.to_value(u.deg), 0.0)
-    assert np.isclose(selector.target_coord.b.to_value(u.deg), 0.0)
+    assert selector.polarization_convention is not None
 
 
-def test_compute_arm_values():
-    source = SkyCoord(l=0.0 * u.deg, b=0.0 * u.deg, frame="galactic")
+def test_target_coord_must_be_skycoord():
+    with pytest.raises(
+        TypeError,
+        match="target_coord must be an astropy.coordinates.SkyCoord object",
+    ):
+        ARMSelector(
+            target_coord=object(),
+            arm_cut=13.0 * u.deg,
+        )
 
-    selector = ARMSelector(
-        spacecraft_history=None,
-        target_coord=source,
-        arm_cut=13.0 * u.deg,
-        chi_col=CHI_COL,
-        psi_col=PSI_COL,
-        phi_col=PHI_COL,
+
+def test_target_coord_must_be_spacecraft_frame():
+    source = SkyCoord(
+        l=0.0 * u.deg,
+        b=0.0 * u.deg,
+        frame="galactic",
     )
 
-    # Source is at l=0 deg, b=0 deg.
-    # Therefore, events at chi=0,10,30 deg and psi=0 deg have
-    # angular separations of 0,10,30 deg from the source.
-    chi_rad = np.deg2rad(np.array([0.0, 10.0, 30.0]))
-    psi_rad = np.deg2rad(np.array([0.0, 0.0, 0.0]))
-    phi_rad = np.deg2rad(np.array([0.0, 5.0, 0.0]))
+    with pytest.raises(
+        ValueError,
+        match="target_coord must be in SpacecraftFrame",
+    ):
+        ARMSelector(
+            target_coord=source,
+            arm_cut=13.0 * u.deg,
+        )
 
-    events = make_events(chi_rad, psi_rad, phi_rad)
+
+def test_invalid_polarization_convention_type_raises_type_error():
+    source = make_source_sc()
+
+    with pytest.raises(
+        TypeError,
+        match="polarization_convention must be either",
+    ):
+        ARMSelector(
+            target_coord=source,
+            arm_cut=13.0 * u.deg,
+            polarization_convention=object(),
+        )
+
+
+def test_compute_arm_values_from_event_interface():
+    source = make_source_sc()
+
+    selector = ARMSelector(
+        target_coord=source,
+        arm_cut=13.0 * u.deg,
+    )
+
+    # Source is at spacecraft lon=0 deg, lat=0 deg.
+    # Events at lon=0, 10, 30 deg and lat=0 deg have angular distances
+    # 0, 10, and 30 deg from the source.
+    # ARM = angular_distance - Phi.
+    events = make_events(
+        scattered_lon_deg=[0.0, 10.0, 30.0],
+        scattered_lat_deg=[0.0, 0.0, 0.0],
+        phi_deg=[0.0, 5.0, 0.0],
+    )
 
     arm = selector._compute_arm(events).to_value(u.deg)
 
@@ -69,25 +109,21 @@ def test_compute_arm_values():
     np.testing.assert_allclose(arm, expected_arm, atol=1e-10)
 
 
-def test_select_returns_boolean_mask():
-    source = SkyCoord(l=0.0 * u.deg, b=0.0 * u.deg, frame="galactic")
+def test_select_returns_boolean_mask_from_event_interface():
+    source = make_source_sc()
 
     selector = ARMSelector(
-        spacecraft_history=None,
         target_coord=source,
         arm_cut=13.0 * u.deg,
-        chi_col=CHI_COL,
-        psi_col=PSI_COL,
-        phi_col=PHI_COL,
     )
 
-    # ARM values will be 0, 10, and 20 deg.
-    # With arm_cut = 13 deg, only the first two should be selected.
-    chi_rad = np.deg2rad(np.array([0.0, 10.0, 20.0]))
-    psi_rad = np.deg2rad(np.array([0.0, 0.0, 0.0]))
-    phi_rad = np.deg2rad(np.array([0.0, 0.0, 0.0]))
-
-    events = make_events(chi_rad, psi_rad, phi_rad)
+    # ARM values are 0, 10, and 20 deg.
+    # With arm_cut = 13 deg, only the first two events should be selected.
+    events = make_events(
+        scattered_lon_deg=[0.0, 10.0, 20.0],
+        scattered_lat_deg=[0.0, 0.0, 0.0],
+        phi_deg=[0.0, 0.0, 0.0],
+    )
 
     mask = selector._select(events)
 
@@ -95,45 +131,20 @@ def test_select_returns_boolean_mask():
     np.testing.assert_array_equal(mask, np.array([True, True, False]))
 
 
-def test_chi_psi_shape_mismatch_raises_value_error():
-    source = SkyCoord(l=0.0 * u.deg, b=0.0 * u.deg, frame="galactic")
+def test_public_select_method_works_from_event_interface():
+    source = make_source_sc()
 
     selector = ARMSelector(
-        spacecraft_history=None,
         target_coord=source,
         arm_cut=13.0 * u.deg,
-        chi_col=CHI_COL,
-        psi_col=PSI_COL,
-        phi_col=PHI_COL,
     )
 
     events = make_events(
-        chi_rad=np.array([0.0, 1.0, 2.0]),
-        psi_rad=np.array([0.0, 1.0]),
-        phi_rad=np.array([0.0, 0.0, 0.0]),
+        scattered_lon_deg=[0.0, 30.0],
+        scattered_lat_deg=[0.0, 0.0],
+        phi_deg=[0.0, 0.0],
     )
 
-    with pytest.raises(ValueError, match="Chi and Psi columns"):
-        selector._compute_arm(events)
+    mask = selector.select(events)
 
-
-def test_phi_shape_mismatch_raises_value_error():
-    source = SkyCoord(l=0.0 * u.deg, b=0.0 * u.deg, frame="galactic")
-
-    selector = ARMSelector(
-        spacecraft_history=None,
-        target_coord=source,
-        arm_cut=13.0 * u.deg,
-        chi_col=CHI_COL,
-        psi_col=PSI_COL,
-        phi_col=PHI_COL,
-    )
-
-    events = make_events(
-        chi_rad=np.array([0.0, 1.0, 2.0]),
-        psi_rad=np.array([0.0, 1.0, 2.0]),
-        phi_rad=np.array([0.0, 0.0]),
-    )
-
-    with pytest.raises(ValueError, match="Chi/Psi and Phi columns"):
-        selector._compute_arm(events)
+    np.testing.assert_array_equal(mask, np.array([True, False]))

--- a/tests/event_selection/test_arm_selector.py
+++ b/tests/event_selection/test_arm_selector.py
@@ -1,0 +1,118 @@
+import numpy as np
+import pytest
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+from cosipy.event_selection import ARMSelector
+
+
+POINTING_COL = "Xpointings (glon,glat)"
+PHI_COL = "Phi"
+
+
+def make_events(pointings_rad, phi_rad):
+    return {
+        POINTING_COL: np.asarray(pointings_rad, dtype=np.float64),
+        PHI_COL: np.asarray(phi_rad, dtype=np.float64),
+    }
+
+
+def test_arm_selector_initialization():
+    source = SkyCoord(l=0.0 * u.deg, b=0.0 * u.deg, frame="galactic")
+    spacecraft_history = object()
+
+    selector = ARMSelector(
+        spacecraft_history=spacecraft_history,
+        target_coord=source,
+        arm_cut=13.0 * u.deg,
+        pointing_col=POINTING_COL,
+        phi_col=PHI_COL,
+    )
+
+    assert selector.spacecraft_history is spacecraft_history
+    assert selector.arm_cut == 13.0 * u.deg
+    assert np.isclose(selector.target_coord.l.to_value(u.deg), 0.0)
+    assert np.isclose(selector.target_coord.b.to_value(u.deg), 0.0)
+
+
+def test_compute_arm_values():
+    source = SkyCoord(l=0.0 * u.deg, b=0.0 * u.deg, frame="galactic")
+
+    selector = ARMSelector(
+        spacecraft_history=None,
+        target_coord=source,
+        arm_cut=13.0 * u.deg,
+        pointing_col=POINTING_COL,
+        phi_col=PHI_COL,
+    )
+
+    pointings_rad = np.deg2rad(
+        np.array(
+            [
+                [0.0, 0.0],
+                [10.0, 0.0],
+                [30.0, 0.0],
+            ]
+        )
+    )
+
+    phi_rad = np.deg2rad(np.array([0.0, 5.0, 0.0]))
+
+    events = make_events(pointings_rad, phi_rad)
+
+    arm = selector._compute_arm(events).to_value(u.deg)
+
+    expected_arm = np.array([0.0, 5.0, 30.0])
+
+    np.testing.assert_allclose(arm, expected_arm, atol=1e-10)
+
+
+def test_select_returns_boolean_mask():
+    source = SkyCoord(l=0.0 * u.deg, b=0.0 * u.deg, frame="galactic")
+
+    selector = ARMSelector(
+        spacecraft_history=None,
+        target_coord=source,
+        arm_cut=13.0 * u.deg,
+        pointing_col=POINTING_COL,
+        phi_col=PHI_COL,
+    )
+
+    pointings_rad = np.deg2rad(
+        np.array(
+            [
+                [0.0, 0.0],
+                [10.0, 0.0],
+                [20.0, 0.0],
+            ]
+        )
+    )
+
+    phi_rad = np.deg2rad(np.array([0.0, 0.0, 0.0]))
+
+    events = make_events(pointings_rad, phi_rad)
+
+    mask = selector._select(events)
+
+    assert mask.dtype == bool
+    np.testing.assert_array_equal(mask, np.array([True, True, False]))
+
+
+def test_invalid_pointing_shape_raises_value_error():
+    source = SkyCoord(l=0.0 * u.deg, b=0.0 * u.deg, frame="galactic")
+
+    selector = ARMSelector(
+        spacecraft_history=None,
+        target_coord=source,
+        arm_cut=13.0 * u.deg,
+        pointing_col=POINTING_COL,
+        phi_col=PHI_COL,
+    )
+
+    events = make_events(
+        pointings_rad=np.array([0.0, 1.0, 2.0]),
+        phi_rad=np.array([0.0, 0.0, 0.0]),
+    )
+
+    with pytest.raises(ValueError, match="Expected pointing column"):
+        selector._compute_arm(events)

--- a/tests/event_selection/test_arm_selector.py
+++ b/tests/event_selection/test_arm_selector.py
@@ -6,13 +6,15 @@ from astropy.coordinates import SkyCoord
 from cosipy.event_selection import ARMSelector
 
 
-POINTING_COL = "Xpointings (glon,glat)"
+CHI_COL = "Chi galactic"
+PSI_COL = "Psi galactic"
 PHI_COL = "Phi"
 
 
-def make_events(pointings_rad, phi_rad):
+def make_events(chi_rad, psi_rad, phi_rad):
     return {
-        POINTING_COL: np.asarray(pointings_rad, dtype=np.float64),
+        CHI_COL: np.asarray(chi_rad, dtype=np.float64),
+        PSI_COL: np.asarray(psi_rad, dtype=np.float64),
         PHI_COL: np.asarray(phi_rad, dtype=np.float64),
     }
 
@@ -25,12 +27,16 @@ def test_arm_selector_initialization():
         spacecraft_history=spacecraft_history,
         target_coord=source,
         arm_cut=13.0 * u.deg,
-        pointing_col=POINTING_COL,
+        chi_col=CHI_COL,
+        psi_col=PSI_COL,
         phi_col=PHI_COL,
     )
 
     assert selector.spacecraft_history is spacecraft_history
     assert selector.arm_cut == 13.0 * u.deg
+    assert selector.chi_col == CHI_COL
+    assert selector.psi_col == PSI_COL
+    assert selector.phi_col == PHI_COL
     assert np.isclose(selector.target_coord.l.to_value(u.deg), 0.0)
     assert np.isclose(selector.target_coord.b.to_value(u.deg), 0.0)
 
@@ -42,23 +48,19 @@ def test_compute_arm_values():
         spacecraft_history=None,
         target_coord=source,
         arm_cut=13.0 * u.deg,
-        pointing_col=POINTING_COL,
+        chi_col=CHI_COL,
+        psi_col=PSI_COL,
         phi_col=PHI_COL,
     )
 
-    pointings_rad = np.deg2rad(
-        np.array(
-            [
-                [0.0, 0.0],
-                [10.0, 0.0],
-                [30.0, 0.0],
-            ]
-        )
-    )
-
+    # Source is at l=0 deg, b=0 deg.
+    # Therefore, events at chi=0,10,30 deg and psi=0 deg have
+    # angular separations of 0,10,30 deg from the source.
+    chi_rad = np.deg2rad(np.array([0.0, 10.0, 30.0]))
+    psi_rad = np.deg2rad(np.array([0.0, 0.0, 0.0]))
     phi_rad = np.deg2rad(np.array([0.0, 5.0, 0.0]))
 
-    events = make_events(pointings_rad, phi_rad)
+    events = make_events(chi_rad, psi_rad, phi_rad)
 
     arm = selector._compute_arm(events).to_value(u.deg)
 
@@ -74,23 +76,18 @@ def test_select_returns_boolean_mask():
         spacecraft_history=None,
         target_coord=source,
         arm_cut=13.0 * u.deg,
-        pointing_col=POINTING_COL,
+        chi_col=CHI_COL,
+        psi_col=PSI_COL,
         phi_col=PHI_COL,
     )
 
-    pointings_rad = np.deg2rad(
-        np.array(
-            [
-                [0.0, 0.0],
-                [10.0, 0.0],
-                [20.0, 0.0],
-            ]
-        )
-    )
-
+    # ARM values will be 0, 10, and 20 deg.
+    # With arm_cut = 13 deg, only the first two should be selected.
+    chi_rad = np.deg2rad(np.array([0.0, 10.0, 20.0]))
+    psi_rad = np.deg2rad(np.array([0.0, 0.0, 0.0]))
     phi_rad = np.deg2rad(np.array([0.0, 0.0, 0.0]))
 
-    events = make_events(pointings_rad, phi_rad)
+    events = make_events(chi_rad, psi_rad, phi_rad)
 
     mask = selector._select(events)
 
@@ -98,21 +95,45 @@ def test_select_returns_boolean_mask():
     np.testing.assert_array_equal(mask, np.array([True, True, False]))
 
 
-def test_invalid_pointing_shape_raises_value_error():
+def test_chi_psi_shape_mismatch_raises_value_error():
     source = SkyCoord(l=0.0 * u.deg, b=0.0 * u.deg, frame="galactic")
 
     selector = ARMSelector(
         spacecraft_history=None,
         target_coord=source,
         arm_cut=13.0 * u.deg,
-        pointing_col=POINTING_COL,
+        chi_col=CHI_COL,
+        psi_col=PSI_COL,
         phi_col=PHI_COL,
     )
 
     events = make_events(
-        pointings_rad=np.array([0.0, 1.0, 2.0]),
+        chi_rad=np.array([0.0, 1.0, 2.0]),
+        psi_rad=np.array([0.0, 1.0]),
         phi_rad=np.array([0.0, 0.0, 0.0]),
     )
 
-    with pytest.raises(ValueError, match="Expected pointing column"):
+    with pytest.raises(ValueError, match="Chi and Psi columns"):
+        selector._compute_arm(events)
+
+
+def test_phi_shape_mismatch_raises_value_error():
+    source = SkyCoord(l=0.0 * u.deg, b=0.0 * u.deg, frame="galactic")
+
+    selector = ARMSelector(
+        spacecraft_history=None,
+        target_coord=source,
+        arm_cut=13.0 * u.deg,
+        chi_col=CHI_COL,
+        psi_col=PSI_COL,
+        phi_col=PHI_COL,
+    )
+
+    events = make_events(
+        chi_rad=np.array([0.0, 1.0, 2.0]),
+        psi_rad=np.array([0.0, 1.0, 2.0]),
+        phi_rad=np.array([0.0, 0.0]),
+    )
+
+    with pytest.raises(ValueError, match="Chi/Psi and Phi columns"):
         selector._compute_arm(events)


### PR DESCRIPTION
This PR adds a first `ARMSelector` implementation for COSIpy event selection.

The selector applies an ARM cut using:

`ARM = angular separation(source direction, event axis) - Phi`

Updated implementation uses:

- `Chi galactic`
- `Psi galactic`
- `Phi`
- all stored in radians

Validated locally on `GRB_bn110605183`:

- ARM cut: ±13 deg
- GRB total events: 2,776
- GRB selected events: 554
- GRB selected fraction: 0.1996
- ARM distribution is centered close to 0°, as expected

Tests were updated accordingly:

- ARMSelector tests: 5/5 passed locally
- Related event-selection tests: 10/10 passed locally

Note:
This is the validated FITS-column implementation. A remaining refinement is adapting it to the full `ComptonDataSpaceInSCFrameEventInterface`, where `SpacecraftHistory` is used internally for the sky-to-spacecraft transformation.