### PR TITLE
Code cleanups and minor performance improvements

### DIFF
--- a/cosipy/polarization/conventions.py
+++ b/cosipy/polarization/conventions.py
@@ -242,14 +242,18 @@ class MEGAlibRelative(ConventionInSpacecraftFrameMixin, OrthographicConvention):
 
         axis = axis.lower()
 
-        if axis == 'x':
-            ref_vector = np.asarray([1,0,0])
-        elif axis == 'y':
-            ref_vector = np.asarray([0,1,0])
-        elif axis == 'z':
-            ref_vector = np.asarray([0,0,1])
-        else:
-            raise ValueError("Axis must be 'x', 'y' or 'z'.")
+        match axis:
+            case 'x':
+                ref_vector = np.asarray([1,0,0])
+
+            case 'y':
+                ref_vector = np.asarray([0,1,0])
+
+            case 'z':
+                ref_vector = np.asarray([0,0,1])
+
+            case _:
+                raise ValueError("Axis must be 'x', 'y' or 'z'.")
 
         frame = SpacecraftFrame(attitude = attitude)
 
@@ -257,12 +261,12 @@ class MEGAlibRelative(ConventionInSpacecraftFrameMixin, OrthographicConvention):
 
     def get_basis_local(self, source_vector: np.ndarray):
 
-        # The MEGAlib and orthographic definitions are prett much the same, but
-        # they differ on the order of the cross products
+        # The MEGAlib and orthographic definitions are pretty much the
+        # same, but they differ on the order of the cross products
 
         # In MEGAlib definition
         # pz = -source_direction = particle_direction
-        # px = particle_direction x ref_vector  = pz x ref_vector
+        # px = particle_direction x ref_vector = pz x ref_vector
         # py = pz x px
 
         # In the base orthographic definition

--- a/cosipy/polarization/polarization_angle.py
+++ b/cosipy/polarization/polarization_angle.py
@@ -72,7 +72,7 @@ class PolarizationAngle:
         Direction of the electric field vector
         """
 
-        if self.source is None:
+        if self._source is None:
             raise RuntimeError("Set source first")
 
         # Get the projection vectors for the source direction in the
@@ -101,7 +101,7 @@ class PolarizationAngle:
 
     def transform_to(self, convention):
 
-        if self.source is None:
+        if self._source is None:
             raise RuntimeError("Set source first")
 
         # Standardize convention

--- a/cosipy/polarization/polarization_angle.py
+++ b/cosipy/polarization/polarization_angle.py
@@ -3,13 +3,16 @@ from astropy.coordinates import SkyCoord, Angle
 import astropy.units as u
 from scoords import SpacecraftFrame
 
-from .conventions import PolarizationConvention
+from .conventions import (
+    PolarizationConvention,
+    IAUPolarizationConvention,
+)
 
 class PolarizationAngle:
 
     def __init__(self, angle,
                  source: SkyCoord = None,
-                 convention = 'iau'):
+                 convention = IAUPolarizationConvention()):
         """
         Defines a polarization angle in the context of a source direction and
         polarization angle convention.

--- a/cosipy/polarization/polarization_axis.py
+++ b/cosipy/polarization/polarization_axis.py
@@ -1,11 +1,14 @@
 import numpy as np
-from .conventions import PolarizationConvention
-from astropy import units as u
 
-from .polarization_angle import PolarizationAngle
+from astropy import units as u
 
 from histpy import Axis
 
