### PR TITLE
Revert binning default to sparse

### DIFF
--- a/cosipy/data_io/BinnedData.py
+++ b/cosipy/data_io/BinnedData.py
@@ -27,7 +27,7 @@ class BinnedData(UnBinnedData):
     def get_binned_data(self, unbinned_data=None, output_name=None,
                         make_binning_plots=False, show_plots=False,
                         psichi_binning="galactic", event_range=None,
-                        weights=None, sparse=None, track_overflow=None):
+                        weights=None, sparse=True, track_overflow=None):
 
         """Bin the data using histpy and mhealpy.
 
@@ -53,7 +53,7 @@ class BinnedData(UnBinnedData):
             use weight of 1
         sparse : bool, optional
             'True' for sparse binning, or
-            'False' for dense binning (default is False).
+            'False' for dense binning (default is True).
         track_overflow: bool, optional
             option to track under/overflow bin (default is False).
 


### PR DESCRIPTION
This reverts the behavior change in #570. @ashwin230998 consulted me before making the change, so this is on me.

@jdbuhler raised very good points on #586 of the potential issue of this new default. @ldigesu just saw it "in the field", clogging the automatic pipeline with a huge file.

Since it's very likely this will be an issue multiple user will encounter while going through DC4, I'm going ahead an making this change before the release.