### PR TITLE
Use response file polarization conventions in tutorials

### DIFF
--- a/cosipy/source_injector/source_injector.py
+++ b/cosipy/source_injector/source_injector.py
@@ -10,7 +10,8 @@ logger = logging.getLogger(__name__)
 
 class SourceInjector():
 
-    def __init__(self, response_path, response_frame="spacecraftframe", pa_convention=None):
+    def __init__(self, response_path, response_frame="spacecraftframe",
+                 pa_convention=None):
         """
         `SourceInjector` convolve response, source model(s) and
         orientation to produce a mocked simulated data. The data can
@@ -27,9 +28,8 @@ class SourceInjector():
             the CDS is in the detector frame.)
         pa_convention : str, optional
             Polarization angle convention for polarization-enabled
-            detector-frame responses. Must be one of ('RelativeX',
-            'RelativeY', 'RelativeZ') when the response includes a
-            `Pol` axis and `response_frame="spacecraftframe"`.
+            detector-frame responses that do not specify their own
+            convention.
 
         """
 
@@ -129,11 +129,11 @@ class SourceInjector():
                                 "be provided to compute the "
                                 "expected counts.")
 
-            # If the response includes a polarization axis, FullDetectorResponse requires an explicit polarization-angle convention.
-            if self.pa_convention is None:
-                response = FullDetectorResponse.open(self.response_path)
-            else:
-                response = FullDetectorResponse.open(self.response_path, pa_convention=self.pa_convention)
+            # If the response includes a polarization axis but does
+            # not specify its convention, FullDetectorResponse
+            # requires an explicit polarization-angle convention.
+            response = FullDetectorResponse.open(self.response_path,
+                                                 pa_convention=self.pa_convention)
 
             with response as response:
 

--- a/docs/tutorials/polarization/ASAD_method.ipynb
+++ b/docs/tutorials/polarization/ASAD_method.ipynb
@@ -367,7 +367,7 @@
    "source": [
     "asad_bin_edges = Angle(np.linspace(-np.pi, np.pi, 17), unit=u.rad)\n",
     "\n",
-    "grb_polarization = PolarizationASAD(source_direction, spectrum, asad_bin_edges, data, background, sc_orientation, response_file, response_convention='RelativeX', show_plots=True)"
+    "grb_polarization = PolarizationASAD(source_direction, spectrum, asad_bin_edges, data, background, sc_orientation, response_file, show_plots=True)"
    ]
   },
   {
@@ -609,7 +609,7 @@
     "attitude = sc_orientation.attitude[0]\n",
     "source_direction_local = source_direction.transform_to(SpacecraftFrame(attitude=attitude))\n",
     "\n",
-    "grb_polarization_local = PolarizationASAD(source_direction_local, spectrum, asad_bin_edges, data, background, sc_orientation, response_file, response_convention='RelativeX', show_plots=True, fit_convention=MEGAlibRelativeX(attitude=attitude))"
+    "grb_polarization_local = PolarizationASAD(source_direction_local, spectrum, asad_bin_edges, data, background, sc_orientation, response_file, show_plots=True, fit_convention=MEGAlibRelativeX(attitude=attitude))"
    ]
   },
   {

--- a/docs/tutorials/polarization/ASAD_method.ipynb
+++ b/docs/tutorials/polarization/ASAD_method.ipynb
@@ -69,7 +69,7 @@
    "outputs": [],
    "source": [
     "fetch_wasabi_file('COSI-SMEX/cosipy_tutorials/polarization_fit/grb_background.fits.gz', checksum = '21b1d75891edc6aaf1ff3fe46e91cb49')\n",
-    "fetch_wasabi_file('COSI-SMEX/DC4/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5', checksum = '46b006a6b397fd777dc561d3b028357f')\n",
+    "fetch_wasabi_file('COSI-SMEX/develop/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5', checksum = 'd417d241be0ba7fbfeaef5e2c3bd6ebc')\n",
     "fetch_wasabi_file('COSI-SMEX/DC4/Data/Orientation/DC4_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = '1b851c042acf4c909798e2401e9d2e38')"
    ]
   },

--- a/docs/tutorials/polarization/Stokes_method.ipynb
+++ b/docs/tutorials/polarization/Stokes_method.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "fetch_wasabi_file('COSI-SMEX/cosipy_tutorials/polarization_fit/grb_background.fits.gz', checksum = '21b1d75891edc6aaf1ff3fe46e91cb49')\n",
-    "fetch_wasabi_file('COSI-SMEX/DC4/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5', checksum = '46b006a6b397fd777dc561d3b028357f')\n",
+    "fetch_wasabi_file('COSI-SMEX/develop/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5', checksum = 'd417d241be0ba7fbfeaef5e2c3bd6ebc')\n",
     "fetch_wasabi_file('COSI-SMEX/DC4/Data/Orientation/DC4_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', checksum = '1b851c042acf4c909798e2401e9d2e38')"
    ]
   },

