### PR TITLE
Add unbinned Crab tutorial notebook and update index files

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -100,7 +100,8 @@ List of tutorials and contents, as a link to the corresponding Python notebook i
    response/SpacecraftHistory.ipynb
    Detector response and signal expectation <response/DetectorResponse.ipynb>
    TS Map: localizing a GRB <ts_map/Parallel_TS_map_computation.ipynb>
-   Fitting the spectrum of the Crab <spectral_fits/continuum_fit/crab/SpectralFit_Crab.ipynb>
+   Fitting the spectrum of the Crab (binned) <spectral_fits/continuum_fit/crab/SpectralFit_Crab.ipynb>
+   Fitting the spectrum of a GRB (unbinned) <spectral_fits/continuum_fit/grb/example_grb_fit_normalizing_flows.ipynb>
    Extended source model fitting <spectral_fits/extended_source_fit/diffuse_511_spectral_fit.ipynb>
    Image deconvolution <image_deconvolution/511keV-Galactic-ImageDeconvolution.ipynb>
    Source injector <source_injector/Point_source_injector.ipynb>

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -34,7 +34,7 @@ List of tutorials and contents, as a link to the corresponding Python notebook i
   - Meaning of the TS map and how to compute confidence contours
   - Computing a TS map, getting the best location and estimating the error
     
-5. Fitting the spectrum of the Crab `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/spectral_fits/continuum_fit/crab/SpectralFit_Crab.ipynb>`_
+5. Fitting the spectrum of the Crab (binned) `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/spectral_fits/continuum_fit/crab/SpectralFit_Crab.ipynb>`_
   
   - Introduction to 3ML and astromodels
   - Likelihood analysis. 
@@ -43,43 +43,51 @@ List of tutorials and contents, as a link to the corresponding Python notebook i
   - Comparing the result with the data
   - Analysing a continuous source transiting in the sky.
 
-6. Extended source model fitting `(ipynb) <https://github.com/cositools/cosipy/blob/main/docs/tutorials/spectral_fits/extended_source_fit/diffuse_511_spectral_fit.ipynb>`_
+6. Fitting the spectrum of a GRB (unbinned) `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/spectral_fits/continuum_fit/grb/example_grb_fit_normalizing_flows.ipynb>`_
+
+  - Introduction to unbinned analysis using normalizing flows.
+  - Setting up the neural-network response and background approximations.
+  - Initializing and saving adaptive integration caches for faster folding.
+  - Performing the unbinned likelihood fit for a GRB point source.
+  - Plotting the result and comparing it with the injected spectrum.
+
+7. Extended source model fitting `(ipynb) <https://github.com/cositools/cosipy/blob/main/docs/tutorials/spectral_fits/extended_source_fit/diffuse_511_spectral_fit.ipynb>`_
    
   - Obtaining the extended source response as a convolution of multiple point sources
   - Pre-computing a response in galactic coordinates for all-sky
   - Fitting an extended source
     
-7. Image deconvolution `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/image_deconvolution/511keV-Galactic-ImageDeconvolution.ipynb>`_
+8. Image deconvolution `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/image_deconvolution/511keV-Galactic-ImageDeconvolution.ipynb>`_
   - Explain the RL algorithm. Reference the previous example. Explain the difference with a TS map.
   - Fitting the 511 diffuse emission.
   - Analyze data in the Compton data space with galactic coordinates.
   - Link to a notebook using Scatt binning which shows its advantages/disadvantages.
     
-8. Source injector `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/source_injector/Point_source_injector.ipynb>`_
+9. Source injector `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/source_injector/Point_source_injector.ipynb>`_
   - Convolve the response, point source model and orientation to obtain the mock data.
   - More types of source (e,g. extended source and polarization) will be suppored.
 
-9. Continuum background estimation `(ipynb) <https://github.com/cositools/cosipy/blob/develop/docs/tutorials/background_estimation/continuum_estimation/BG_estimationNN_example.ipynb>`_
+10. Continuum background estimation `(ipynb) <https://github.com/cositools/cosipy/blob/develop/docs/tutorials/background_estimation/continuum_estimation/BG_estimationNN_example.ipynb>`_
   - Estimating the continuum background from the data. 
 
