### PR TITLE
docs: suggest clone over https rather than ssh

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -32,7 +32,7 @@ accommodate new features in cosipy.
   
 Do the following (preferably inside a conda environment)::
 
-    git clone git@github.com:cositools/cosipy.git
+    git clone https://github.com/cositools/cosipy
     cd cosipy
     pip install -e .
 

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -1,7 +1,7 @@
 Tutorials
 =========
 
-This is a series of tutorials explaining step by step the various components of the `cosipy` library and how to use it. Although they are rendered as a webpage here, these are interactive Python notebooks (ipynb) that you can execute and modify, distributed as part of the cosipy repository. You can download them using the links below, or by cloning the whole repository running :code:`git clone git@github.com:cositools/cosipy.git`.
+This is a series of tutorials explaining step by step the various components of the `cosipy` library and how to use it. Although they are rendered as a webpage here, these are interactive Python notebooks (ipynb) that you can execute and modify, distributed as part of the cosipy repository. You can download them using the links below, or by cloning the whole repository running :code:`git clone https://github.com/cositools/cosipy`.
 
 If you are interested instead of the description of each class and method, please see our `API <../api/index.html>`_ section.
 


### PR DESCRIPTION
Resolves https://github.com/cositools/cosipy/issues/589

"`git clone`" was found twice in the docs :))