+from .polarization_angle import PolarizationAngle
+from .conventions import (
+    PolarizationConvention,
+    IAUPolarizationConvention,
+)
 
 class PolarizationAxis(Axis):
     """
@@ -28,7 +31,7 @@ class PolarizationAxis(Axis):
 
     def __init__(self,
                  edges,
-                 convention = 'iau',
+                 convention = IAUPolarizationConvention(),
                  label = None,
                  unit = None,
                  copy = True):

--- a/cosipy/response/FullDetectorResponse.py
+++ b/cosipy/response/FullDetectorResponse.py
@@ -596,7 +596,7 @@ class FullDetectorResponse(HealpixBase):
             if isinstance(source.frame, SpacecraftFrame):
                 raise ValueError("scatt_map is not supported for source in local coordinate frame")
 
-            has_pol = ('Pol' in self._axes.labels and source.frame != 'spacecraftframe')
+            has_pol = ('Pol' in self._axes.labels)
 
             if source.ndim > 0:
                 source = source[0]

--- a/cosipy/response/RspConverter.py
+++ b/cosipy/response/RspConverter.py
@@ -481,7 +481,8 @@ class RspConverter():
                 axes.append(PolarizationAxis(edges=axis_edges,
                                              unit=axis_unit,
                                              convention=hdr["pa_convention"],
-                                             label=axis_label))
+                                             label=axis_label,
+                                             copy=False))
 
             else:
                 scale = RspConverter.axis_scale[axis_label]

--- a/cosipy/response/instrument_response.py
+++ b/cosipy/response/instrument_response.py
@@ -139,9 +139,9 @@ class BinnedInstrumentResponse(BinnedInstrumentResponseInterface):
                 raise RuntimeError(
                     "Currently, the probed polarization angles need to match the underlying response matrix Pol centers.")
 
-        # Get the pixel as is since we already checked that the requested
-        # energy and polarization points match the underlying response centers
-        # Matches the v0.3 behaviour
+        # Get the pixel as is since we already checked that the
+        # requested energy and polarization points match the
+        # underlying response centers. Matches the v0.3 behaviour
         pix = self._dr.ang2pix(direction)
 
         # TODO: Update after Pr364. get_pixel(pix, weight) should make
@@ -215,7 +215,7 @@ class BinnedInstrumentResponse(BinnedInstrumentResponseInterface):
 
         """
 
-        # Generate axes that will allow us to use _sum_rot_hist,
+        # Generate axes that will allow us to use _rot_psr,
         # and obtain the same results as in v3.x
         out_axes = [self._dr.axes['Ei']]
 
@@ -226,16 +226,18 @@ class BinnedInstrumentResponse(BinnedInstrumentResponseInterface):
             # Since we're doing a 0-th order interpolation, the only
             # thing that matter are the bin centers, so we're placing
             # them at the input polarization angles
+            center_angles = polarization.centers.angle.to_value(u.deg)
 
-            if np.any(polarization.centers.angle.value[1:] - polarization.centers.angle.value[:-1] < 0):
+            if np.any(np.diff(center_angles) < 0):
                 raise ValueError("This implementation requires strictly monotonically increasing polarization angles")
 
-            pol_edges = (polarization.centers.angle[:-1] + polarization.centers.angle[1:]).to_value(u.deg)/2
+            pol_edges = 0.5*(center_angles[:-1] + center_angles[1:])
 
-            pol_edges = np.concatenate((np.array([pol_edges[0] - 2*(pol_edges[0] - polarization.centers.angle.to_value(u.deg)[0])]), pol_edges))
-            pol_edges = np.concatenate((pol_edges, np.array([pol_edges[-1] + 2 * (polarization.centers.angle.to_value(u.deg)[-1] - pol_edges[-1])])))
+            pol_edges = np.r_[ pol_edges[0]  - 2 * (pol_edges[0] - center_angles[0]),
+                               pol_edges,
+                               pol_edges[-1] + 2 * (center_angles[-1] - pol_edges[-1]) ]
 
-            out_axes += [PolarizationAxis(pol_edges*u.deg, convention = polarization.convention)]
+            out_axes.append( PolarizationAxis(pol_edges, unit=u.deg, convention = polarization.convention, copy=False) )
 
         out_axes += list(axes)
         out_axes = Axes(out_axes)
@@ -282,10 +284,9 @@ class BinnedInstrumentResponse(BinnedInstrumentResponseInterface):
 
         # Either initialize a new or clear cache
         if out is None:
-            out = Quantity(np.zeros(out_axes.shape), dr_pix.unit)
-        else:
-            if not add_inplace:
-                out[:] = 0
+            out = Quantity(np.zeros(out_axes.shape), dr_pix.unit, copy = None)
+        elif not add_inplace:
+            out.value[:] = 0
 
         if isinstance(weight, Quantity):
             weight_unit = weight.unit