-10. Line background estimation `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/background_estimation/line_background/line_background_estimation_example_notebook.ipynb>`_
+11. Line background estimation `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/background_estimation/line_background/line_background_estimation_example_notebook.ipynb>`_
   - Estimating the background from neighboring energy bins.
 
-11. Polarization (ASAD method) `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/polarization/ASAD_method.ipynb>`_
+12. Polarization (ASAD method) `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/polarization/ASAD_method.ipynb>`_
   - Estimating the polarization degree and angle of a GRB using the Azimuthal Scattering Angle Distribution (ASAi)
 
 
-12. Transient background estimation `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/background_estimation/transient_background/Transient_background_example.ipynb>`_
+13. Transient background estimation `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/background_estimation/transient_background/Transient_background_example.ipynb>`_
     
   - Estimating the background for transients.
 
-13. Polarization (ASAD method) `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/polarization/ASAD_method.ipynb>`_
+14. Polarization (ASAD method) `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/polarization/ASAD_method.ipynb>`_
   - Estimating the polarization degree and angle of a GRB using the Azimuthal Scattering Angle Distribution (ASAD)
 
-14. Polarization (Stokes parameters method) `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/polarization/Stokes_method.ipynb>`_
+15. Polarization (Stokes parameters method) `(ipynb) <https://github.com/cositools/cosipy/tree/main/docs/tutorials/polarization/Stokes_method.ipynb>`_
   - Estimating the polarization of a GRB using Stokes parameters
 
-14. Phase-resolved analysis `(ipynb) <https://github.com/cositools/cosipy/blob/develop/docs/tutorials/phase_resolved_analysis/example_notebook.ipynb>`_
+16. Phase-resolved analysis `(ipynb) <https://github.com/cositools/cosipy/blob/develop/docs/tutorials/phase_resolved_analysis/example_notebook.ipynb>`_
    - Folding event data and scaling mission exposure using pulsar timing models (ephemeris).
 
 .. warning::

--- a/docs/tutorials/other_examples.rst
+++ b/docs/tutorials/other_examples.rst
@@ -8,7 +8,7 @@ Other examples
 
    Fitting the spectrum of a GRB (binned, inertial coordinates) <spectral_fits/continuum_fit/grb/SpectralFit_GRB.ipynb>
 
-   Fitting the spectrum of a GRB (unbinned) <spectral_fits/continuum_fit/grb/example_grb_fit_normalizing_flows.ipynb>
+   Fitting the spectrum of the Crab (unbinned) <spectral_fits/continuum_fit/crab/example_crab_fit_normalizing_flows.ipynb>
   
    Galactic diffuse continuum spectral fit <spectral_fits/galactic_diffuse_continuum/galdiff_continuum.ipynb> 
 

--- a/docs/tutorials/run_tutorials.yml
+++ b/docs/tutorials/run_tutorials.yml
@@ -95,7 +95,7 @@ tutorials:
         COSI-SMEX/develop/Data/Responses/SMEXv12.Continuum.HEALPixO3_10bins_log_flat.binnedimaging.imagingresponse.h5:
           checksum: eb72400a1279325e9404110f909c7785
 
-    spectral_fit_normalizing_flows:
+    spectral_fit_normalizing_flows_grb:
       notebook: spectral_fits/continuum_fit/grb/example_grb_fit_normalizing_flows.ipynb
       wasabi_files:
         COSI-SMEX/DC3/Data/Sources/GRB_bn090424592_3months_unbinned_data_filtered_with_SAAcut.fits.gz:
@@ -104,8 +104,22 @@ tutorials:
           checksum: bbbe34004153d3a75b051f78cb2a93d9
         COSI-SMEX/DC4/Data/Backgrounds/Total_DC4_BG_3months_unbinned_data_timecut_GRB_bn090424592.fits.gz:
           checksum: a7b5b64e770249bd79a734fd652c5b95
