### PR TITLE
Fix EventSelectorInterface._select indentation.

### DIFF
--- a/cosipy/interfaces/event_selection.py
+++ b/cosipy/interfaces/event_selection.py
@@ -43,10 +43,10 @@ class EventSelectorInterface(Protocol):
         else:
             return self._select(events, early_stop)
 
-        def _select(self, events:EventDataInterface,
-                    early_stop:bool = True) -> Iterable[bool]:
-            """
-            This allows implementation to only define the behaviour for list,
-            and let the above function handle the case of single event.
+    def _select(self, events:EventDataInterface,
+                early_stop:bool = True) -> Iterable[bool]:
+        """
+        This allows implementation to only define the behaviour for list,
+        and let the above function handle the case of single event.
 
-            """
+        """


### PR DESCRIPTION
_select is meant to be part of the interface definition, but it had the wrong indentation.

It was a hidden problem because the existing implementation had their own _select. This piece of code as simply unreachable. 