@@ -294,8 +295,8 @@ class BinnedInstrumentResponse(BinnedInstrumentResponseInterface):
             weight_unit = None
 
         out.value[:] += self._dr._rot_psr(out_axes, weight,
-                                  loc_psichi_pixels,
-                                  (loc_src_pixels,))
+                                          loc_psichi_pixels,
+                                          (loc_src_pixels,))
 
         if weight_unit is not None:
             out = Quantity(out.value, weight_unit*out.unit, copy = None)

--- a/cosipy/response/rsp_to_arf_rmf.py
+++ b/cosipy/response/rsp_to_arf_rmf.py
@@ -374,7 +374,7 @@ class RspArfRmfConverter:
         Parameters
         ----------
         ax: Optional(matpltlib.axes)
-            Matplotlib axes to use for plotting. We'll create new one if not privided.
+            Matplotlib axes to use for plotting. We'll create new one if not provided.
         file_name: str, optional
             The directory if the arf fits file (the default is `None`,
             which implies the file name will be read from the
@@ -419,7 +419,7 @@ class RspArfRmfConverter:
 
         return  ax
 
-    def plot_rmf(self, ax = None,  file_name=None):
+    def plot_rmf(self, ax = None, file_name=None):
 
         """Read the rmf fits file, plot and save it.
 

--- a/cosipy/source_injector/source_injector.py
+++ b/cosipy/source_injector/source_injector.py
@@ -1,10 +1,14 @@
 import numpy as np
+
+import matplotlib.pyplot as plt
+
 from cosipy.response import (
     GalacticResponse,
     FullDetectorResponse,
     PointSourceResponse,
     ExtendedSourceResponse
 )
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -184,11 +188,17 @@ class SourceInjector():
             ax.set_xlabel("Em [keV]", fontsize=14, fontweight="bold")
             ax.set_ylabel("Counts", fontsize=14, fontweight="bold")
 
+            plt.show()
+            plt.close()
+
         if make_PsiChi_plot:
             plot, ax = injected.project('PsiChi').plot(coord='G',
                                                        ax_kw={'coord': 'G'})
             ax.get_figure().set_figwidth(4)
             ax.get_figure().set_figheight(3)
+
+            plt.show()
+            plt.close()
 
         if data_save_path is not None:
             injected.write(data_save_path)
@@ -272,7 +282,7 @@ class SourceInjector():
             ax.set_ylabel("Counts", fontsize=14, fontweight="bold")
 
         if make_PsiChi_plot:
-            plot, ax = injected.project('PsiChi').plot(coord='G',
+            ax, plot = injected.project('PsiChi').plot(coord='G',
                                                        ax_kw={'coord': 'G'})
             ax.get_figure().set_figwidth(4)
             ax.get_figure().set_figheight(3)
@@ -406,10 +416,16 @@ class SourceInjector():
             ax.set_xlabel("Em [keV]", fontsize=14, fontweight="bold")
             ax.set_ylabel("Counts", fontsize=14, fontweight="bold")
 
+            plt.show()
+            plt.close()
+
         if make_PsiChi_plot:
             plot, ax = injected_all.project('PsiChi').plot(coord='G',
                                                            ax_kw={'coord': 'G'})
             ax.get_figure().set_figwidth(4)
             ax.get_figure().set_figheight(3)
+
+            plt.show()
+            plt.close()
 
         return injected_all

--- a/cosipy/ts_map/fast_ts_fit.py
+++ b/cosipy/ts_map/fast_ts_fit.py
@@ -48,6 +48,10 @@ class FastTSMap():
             "local" (frame attached to spacecraft) or "galactic".
             Default is local.
 
+        Note: the floating-point precision used for mapping is determined
+        by the precision of the 'data' argument.  Use single precision
+        if desired for faster performance.
+
         """
 
         match cds_frame:

--- a/cosipy/ts_map/fast_ts_fit.py
+++ b/cosipy/ts_map/fast_ts_fit.py
@@ -59,6 +59,8 @@ class FastTSMap():
                 raise TypeError(f"Unrecognized frame {cds_frame}, "
                                 "must be 'local' or 'galactic'")
 
+        # open response with same dtype (in particular, same FP
+        # precision) as data
         if self._cds_frame == Frame.LOCAL:
             if orientation is None:
                 raise TypeError("When data are binned in local frame, "
@@ -66,10 +68,12 @@ class FastTSMap():
 
             self._orientation = orientation
 
-            self._response = FullDetectorResponse.open(response_path)
+            self._response = FullDetectorResponse.open(response_path,
+                                                       dtype=data.dtype)
         else:
 
-            self._response = GalacticResponse.open(response_path)
+            self._response = GalacticResponse.open(response_path,
+                                                   dtype=data.dtype)
 
         labels = self._response.axes.labels
 
@@ -88,8 +92,9 @@ class FastTSMap():
             raise ValueError("Response CDS axes must be Em/Phi/PsiChi")
 
         # make sure data and background CDS are ordered to match response
-        self._data = data.to_dense(copy=False).project(cds_order)
-        self._bkg_model = bkg_model.to_dense(copy=False).project(cds_order)
+        # and share its dtype
+        self._data = data.to_dense(copy=False).project(cds_order).astype(self._response.dtype)
+        self._bkg_model = bkg_model.to_dense(copy=False).project(cds_order).astype(self._response.dtype)
 
         self._fnf = fnf(max_iter=1000)
 
@@ -478,7 +483,7 @@ class PSRCache:
         self.em_slice = em_slice
         self.valid_cells = valid_cells
 
-        self.ei_weights = flux.contents.value * response.eff_area_correction
+        self.ei_weights = flux.contents.value.astype(response.dtype) * response.eff_area_correction
 
         #self.nLookups = 0
         #self.nMisses = 0

--- a/tests/event_selection/test_time_selector.py
+++ b/tests/event_selection/test_time_selector.py
@@ -1,9 +1,11 @@
 from typing import Iterable
+import warnings
 
 import numpy as np
 import pytest
 from astropy.time import Time
 from astropy.utils.metadata.utils import dtype
+from erfa import ErfaWarning
 
 from cosipy.event_selection import GoodTimeInterval
 from cosipy.event_selection.time_selection import TimeSelector
@@ -11,7 +13,7 @@ from cosipy.interfaces import TimeTagEventInterface, TimeTagEventDataInterface
 from cosipy.util.iterables import asarray
 
 # Dummy events
-times = Time(60000 + np.arange(0,15), format = 'jd')
+times = Time(60000. + np.arange(0,15), format = 'jd')
 
 class DummyTimeTagEventData(TimeTagEventDataInterface):
 
@@ -47,6 +49,8 @@ events = DummyTimeTagEventData()
 events_iter = DummyTimeTagEventDataIterable()
 
 def test_time_selector():
+
+    warnings.filterwarnings("ignore", category=ErfaWarning)
 
     tstart = Time(60000. + np.asarray([0, 5]), format='jd')
     tstop = Time(60000. + np.asarray([1, 10]), format='jd')
@@ -140,6 +144,3 @@ def test_time_selector():
 
     with pytest.raises(ValueError):
         TimeSelector(tstart, None)
-
-
-

--- a/tests/source_injector/test_source_injector.py
+++ b/tests/source_injector/test_source_injector.py
@@ -37,7 +37,9 @@ def test_inject_point_source():
     # Get the data of the injected source
     injected_crab_signal = injector.inject_point_source(spectrum = spectrum, coordinate = source_coord,
                                                         orientation = ori, source_name = "point_source",
-                                                        make_spectrum_plot = False, make_PsiChi_plot = False ,data_save_path = None,
+                                                        make_spectrum_plot = True,
+                                                        make_PsiChi_plot = True,
+                                                        data_save_path = None,
                                                         project_axes = None)
 
     results = injected_crab_signal.project("Em").contents
@@ -75,7 +77,9 @@ def test_inject_point_source_galactic():
     # Get the data of the injected source
     injected_crab_signal = injector.inject_point_source(spectrum = spectrum, coordinate = source_coord,
                                                         source_name = "point_source",
-                                                        make_spectrum_plot = True, make_PsiChi_plot=True , data_save_path = None,
+                                                        make_spectrum_plot = True,
+                                                        make_PsiChi_plot=True,
+                                                        data_save_path = None,
                                                         project_axes = None)
 
     results = injected_crab_signal.project("Em").contents
@@ -113,7 +117,9 @@ def test_inject_point_source_saving():
     # Get the data of the injected source
     injected_crab_signal = injector.inject_point_source(spectrum = spectrum, coordinate = source_coord,
                                                         source_name = "point_source",
-                                                        make_spectrum_plot = False, make_PsiChi_plot=False ,data_save_path = Path("./galactic_rsp.h5"),
+                                                        make_spectrum_plot = True,
+                                                        make_PsiChi_plot = False,
+                                                        data_save_path = Path("./galactic_rsp.h5"),
                                                         project_axes = "Em")
 
     hist= Histogram.open(Path("./galactic_rsp.h5"))
@@ -162,7 +168,9 @@ def test_orientation_error():
         # Get the data of the injected source
         injected_crab_signal = injector.inject_point_source(spectrum = spectrum, coordinate = source_coord,
                                                             source_name = "point_source",
-                                                            make_spectrum_plot = False, make_PsiChi_plot=False ,data_save_path = None,
+                                                            make_spectrum_plot = True,
+                                                            make_PsiChi_plot = True,
+                                                            data_save_path = None,
                                                             project_axes = None)
 
 
@@ -243,8 +251,8 @@ def test_inject_extended_source_saving():
     # Get the data of the injected source
     injected = injector.inject_extended_source(
         source_model=model,
-        make_spectrum_plot=False,
-        make_PsiChi_plot=False,
+        make_spectrum_plot=True,
+        make_PsiChi_plot=True,
         data_save_path=file_path,
         project_axes=None,
     )

--- a/tests/source_injector/test_source_injector.py
+++ b/tests/source_injector/test_source_injector.py
@@ -341,6 +341,8 @@ def test_inject_model():
 
     # Get the data of the injected source
     injected = injector.inject_model(model,
+                                     make_spectrum_plot=True,
+                                     make_PsiChi_plot=True,
                                      data_save_path=file_path)
 
     hist = Histogram.open(file_path)

--- a/tests/spacecraftfile/test_arf_rmf_converter.py
+++ b/tests/spacecraftfile/test_arf_rmf_converter.py
@@ -6,6 +6,8 @@ import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 
+import matplotlib.pyplot as plt
+
 from cosipy import test_data, SpacecraftHistory
 from cosipy.response import FullDetectorResponse
 from cosipy.response import RspArfRmfConverter
@@ -183,6 +185,8 @@ def test_plot_arf(tmp_path):
     converter = RspArfRmfConverter(response, ori, target_coord)
 
     converter.plot_arf()
+    plt.show()
+    plt.close()
 
 def test_plot_rmf(tmp_path):
     response_path = test_data.path / "test_full_detector_response.h5"
@@ -194,3 +198,5 @@ def test_plot_rmf(tmp_path):
     converter = RspArfRmfConverter(response, ori, target_coord)
 
     converter.plot_rmf()
+    plt.show()
+    plt.close()

--- a/tests/ts_map/test_fast_ts_map.py
+++ b/tests/ts_map/test_fast_ts_map.py
@@ -207,8 +207,6 @@ def test_moc_ts_fit():
                         strategy=MOCTSMap.ContainmentStrategy(0.9))
 
     ts_values, pixels = ts_results
-    print(pixels)
-    print(ts_values)
 
     assert all(pixels == [
         16, 20, 24, 28, 32,


### PR DESCRIPTION
This patch collects numerous small changes I made while working on other things.  Aside from some comment cleanups, the changes include

 * allow ts_map code to use the FP type of the data for all operations, rather than defaulting to 64-bit; using single-precision can be a significant (on the order of a couple of seconds) performance win
  * take advantage of PolarizationAxis's copy=False argument
  * remove no-op test in FullDetectorResponse.get_point_source_response()
 * don't require string->PolarizationConvention mapping through default function arguments
 * simplify Axes construction in  instrument_response.py
 * force some plotting code to close its figure on completion, to avoid test-case warnings about too many open figures
 * suppress ERFA warnings from time_selector tests