-        COSI-SMEX/DC4/Data/Responses/unpolarized_nfresponse_v1-00.pt:
-          checksum: a4f9a7842f2a7345f604da32a155803f
+        COSI-SMEX/DC4/Data/Responses/unpolarized_nfresponse_v1-01.pt:
+          checksum: bf2d0c16eac5954fb56489480c2602ca
+        COSI-SMEX/DC4/Data/Responses/nfbackground_v1-01.pt:
+          checksum: 52a4fb024930e18430bff80db882d3d5
+    
+    spectral_fit_normalizing_flows_crab:
+      notebook: spectral_fits/continuum_fit/crab/example_crab_fit_normalizing_flows.ipynb
+      wasabi_files:
+        COSI-SMEX/DC3/Data/Sources/crab_powerlaw_3months_unbinned_data_filtered_with_SAAcut.fits.gz:
+          checksum: fea0a6a1d2ad87589cedcadf0328ebc3
+        COSI-SMEX/DC4/Data/Orientation/DC4_final_530km_3_month_with_slew_15sbins_GalacticEarth_SAA.ori:
+          checksum: bbbe34004153d3a75b051f78cb2a93d9
+        COSI-SMEX/DC4/Data/Backgrounds/Total_DC4_BG_3months_unbinned_data_filtered_with_SAAcut_withSAAbck.fits.gz:
+          checksum: 73c8b23e43684da3b35c25499254202b
+        COSI-SMEX/DC4/Data/Responses/unpolarized_nfresponse_v1-01.pt:
+          checksum: bf2d0c16eac5954fb56489480c2602ca
         COSI-SMEX/DC4/Data/Responses/nfbackground_v1-01.pt:
           checksum: 52a4fb024930e18430bff80db882d3d5
 

