### PR TITLE
Fix ResponseConverter's renaming of .rsp and .rsp/.gz files

### DIFF
--- a/cosipy/response/RspConverter.py
+++ b/cosipy/response/RspConverter.py
@@ -238,12 +238,13 @@ class RspConverter():
         if h5_filename is None:
             rsp_path = Path(rsp_filename)
 
-            # strip any .rsp and .gz from end of path and add .h5
-            h5_path = rsp_path.parent / rsp_path.stem
-            while h5_path.suffix in {".rsp", "gz"}:
+            # strip any .rsp and .gz from end of path
+            h5_path = rsp_path
+            while h5_path.suffix in {".rsp", ".gz"}:
                 h5_path = h5_path.with_suffix("")
 
-            h5_filename = h5_path.parent / (h5_path.stem + ".h5")
+            # add .h5 to end of path
+            h5_filename = str(h5_path) + ".h5"
 
         if Path(h5_filename).exists() and not overwrite:
             raise RuntimeError(f"Not overwriting existing HDF5 file {h5_filename}")


### PR DESCRIPTION
When converting an .rsp or .rsp.gz response file to HDF5, the ResponseConverter can automatically choose the HDF5 file's name if none is provided.  The intended behavior is that foo.rsp or foo.rsp.gz becomes foo.h5 .  Unfortunately, the existing name formation code was buggy.  In particular, if the base filename contains additional periods (e.g., foo.bar.rsp), part of the base could be deleted.

This patch fixes the renaming code to avoid this bad behavior.