### PR TITLE
Avoid NumPy ufunc dispatch when scaling background Histogram

### DIFF
--- a/cosipy/background_estimation/TransientBackgroundEstimation.py
+++ b/cosipy/background_estimation/TransientBackgroundEstimation.py
@@ -249,7 +249,8 @@ class TransientBackgroundEstimation:
         unit_bkg = total_bkg/(np.sum(self.bkg_durations))
 
         if scaling == "duration":
-            bkg_model = self.burst_durations[0]*unit_bkg
+            duration = float(self.burst_durations[0])
+            bkg_model = unit_bkg * duration
 
         elif scaling == "fitting":
             raise NotImplementedError(


### PR DESCRIPTION
## What is changed

Fix duration scaling in transient background modeling

The background scaling by duration previously multiplied a NumPy scalar by a `histpy.Histogram`:

    self.burst_durations[0] * unit_bkg

When the duration is a `np.float64`, this dispatches through NumPy's binary ufunc machinery and triggers `Histogram.__array_ufunc__`, which only supports single-operand NumPy functions. This raises `NotImplementedError`.

This patch reverses the multiplication order and converts the duration to a plain float:

    duration = float(self.burst_durations[0])

    bkg_model = unit_bkg * duration

so the operation is handled by histpy's Histogram arithmetic implementation.

## Original error message
```
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
Cell In[28], line 3
      1 # It only supports scaling by duratiom now.
      2 
----> 3 bkg_model = estimator.make_background_model(scaling = "duration", save_path = data_dir / "GRB_bn100612726_bkg_model.hdf5")

File ~/Applications/conda_envs/cosipy_dev/cosipy/cosipy/background_estimation/TransientBackgroundEstimation.py:252, in TransientBackgroundEstimation.make_background_model(self, scaling, save_path)
    249 unit_bkg = total_bkg/(np.sum(self.bkg_durations))
    251 if scaling == "duration":
--> 252     bkg_model = self.burst_durations[0]*unit_bkg
    254 elif scaling == "fitting":
    255     raise NotImplementedError(
    256         "The scaling by fitting the background before and after the burst \
    257         is not implemented yet!"
    258     )

File ~/Applications/conda_envs/cosipy_dev/lib/python3.12/site-packages/histpy/histogram.py:875, in Histogram.__array_ufunc__(self, ufunc, method, *inputs, **kwargs)
    872 def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
    874     if len(inputs) != 1 or inputs[0] is not self:
--> 875         raise NotImplementedError(
    876             "Only numpy functions with a single operand are supported "
    877             "e.g. np.sin(h). Call h.contents explicitly to "
    878             "get the corresponding array e.g. np.maximum(h.contents, a)")
    880     # units are *not* dropped for dense contents (but are for sparse)
    881     arr = self._with_units(self._get_contents())

NotImplementedError: Only numpy functions with a single operand are supported e.g. np.sin(h). Call h.contents explicitly to get the corresponding array e.g. np.maximum(h.contents, a)
```