--- a/docs/tutorials/spectral_fits/continuum_fit/crab/example_crab_fit_normalizing_flows.ipynb
+++ b/docs/tutorials/spectral_fits/continuum_fit/crab/example_crab_fit_normalizing_flows.ipynb
@@ -9,7 +9,7 @@
     "frozen": false
    },
    "source": [
-    "# Fitting the GRB Spectrum with the Neural-Network Response and Background Approximation"
+    "# Fitting the Crab Spectrum with the Neural-Network Response and Background Approximation"
    ]
   },
   {
@@ -24,43 +24,9 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "This notebook provides an overview of the different new classes introduced to allow for a truly unbinned spectral analysis of continuum point sources. The user will mainly interact with:\n",
+    "This notebook demonstrates an unbinned spectral analysis of the Crab Nebula using a simulated power-law spectrum. \n",
     "\n",
-    "1. `NFResponse` and `UnpolarizedNFFarFieldInstrumentResponseFunction`: Provide the **C-A-RQS + Spherical Harmonics Expansion** approximation of the response.\n",
-    "2. `NFBackground` and `FreeNormNFUnbinnedBackground`: Provide the **C-A-RQS + Analytical Rate Model** approximation of the simulated background (currently total DC4).\n",
-    "3. `UnbinnedThreeMLPointSourceResponseIRFAdaptive`: Perform the folding of the response with the flux model in a more efficient way.\n",
-    "4. `CachedUnbinnedThreeMLModelFolding`: Adds the capability to save and load the cache of `UnbinnedThreeMLPointSourceResponseIRFAdaptive`.\n",
-    "\n",
-    "### Inner Workings\n",
-    "\n",
-    "For a comprehensive description of the underlying architecture or more detailed comparison plots and benchmarks, please for now refer to my (Pascal J.) thesis, \"Development of an Efficient Response Description for the COSI MeV 𝜸-Ray Telescope.\" Here, I will just provide a very basic explanation of the code structure.\n",
-    "\n",
-    "#### Flow-Based Models\n",
-    "\n",
-    "The building blocks managing the approximations are `NFResponse` and `NFBackground` (both of type `NFBase`). During setup, both require a checkpoint file (e.g., `unpolarized_nfresponse_v1-00.pt`) which contains all the necessary information, such as the neural network weights and hyperparameters, the version number to choose the correct model, or the coefficients for the effective area or background rate model.\n",
-    "\n",
-    "Another important task is the creation of compute pools. All PyTorch-related inference tasks are managed by a separate process for each chosen device. These processes need to be started or stopped, as shown in the example below.\n",
-    "\n",
-    "All queries, such as evaluating the effective area or density as well as sampling, are passed through an `Approximation` object (which chooses the correct model and prepares the input) to a `Model` object (which handles the actual inference on the PyTorch device). For the response $R = A_\\mathrm{eff}(\\nu\\lambda, E_i) \\cdot P(E_m, \\phi, \\psi\\chi|\\nu\\lambda, E_i)$, this includes:\n",
-    "\n",
-    "1. The effective area $A_\\mathrm{eff}$, modeled with a spherical harmonics expansion. The latter are evaluated using the PyTorch backend of the `sphericart` library.\n",
-    "2. The probability density $P(E_m, \\phi, \\psi\\chi|\\nu\\lambda, E_i)$, modeled with conditional-autoregressive-rational quadratic spline flows. The library used is called `normflows`.\n",
-    "\n",
-    "The background model $B = R(t) \\cdot P(E_m, \\phi, \\psi\\chi|t)$ follows a very similar structure and therefore uses most of the same code. While the rate $R(t)$ is always computed on the CPU, the density $P$ is also modeled using `normflows`.\n",
-    "\n",
-    "#### Folding\n",
-    "\n",
-    "For the unbinned analysis, we need to calculate the total number of events we expect, $N$, and the expectation density, $\\mathrm{d}N/\\mathrm{d}t\\mathrm{d}E_m\\mathrm{d}\\phi\\mathrm{d}\\psi\\chi$. The latter is especially difficult to compute, since it requires folding the response with the flux model and therefore computing a numerical integral with enough precision for every event in the analysis. The background model $B$, on the other hand, is already the expectation density and requires no integration.\n",
-    "\n",
-    "The folding can be performed using `UnbinnedThreeMLPointSourceResponseTrapz`. However, since $R$ has a low inference rate, `UnbinnedThreeMLPointSourceResponseIRFAdaptive` provides an optimized implementation. It uses the fact that many flux models are \"well-behaved\" (low order in a Taylor series). This means one can significantly reduce the integration error by concentrating most Gauss-Legendre integration nodes at peaks of the response and distributing the remaining ones in between. \n",
-    "\n",
-    "The exact parameters can be tuned by the user, but it probably won't be able to account for very complex spectral shapes. For each integration node, the response is evaluated once and cached, which takes most of the time. This way, during optimization, only the flux model changes and the fitting is fast.\n",
-    "\n",
-    "Using `CachedUnbinnedThreeMLModelFolding` instead of `UnbinnedThreeMLModelFolding` adds the capability to save this cache and other parameters of `UnbinnedThreeMLPointSourceResponseIRFAdaptive`. These files can be shared with other scientists and loaded during another session to skip the expensive cache initialization.\n",
-    "\n",
-    "### Hardware Requirements\n",
-    "\n",
-    "It is highly recommended to use a GPU, preferably by NVIDIA, for the inference. A CPU, even something like an AMD Threadripper, will only allow you to analyze a few orbits in a reasonable time. Also, note that the unbinned analysis requires you to have enough RAM, which increases as the number of events you include in the analysis increases. The batch size can be decreased to limit the maximum consumption."
+    "> **Note on Underlying Mechanics:** To keep this tutorial concise, the detailed explanations of the underlying classes (such as `NFResponse`, `NFBackground`, and `UnbinnedThreeMLPointSourceResponseIRFAdaptive`) have been omitted here. If you are unfamiliar with the Neural-Network Response, the Background Approximation, or the corresponding hardware requirements introduced for DC4, **please refer to the foundational tutorial:** `example_grb_fit_normalizing_flows.ipynb`."
    ]
   },
   {
@@ -108,8 +74,8 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
-    "from threeML import Band, PointSource, Model, JointLikelihood, DataList\n",
-    "from astromodels import Parameter\n",
+    "from threeML import PointSource, Model, JointLikelihood, DataList\n",
+    "from astromodels import Parameter, Powerlaw\n",
     "\n",
     "from cosipy.threeml.unbinned_model_folding import CachedUnbinnedThreeMLModelFolding\n",
     "from cosipy.statistics import UnbinnedLikelihood\n",
@@ -139,19 +105,19 @@
    },
    "outputs": [],
    "source": [
-    "data_path = Path(\"./\") # Current path by default\n",
+    "data_path = Path(\".\") # Current path by default\n",
     "\n",
-    "grb_data_path = data_path / \"GRB_bn090424592_3months_unbinned_data_filtered_with_SAAcut.fits.gz\"\n",
-    "fetch_wasabi_file('COSI-SMEX/DC3/Data/Sources/GRB_bn090424592_3months_unbinned_data_filtered_with_SAAcut.fits.gz', \n",
-    "                  checksum = '08c1f1202d78df40a4aed3b785d273e0', output=str(grb_data_path))\n",
+    "crab_data_path = data_path / \"crab_powerlaw_3months_unbinned_data_filtered_with_SAAcut.fits.gz\"\n",
+    "fetch_wasabi_file('COSI-SMEX/DC3/Data/Sources/crab_powerlaw_3months_unbinned_data_filtered_with_SAAcut.fits.gz', \n",
+    "                  checksum = 'fea0a6a1d2ad87589cedcadf0328ebc3', output=str(crab_data_path))\n",
     "\n",
     "sc_orientation_path = data_path / \"DC4_final_530km_3_month_with_slew_15sbins_GalacticEarth_SAA.ori\"\n",
     "fetch_wasabi_file('COSI-SMEX/DC4/Data/Orientation/DC4_final_530km_3_month_with_slew_15sbins_GalacticEarth_SAA.ori', \n",
     "                  checksum = 'bbbe34004153d3a75b051f78cb2a93d9', output=str(sc_orientation_path))\n",
     "\n",
-    "bkg_data_path = data_path / \"Total_DC4_BG_3months_unbinned_data_timecut_GRB_bn090424592.fits.gz\"\n",
-    "fetch_wasabi_file('COSI-SMEX/DC4/Data/Backgrounds/Total_DC4_BG_3months_unbinned_data_timecut_GRB_bn090424592.fits.gz', \n",
-    "                  checksum = 'a7b5b64e770249bd79a734fd652c5b95', output=str(bkg_data_path))\n",
+    "bkg_data_path = data_path / \"Total_DC4_BG_3months_unbinned_data_filtered_with_SAAcut_withSAAbck.fits.gz\"\n",
+    "fetch_wasabi_file('COSI-SMEX/DC4/Data/Backgrounds/Total_DC4_BG_3months_unbinned_data_filtered_with_SAAcut_withSAAbck.fits.gz', \n",
+    "                  checksum = '73c8b23e43684da3b35c25499254202b', output=str(bkg_data_path))\n",
     "\n",
     "rsp_path = data_path / \"unpolarized_nfresponse_v1-01.pt\"\n",
     "fetch_wasabi_file('COSI-SMEX/DC4/Data/Responses/unpolarized_nfresponse_v1-01.pt',\n",
@@ -171,7 +137,7 @@
     "frozen": false
    },
    "source": [
-    "Define the observation duration here. This GRB lasts approximately 10 seconds."
+    "Define the observation duration here. For this tutorial we choose one day."
    ]
   },
   {
@@ -185,22 +151,10 @@
    },
    "outputs": [],
    "source": [
-    "tstart = Time(\"2028-03-24 10:36:42.000\")\n",
-    "tstop = Time(\"2028-03-24 10:36:51.921\")\n",
+    "tstart = Time(\"2028-03-23 10:36:00.000\")\n",
+    "tstop = Time(\"2028-03-24 10:36:00.000\")\n",
     "sc_orientation = SpacecraftHistory.open(sc_orientation_path)\n",
     "sc_orientation = sc_orientation.select_interval(tstart, tstop)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cd8dbcc7-016d-411a-b6de-f0958aa6ae5c",
-   "metadata": {
-    "deletable": true,
-    "editable": true,
-    "frozen": false
-   },
-   "source": [
-    "Typically, you would need to perform a time selection. Although this tutorial includes pre-selected files covering the full duration of the GRB, reducing the observation window is recommended if you are working with limited computational resources."
    ]
   },
   {
@@ -214,7 +168,7 @@
    },
    "outputs": [],
    "source": [
-    "data_file = [grb_data_path, bkg_data_path]\n",
+    "data_file = [crab_data_path, bkg_data_path]\n",
     "selector = TimeSelector(tstart = sc_orientation.tstart, tstop = sc_orientation.tstop)\n",
     "data = TimeTagEmCDSEventDataInSCFrameFromDC3Fits(data_file, selection=selector)"
    ]
