### PR TITLE
Update h5py dependency version due to vulnerability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "High-level analysis for the COSI telescope data"
 requires-python = ">=3.12"
 dependencies = [
                   "histpy>=2.0.7",
-                  "h5py",
+                  "h5py>=3.13.0",
                   "hdf5plugin",
                   "mhealpy>=0.3.7",
                   "scoords",


### PR DESCRIPTION
See https://www.sentinelone.com/vulnerability-database/cve-2026-26200/ 

Affecting HDF5 versions prior to 1.14.4-2

While the h5py version is technically be independent of the underlaying HDF5 version, I checked in conda-forge and the h5py 3.13.0 (released Feb 18, 2025) is the first version shipped with an HDF5 after the one with the vulnerability (1.14.6). It might be system dependent, so this should be double check on deployment.