--- a/docs/tutorials/polarization/Stokes_method.ipynb
+++ b/docs/tutorials/polarization/Stokes_method.ipynb
@@ -237,7 +237,7 @@
    ],
    "source": [
     "source_photons = PolarizationStokes(source_direction, spectrum, data, response_file, sc_orientation, \n",
-    "                                    background=background, response_convention='RelativeX', show_plots=False)"
+    "                                    background=background, show_plots=False)"
    ]
   },
   {

--- a/docs/tutorials/polarization/maximum_likelihood_method.ipynb
+++ b/docs/tutorials/polarization/maximum_likelihood_method.ipynb
@@ -104,12 +104,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "A file named ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5 already exists with the specified checksum (46b006a6b397fd777dc561d3b028357f). Skipping.\n"
+      "A file named ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5 already exists with the specified checksum (d417d241be0ba7fbfeaef5e2c3bd6ebc). Skipping.\n"
      ]
     }
    ],
    "source": [
-    "fetch_wasabi_file('COSI-SMEX/DC4/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5', checksum = '46b006a6b397fd777dc561d3b028357f')"
+    "fetch_wasabi_file('COSI-SMEX/develop/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5', checksum = 'd417d241be0ba7fbfeaef5e2c3bd6ebc')"
    ]
   },
   {

--- a/docs/tutorials/polarization/maximum_likelihood_method.ipynb
+++ b/docs/tutorials/polarization/maximum_likelihood_method.ipynb
@@ -197,7 +197,7 @@
    "outputs": [],
    "source": [
     "response_file = data_path / 'ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5'\n",
-    "dr = FullDetectorResponse.open(response_file, pa_convention='RelativeX')\n",
+    "dr = FullDetectorResponse.open(response_file)\n",
     "\n",
     "sc_orientation = SpacecraftHistory.open(data_path/'DC4_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits', tstart=Time(1835493492.2, format = 'unix'), tstop=Time(1835493492.8, format = 'unix'))"
    ]

--- a/docs/tutorials/run_tutorials.yml
+++ b/docs/tutorials/run_tutorials.yml
@@ -301,8 +301,8 @@ tutorials:
           checksum: 21b1d75891edc6aaf1ff3fe46e91cb49
         COSI-SMEX/DC4/Data/Orientation/DC4_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits:
           checksum: 1b851c042acf4c909798e2401e9d2e38
-        COSI-SMEX/DC4/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5:
-          checksum: 46b006a6b397fd777dc561d3b028357f
+        COSI-SMEX/develop/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5:
+          checksum: d417d241be0ba7fbfeaef5e2c3bd6ebc
 
     polarization_ml:
       notebook:
@@ -316,8 +316,8 @@ tutorials:
           checksum: 21b1d75891edc6aaf1ff3fe46e91cb49
         COSI-SMEX/DC4/Data/Orientation/DC4_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits:
           checksum: 1b851c042acf4c909798e2401e9d2e38
-        COSI-SMEX/DC4/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5:
-          checksum: 46b006a6b397fd777dc561d3b028357f
+        COSI-SMEX/develop/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5:
+          checksum: d417d241be0ba7fbfeaef5e2c3bd6ebc
 
     polarization_stokes:
       notebook:
@@ -331,8 +331,8 @@ tutorials:
           checksum: 21b1d75891edc6aaf1ff3fe46e91cb49
         COSI-SMEX/DC4/Data/Orientation/DC4_final_530km_3_month_with_slew_1sbins_GalacticEarth_SAA.fits:
           checksum: 1b851c042acf4c909798e2401e9d2e38
-        COSI-SMEX/DC4/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5:
-          checksum: 46b006a6b397fd777dc561d3b028357f
+        COSI-SMEX/develop/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5:
+          checksum: d417d241be0ba7fbfeaef5e2c3bd6ebc
 
     galactic_diffuse_continuum:
       notebook: spectral_fits/galactic_diffuse_continuum/galdiff_continuum.ipynb

--- a/docs/tutorials/source_injector/Point_source_injector.ipynb
+++ b/docs/tutorials/source_injector/Point_source_injector.ipynb
@@ -770,7 +770,7 @@
     "response_path = data_dir/\"ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5\"\n",
     "\n",
     "# download response file ~839.62 MB\n",
-    "fetch_wasabi_file(\"COSI-SMEX/DC4/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5\", response_path)"
+    "fetch_wasabi_file(\"COSI-SMEX/develop/Data/Responses/ResponseContinuum.o3.pol.e200_10000.b4.p12.relx.s10396905069491.m420.filtered.binnedpolarization.11D.h5\", response_path)"
    ]
   },
   {

--- a/docs/tutorials/source_injector/Point_source_injector.ipynb
+++ b/docs/tutorials/source_injector/Point_source_injector.ipynb
@@ -782,8 +782,7 @@
     "# Define an injector by the response\n",
     "injector = SourceInjector(\n",
     "    response_path=response_path,\n",
-    "    response_frame=\"spacecraftframe\",\n",
-    "    pa_convention=\"RelativeX\",  # or \"RelativeY\" / \"RelativeZ\"\n",
+    "    response_frame=\"spacecraftframe\"\n",
     ")"
    ]
   },


### PR DESCRIPTION
A recent update to cosipy ( PR #518 ) added support for storing polarization conventions inside response files, which is useful for both polarization and relative binned responses.  This patch updates tutorials using the DC3/4 o3 polarization response to expect the response to contain a stored convention, rather than supplying one explicitly on the command line.

I have uploaded an updated pol response to COSI-SMEX/develop/Data/Responses, and the tutorials that need a pol response now use this one.  I also fixed the docstring for the source injector to reflect that a convention is needed only if the file doesn't have one.

Note that this is for develop *only*, since the relevant PR was merged after the 0.4 release.