@@ -230,30 +184,26 @@
    },
    "outputs": [],
    "source": [
-    "print(f\"This analysis uses {data.nevents} Events\")"
+    "print(f\"This analysis uses {data.nevents} events\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e676fa4e-d0a5-4b58-b309-19bb17dc95c3",
-   "metadata": {
-    "deletable": true,
-    "editable": true,
-    "frozen": false
-   },
+   "id": "64146376-7c0e-4cd3-8537-c5c167e86911",
+   "metadata": {},
    "source": [
-    "`NFResponse` and `NFBackground`\n",
-    "- `devices`: Optional default devices. \n",
-    "    - This example notebook defaults to CPU with the `[\"cpu\"]` argument.\n",
-    "    - For GPU usage, provide a list of devices following standard PyTorch naming conventions. For example, a system with four CUDA-capable GPUs can be accessed using `[\"cuda:0\", \"cuda:1\", \"cuda:2\", \"cuda:3\"]`.\n",
-    "        - You must install PyTorch with the CUDA version that matches your system. You can check your system's supported CUDA version by running the `nvidia-smi` command in your terminal.\n",
-    "        - Once you know your system version, verify which CUDA version PyTorch is currently using by running: `import torch; print(torch.version.cuda); print(torch.__version__)`.\n",
-    "        - If the versions do not match, reinstall PyTorch using the specific index URL: `pip install torch torchvision --index-url https://download.pytorch.org/whl/cu{iii}`, where `{iii}` is the CUDA version (e.g., cu121 for CUDA 12.1). Note that not all versions are available and you may need to select the closest compatible version.\n",
-    "    - Using the devices argument causes the compute pool to initialize and close automatically for each inference. This may produce unnecessary overhead unless used with functions like `UnbinnedThreeMLPointSourceResponseIRFAdaptive`, which handles pool management internally.\n",
-    "    - Alternatively, you can manually manage compute pools using `init_compute_pool`, `clean_compute_pool`, and `shutdown_compute_pool`.\n",
-    "- `compile_mode`: Optional from a list of options.\n",
-    "    - To ensure maximum compatibility, this tutorial defaults to `None`. \n",
-    "    - For potential speed-ups, you can experiment with `density_compile_mode=\"default\"` and `area_compile_mode=\"max-autotune-no-cudagraphs\"` or other [PyTorch compilation modes](https://docs.pytorch.org/docs/stable/generated/torch.compile.html)."
+    "### Initializing Models and Folding Objects\n",
+    "Setting up the neural-network response (`NFResponse`), the background approximation (`NFBackground`), and the adaptive folding objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0802eeb3-92af-4e8d-873a-e9697acfc07b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "devices = [\"cpu\"]"
    ]
   },
   {
@@ -271,7 +221,7 @@
     "    path_to_model=rsp_path,\n",
     "    area_batch_size=300_000,\n",
     "    density_batch_size=100_000, \n",
-    "    devices=[\"cpu\"],\n",
+    "    devices=devices,\n",
     "    area_compile_mode=None,\n",
     "    density_compile_mode=None,\n",
     "    show_progress=True)\n",
@@ -293,7 +243,7 @@
     "bkg_model = NFBackground(\n",
     "    path_to_model=bkg_path,\n",
     "    density_batch_size=100_000,\n",
-    "    devices=[\"cpu\"],\n",
+    "    devices=devices,\n",
     "    density_compile_mode=None,\n",
     "    show_progress=True)\n",
     "\n",
@@ -302,24 +252,6 @@
     "    data=data, \n",
     "    sc_history=sc_orientation, \n",
     "    label=\"bkg_norm\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4904469c-285e-4a3a-8770-3dbb2bc0857b",
-   "metadata": {
-    "deletable": true,
-    "editable": true,
-    "frozen": false
-   },
-   "source": [
-    "`UnbinnedThreeMLPointSourceResponseIRFAdaptive`\n",
-    "- `force_energy_node_caching`\n",
-    "    - Saves the energy nodes used for integration even when the batch size is small. This increases memory consumption but significantly speeds up expectation calculations during optimization.\n",
-    "- `reduce_memory`\n",
-    "    - Saves caches as `float32`, which can reduce the memory footprint. However, this will slow down expectation calculations. Note that for large batch sizes, this may actually increase memory consumption, so keep an eye out for related warnings.\n",
-    "- Other arguments\n",
-    "    - The class provides several getters and setters for parameters regarding integration nodes and batch sizes."
    ]
   },
   {
@@ -368,26 +300,23 @@
    },
    "outputs": [],
    "source": [
-    "l = 21.293418951586656\n",
-    "b = -42.384846594045484\n",
+    "l = 184.56\n",
+    "b = -5.78\n",
     "\n",
-    "alpha = -1.021866\n",
-    "beta = -2.762827\n",
-    "xp = 159.9995 * u.keV\n",
-    "piv = 100. * u.keV\n",
-    "K = 5.2385389556 / u.cm / u.cm / u.s / u.keV\n",
+    "index = -2.00\n",
+    "piv = 1. * u.keV\n",
+    "K = 4.94717171 / u.cm / u.cm / u.s / u.keV\n",
     "\n",
-    "spectrum = Band(beta=beta, K=K.value, piv=piv.value)\n",
+    "spectrum = Powerlaw(index=index, K=K.value, piv=piv.value)\n",
     "\n",
-    "spectrum.alpha.delta = 0.01\n",
-    "spectrum.beta.delta = 0.01\n",
+    "spectrum.index.min_value = -4\n",
+    "spectrum.index.max_value = -1\n",
     "\n",
-    "spectrum.alpha.value = alpha\n",
-    "spectrum.xp.value = xp.value\n",
-    "\n",
-    "spectrum.xp.unit = xp.unit\n",
     "spectrum.K.unit = K.unit\n",
-    "spectrum.piv.unit = piv.unit"
+    "spectrum.piv.unit = piv.unit\n",
+    "\n",
+    "spectrum.index.delta = 0.01\n",
+    "spectrum.K.delta = 0.1"
    ]
   },
   {
@@ -415,7 +344,7 @@
    },
    "outputs": [],
    "source": [
-    "source = PointSource(\"GRB\",\n",
+    "source = PointSource(\"Crab\",\n",
     "                     l=l,\n",
     "                     b=b,\n",
     "                     spectral_shape=spectrum)\n",
@@ -485,6 +414,7 @@
     "                                          max_value=150,\n",
     "                                          delta=0.05,\n",
     "                                          )\n",
+    "\n",
     "print(f\"The average background flux is {bkg_norm:.2f} Hz\")"
    ]
   },
@@ -538,7 +468,7 @@
    },
    "outputs": [],
    "source": [
-    "# response.load_caches(data_path / \"GRB_tutorial\")"
+    "# response.load_caches(data_path / \"Crab_tutorial\")"
    ]
   },
   {
@@ -591,7 +521,7 @@
    },
    "outputs": [],
    "source": [
-    "response.save_caches(data_path / \"GRB_tutorial\")"
+    "response.save_caches(data_path / \"Crab_tutorial\")"
    ]
   },
   {
@@ -647,10 +577,10 @@
     "results = like.results\n",
     "\n",
     "parameters = {par.name: results.get_variates(par.path)\n",
-    "              for par in results.optimized_model[\"GRB\"].parameters.values()\n",
+    "              for par in results.optimized_model[\"Crab\"].parameters.values()\n",
     "              if par.free}\n",
     "\n",
-    "results_err = results.propagate(results.optimized_model[\"GRB\"].spectrum.main.shape.evaluate_at, **parameters)"
+    "results_err = results.propagate(results.optimized_model[\"Crab\"].spectrum.main.shape.evaluate_at, **parameters)"
    ]
   },
   {
@@ -701,15 +631,15 @@
    "source": [
     "fig, ax = plt.subplots(figsize = (9, 6))\n",
     "\n",
-    "ax.plot(energy, energy**2 * flux_median, label = \"Best fit\")\n",
-    "ax.fill_between(energy, energy**2 * flux_lo, energy*energy*flux_hi, alpha = .5, label = \"Best fit (errors)\")\n",
-    "ax.plot(energy, energy**2 * flux_inj, color = 'black', ls = \":\", label = \"Injected\")\n",
+    "ax.plot(energy, flux_median, label = \"Best fit\")\n",
+    "ax.fill_between(energy, flux_lo, flux_hi, alpha = .5, label = \"Best fit (errors)\")\n",
+    "ax.plot(energy, flux_inj, color = 'black', ls = \":\", label = \"Injected\")\n",
     "\n",
     "ax.semilogx()\n",
     "ax.semilogy()\n",
     "\n",
     "ax.set_xlabel(\"Energy [keV]\")\n",
-    "ax.set_ylabel(r\"$E^2 \\frac{\\mathrm{d}N}{\\mathrm{d}E}$ [keV cm$^{-2}$ s$^{-1}$]\")\n",
+    "ax.set_ylabel(r\"$\\frac{\\mathrm{d}N}{\\mathrm{d}E}$ [keV$^{-1}$ cm$^{-2}$ s$^{-1}$]\")\n",
     "\n",
     "ax.legend();"
    ]
@@ -739,7 +669,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/spectral_fits/continuum_fit/crab/example_crab_fit_normalizing_flows.ipynb
+++ b/docs/tutorials/spectral_fits/continuum_fit/crab/example_crab_fit_normalizing_flows.ipynb
@@ -152,7 +152,7 @@
    "outputs": [],
    "source": [
     "tstart = Time(\"2028-03-23 10:36:00.000\")\n",
-    "tstop = Time(\"2028-03-24 10:36:00.000\")\n",
+    "tstop = Time(\"2028-03-23 13:36:00.000\")\n",
     "sc_orientation = SpacecraftHistory.open(sc_orientation_path)\n",
     "sc_orientation = sc_orientation.select_interval(tstart, tstop)"
    ]

--- a/docs/tutorials/spectral_fits/continuum_fit/grb/example_grb_fit_normalizing_flows.ipynb
+++ b/docs/tutorials/spectral_fits/continuum_fit/grb/example_grb_fit_normalizing_flows.ipynb
@@ -60,7 +60,15 @@
     "\n",
     "### Hardware Requirements\n",
     "\n",
-    "It is highly recommended to use a GPU, preferably by NVIDIA, for the inference. A CPU, even something like an AMD Threadripper, will only allow you to analyze a few orbits in a reasonable time. Also, note that the unbinned analysis requires you to have enough RAM, which increases as the number of events you include in the analysis increases. The batch size can be decreased to limit the maximum consumption."
+    "It is highly recommended to use a GPU, preferably by NVIDIA, for the inference. A CPU, even something like an AMD Threadripper, will only allow you to analyze a few orbits in a reasonable time. Also, note that the unbinned analysis requires you to have enough RAM, which increases as the number of events you include in the analysis increases. The batch size can be decreased to limit the maximum consumption.\n",
+    "\n",
+    "### Troubleshooting\n",
+    "\n",
+    "#### Too many open files error\n",
+    "\n",
+    "You might get this error while trying to run the tutorial: `RuntimeError: unable to open shared memory object </torch_...> in read-write mode: Too many open files (...)`\n",
+    "\n",
+    "The quickest fix is to tell your OS to allow more open files. On Linux or macOS, you can check your current limit by running `ulimit -n` in your terminal. To increase it for the current session: `ulimit -n 65535`"
    ]
   },
   {


### PR DESCRIPTION
This PR adds a Crab spectral fitting tutorial, which is similar to the GRB notebook but with less documentation. I also included the GRB tutorial in the main `index.rst`, added the Crab fit to the other examples, and updated the `run_tutorials` file.