### PR TITLE
Implement the Earth Horizon cut 

### DIFF
--- a/cosipy/data_io/EmCDSUnbinnedData.py
+++ b/cosipy/data_io/EmCDSUnbinnedData.py
@@ -1,20 +1,30 @@
 from pathlib import Path
-from typing import Iterable, Iterator, Optional, Tuple, Union, List
+from typing import Iterable, Iterator, Optional, Union, List
 
 import numpy as np
-from astropy.coordinates import BaseCoordinateFrame, Angle, SkyCoord, UnitSphericalRepresentation
+from astropy.coordinates import Angle, SkyCoord, UnitSphericalRepresentation
 from astropy.time import Time
 from astropy.units import Quantity
-from numpy._typing import ArrayLike
 from scoords import SpacecraftFrame
 
 from cosipy.data_io.UnBinnedData import UnBinnedData
-from cosipy.interfaces import EventWithEnergyInterface, EventDataInterface, EventDataWithEnergyInterface
-from cosipy.interfaces.data_interface import TimeTagEmCDSEventDataInSCFrameInterface, EmCDSEventDataInSCFrameInterface, \
-    TimeTagEmCDSEventDataInSCAndGalFrameInterface, EmCDSEventDataInSCAndGalFrameInterface
-from cosipy.interfaces.event import  TimeTagEmCDSEventInSCFrameInterface, \
-    EmCDSEventInSCFrameInterface , TimeTagEmCDSEventInSCAndGalFrameInterface, EmCDSEventInSCAndGalFrameInterface
-
+from cosipy.interfaces import (
+    EventWithEnergyInterface, 
+    EventDataInterface, 
+    EventDataWithEnergyInterface
+)
+from cosipy.interfaces.data_interface import (
+    TimeTagEmCDSEventDataInSCFrameInterface, 
+    EmCDSEventDataInSCFrameInterface, 
+    TimeTagEmCDSEventDataInSCAndGalFrameInterface, 
+    EmCDSEventDataInSCAndGalFrameInterface
+)
+from cosipy.interfaces.event import  (
+    TimeTagEmCDSEventInSCFrameInterface, 
+    EmCDSEventInSCFrameInterface , 
+    TimeTagEmCDSEventInSCAndGalFrameInterface, 
+    EmCDSEventInSCAndGalFrameInterface
+)
 import astropy.units as u
 
 from cosipy.interfaces.event_selection import EventSelectorInterface

--- a/cosipy/data_io/EmCDSUnbinnedData.py
+++ b/cosipy/data_io/EmCDSUnbinnedData.py
@@ -704,8 +704,9 @@ class TimeTagEmCDSEventDataInSCFrameFromDC3Fits(TimeTagEmCDSEventDataInSCFrameFr
             data_path = [Path(data_path)]
 
         for file in data_path:
-            # get_dict_from_fits is really a static method, no config file needed
-            data_dict = UnBinnedData.get_dict_from_fits(None, str(file))
+            # get_dict is really a static method, no config file needed
+            # You can pass either hdf5 or fits file
+            data_dict = UnBinnedData.get_dict(None, str(file))
 
             time = np.append(time, data_dict['TimeTags'])
             energy = np.append(energy, data_dict['Energies'])
@@ -746,8 +747,9 @@ class TimeTagEmCDSEventDataInSCAndGalFrameFromDC3Fits(TimeTagEmCDSEventDataInSCA
             data_path = [Path(data_path)]
 
         for file in data_path:
-            # get_dict_from_fits is really a static method, no config file needed
-            data_dict = UnBinnedData.get_dict_from_fits(None, str(file))
+            # get_dict is really a static method, no config file needed
+            # You can pass either hdf5 or fits file
+            data_dict = UnBinnedData.get_dict(None, str(file))
 
             time = np.append(time, data_dict['TimeTags'])
             energy = np.append(energy, data_dict['Energies'])

--- a/cosipy/data_io/EmCDSUnbinnedData.py
+++ b/cosipy/data_io/EmCDSUnbinnedData.py
@@ -704,9 +704,14 @@ class TimeTagEmCDSEventDataInSCFrameFromDC3Fits(TimeTagEmCDSEventDataInSCFrameFr
             data_path = [Path(data_path)]
 
         for file in data_path:
-            # get_dict is really a static method, no config file needed
+            # get_dict_fits or hdf5 is really a static method, no config file needed
             # You can pass either hdf5 or fits file
-            data_dict = UnBinnedData.get_dict(None, str(file))
+            if "hdf5" in str(file).split("."):
+                data_dict = UnBinnedData.get_dict_from_hdf5(None, str(file))
+            elif "fits" in str(file).split("."):
+                data_dict = UnBinnedData.get_dict_from_fits(None, str(file))
+            else:
+                raise ValueError("You should pass a fits or hdf5 file.")
 
             time = np.append(time, data_dict['TimeTags'])
             energy = np.append(energy, data_dict['Energies'])
@@ -747,10 +752,15 @@ class TimeTagEmCDSEventDataInSCAndGalFrameFromDC3Fits(TimeTagEmCDSEventDataInSCA
             data_path = [Path(data_path)]
 
         for file in data_path:
-            # get_dict is really a static method, no config file needed
+            # get_dict_fits or hdf5 is really a static method, no config file needed
             # You can pass either hdf5 or fits file
-            data_dict = UnBinnedData.get_dict(None, str(file))
-
+            if "hdf5" in str(file).split("."):
+                data_dict = UnBinnedData.get_dict_from_hdf5(None, str(file))
+            elif "fits" in str(file).split("."):
+                data_dict = UnBinnedData.get_dict_from_fits(None, str(file))
+            else:
+                raise ValueError("You should pass a fits or hdf5 file.")
+            
             time = np.append(time, data_dict['TimeTags'])
             energy = np.append(energy, data_dict['Energies'])
             phi = np.append(phi, data_dict['Phi'])

--- a/cosipy/data_io/EmCDSUnbinnedData.py
+++ b/cosipy/data_io/EmCDSUnbinnedData.py
@@ -1,24 +1,21 @@
 from pathlib import Path
-from typing import Iterable, Iterator, Optional, Union, List
+from typing import Iterable, Iterator, Optional, Tuple, Union, List
 
 import numpy as np
-
-from astropy.coordinates import Angle, SkyCoord, UnitSphericalRepresentation
+from astropy.coordinates import BaseCoordinateFrame, Angle, SkyCoord, UnitSphericalRepresentation
 from astropy.time import Time
 from astropy.units import Quantity
-import astropy.units as u
-
+from numpy._typing import ArrayLike
 from scoords import SpacecraftFrame
 
 from cosipy.data_io.UnBinnedData import UnBinnedData
-from cosipy.interfaces.data_interface import (
-    TimeTagEmCDSEventDataInSCFrameInterface,
-    EmCDSEventDataInSCFrameInterface
-)
-from cosipy.interfaces.event import (
-    TimeTagEmCDSEventInSCFrameInterface,
-    EmCDSEventInSCFrameInterface
-)
+from cosipy.interfaces import EventWithEnergyInterface, EventDataInterface, EventDataWithEnergyInterface
+from cosipy.interfaces.data_interface import TimeTagEmCDSEventDataInSCFrameInterface, EmCDSEventDataInSCFrameInterface, \
+    TimeTagEmCDSEventDataInSCAndGalFrameInterface, EmCDSEventDataInSCAndGalFrameInterface
+from cosipy.interfaces.event import  TimeTagEmCDSEventInSCFrameInterface, \
+    EmCDSEventInSCFrameInterface , TimeTagEmCDSEventInSCAndGalFrameInterface, EmCDSEventInSCAndGalFrameInterface
+
+import astropy.units as u
 
 from cosipy.interfaces.event_selection import EventSelectorInterface
 from cosipy.util.iterables import asarray
@@ -69,6 +66,64 @@ class EmCDSEventInSCFrame(EmCDSEventInSCFrameInterface):
     def scattered_lat_rad_sc(self) -> float:
         return self._scatt_lat
 
+
+class EmCDSEventInSCAndGalFrame(EmCDSEventInSCAndGalFrameInterface):
+
+
+    def __init__(self, energy, scatt_angle, scatt_lon_sc, scatt_lat_sc, 
+                 scatt_lon_gal, scatt_lat_gal, event_id = None):
+        """
+        Parameters
+        ----------
+        jd1: julian days
+        jd2: julian days
+        energy: keV
+        scatt_angle: scattering angle radians
+        scatt_lon_sc: scattering longitude radians (SC frame)
+        scatt_lat_sc: scattering latitude radians (SC frame)
+        scatt_lon_gal: scattering longitude radians (Gal frame)
+        scatt_lat_gal: scattering latitude radians (Gal frame)
+        """
+        self._id = event_id
+        self._energy = energy
+        self._scatt_angle = scatt_angle
+        self._scatt_lat_sc = scatt_lat_sc
+        self._scatt_lon_sc = scatt_lon_sc
+        self._scatt_lat_gal = scatt_lat_gal
+        self._scatt_lon_gal = scatt_lon_gal
+
+    @property
+    def id(self) -> int:
+        return self._id
+
+    @property
+    def frame(self):
+        return self._frame
+
+    @property
+    def energy_keV(self) -> float:
+        return self._energy
+
+    @property
+    def scattering_angle_rad(self) -> float:
+        return self._scatt_angle
+
+    @property
+    def scattered_lon_rad_sc(self) -> float:
+        return self._scatt_lon_sc
+
+    @property
+    def scattered_lat_rad_sc(self) -> float:
+        return self._scatt_lat_sc
+
+    @property
+    def scattered_lon_deg_gal(self) -> float:
+        return self._scatt_lon_gal
+
+    @property
+    def scattered_lat_deg_gal(self) -> float:
+        return self._scatt_lat_gal
+        
 class TimeTagEmCDSEventInSCFrame(EmCDSEventInSCFrame, TimeTagEmCDSEventInSCFrameInterface):
 
     def __init__(self, jd1, jd2, energy, scatt_angle, scatt_lon, scatt_lat, event_id=None):
@@ -95,6 +150,37 @@ class TimeTagEmCDSEventInSCFrame(EmCDSEventInSCFrame, TimeTagEmCDSEventInSCFrame
     def jd2(self):
         return self._jd2
 
+class TimeTagEmCDSEventInSCAndGalFrame(EmCDSEventInSCAndGalFrame, TimeTagEmCDSEventInSCAndGalFrameInterface):
+
+    def __init__(self, jd1, jd2, energy, scatt_angle, scatt_lon_sc, scatt_lat_sc, scatt_lon_gal, scatt_lat_gal, event_id=None):
+        """
+        Parameters
+        ----------
+        jd1: julian days
+        jd2: julian days
+        energy: keV
+        scatt_angle: scattering angle radians
+        scatt_lon_sc: scattering longitude radians (SC frame)
+        scatt_lat_sc: scattering latitude radians (SC frame)
+        scatt_lon_gal: scattering longitude deg (Gal frame)
+        scatt_lat_gal: scattering latitude deg (Gal frame)
+        """
+        super().__init__(energy, scatt_angle, scatt_lon_sc, scatt_lat_sc, scatt_lon_gal, scatt_lat_gal, event_id)
+
+        self._jd1 = jd1
+        self._jd2 = jd2
+
+    @property
+    def jd1(self):
+        return self._jd1
+
+    @property
+    def jd2(self):
+        return self._jd2
+
+
+
+        
 class EmCDSEventDataInSCFrameFromArrays(EmCDSEventDataInSCFrameInterface):
 
     _frame = SpacecraftFrame()
@@ -108,20 +194,16 @@ class EmCDSEventDataInSCFrameFromArrays(EmCDSEventDataInSCFrameInterface):
                    event_id: Optional[np.ndarray[int]] = None,
                    selection: Optional[EventSelectorInterface] = None):
         """
-        Initialize from bare numpy arrays. The user is responsible from
-        getting the right units, coordinates and formats
+        Initialize from bare numpy arrays. The user is responsible from getting the right units, coordinates and formats
 
         Parameters
         ----------
         energy_keV: energy [keV]
-        scattered_lon_rad_sc: Longitude of the direction of the
-          scattered photon in spacecraft coordinates [radian]
-        scattered_lat_rad_sc: Latitude of the direction of the
-          scattered photon in spacecraft coordinates [radian]
+        scattered_lon_rad_sc: Longitude of the direction of the scattered photon in spacecraft coordinates [radian]
+        scattered_lat_rad_sc:  Latitude of the direction of the scattered photon in spacecraft coordinates [radian]
         scatt_angle_rad: Compton scattering angle [radians]
         event_id: Event ID. Optional. Sequential is not provided
         selection: Optional. Apply an event selection.
-
         """
 
         # Check size
@@ -157,8 +239,7 @@ class EmCDSEventDataInSCFrameFromArrays(EmCDSEventDataInSCFrameInterface):
                  event_id:Optional[Iterable[int]] = None,
                  selection:Optional[EventSelectorInterface] = None):
         """
-        Initialize from astropy objects, taking into account the units and
-        formats
+        Initialize from astropy objects, taking into account the units and formats
 
         Parameters
         ----------
@@ -167,7 +248,6 @@ class EmCDSEventDataInSCFrameFromArrays(EmCDSEventDataInSCFrameInterface):
         scattered_direction
         event_id
         selection
-
         """
 
         energy = energy.to_value(u.keV)
@@ -223,6 +303,152 @@ class EmCDSEventDataInSCFrameFromArrays(EmCDSEventDataInSCFrameInterface):
     def scattered_lat_rad_sc(self) -> Iterable[float]:
         return self._scatt_lat
 
+
+class EmCDSEventDataInSCAndGalFrameFromArrays(EmCDSEventDataInSCAndGalFrameInterface):
+
+    _frame = "SpacecraftAndGalacticFrame"
+    event_type = EmCDSEventInSCAndGalFrameInterface
+
+    def __init__(self,
+                   energy_keV: np.ndarray[float],
+                   scattered_lon_rad_sc:  np.ndarray[float],
+                   scattered_lat_rad_sc: np.ndarray[float],
+                   scattered_lon_deg_gal:  np.ndarray[float],
+                   scattered_lat_deg_gal: np.ndarray[float],
+                   scatt_angle_rad: np.ndarray[float],
+                   event_id: Optional[np.ndarray[int]] = None,
+                   selection: Optional[EventSelectorInterface] = None):
+        """
+        Initialize from bare numpy arrays. The user is responsible from getting the right units, coordinates and formats
+
+        Parameters
+        ----------
+        energy_keV: energy [keV]
+        scattered_lon_rad_sc: Longitude of the direction of the scattered photon in spacecraft coordinates [radian]
+        scattered_lat_rad_sc:  Latitude of the direction of the scattered photon in spacecraft coordinates [radian]
+        scattered_lon_deg_gal: Longitude of the direction of the scattered photon in galactic coordinates [deg]
+        scattered_lat_deg_gal:  Latitude of the direction of the scattered photon in galactic coordinates [deg]
+        scatt_angle_rad: Compton scattering angle [radians]
+        event_id: Event ID. Optional. Sequential is not provided
+        selection: Optional. Apply an event selection.
+        """
+
+        # Check size
+        self._energy, self._scatt_angle, self._scatt_lon_sc, self._scatt_lat_sc, self._scatt_lon_gal, self._scatt_lat_gal = np.broadcast_arrays(energy_keV, scatt_angle_rad, scattered_lon_rad_sc, scattered_lat_rad_sc, scattered_lon_deg_gal, scattered_lat_deg_gal)
+
+        if event_id is None:
+            self._id = np.arange(self._energy.size)
+        else:
+            self._id = np.asarray(event_id)
+
+        self._nevents = self._id.size
+
+        if selection is not None:
+            mask = asarray(selection.select(self), dtype=bool)
+
+            if mask.size < self._nevents:
+                # The rest of the events are False implicitly
+                mask = np.append(mask, np.full(self._nevents - mask.size, False))
+
+            self._id = self._id[mask]
+            self._energy = self._energy[mask]
+            self._scatt_angle = self._scatt_angle[mask]
+            self._scatt_lat_sc = self._scatt_lat_sc[mask]
+            self._scatt_lon_sc = self._scatt_lon_sc[mask]
+            self._scatt_lat_gal = self._scatt_lat_gal[mask]
+            self._scatt_lon_gal = self._scatt_lon_gal[mask]
+            
+            self._nevents = self._id.size
+
+    @classmethod
+    def from_astropy(cls,
+                 energy:Quantity,
+                 scattering_angle:Angle,
+                 scattered_direction_sc:SkyCoord,
+                 scattered_direction_gal:SkyCoord,    
+                 event_id:Optional[Iterable[int]] = None,
+                 selection:Optional[EventSelectorInterface] = None):
+        """
+        Initialize from astropy objects, taking into account the units and formats
+
+        Parameters
+        ----------
+        energy
+        scattering_angle
+        scattered_direction_sc
+        scattered_direction_gal
+        event_id
+        selection
+        """
+
+        energy = energy.to_value(u.keV)
+        scatt_angle = scattering_angle.to_value(u.rad)
+
+        if not isinstance(scattered_direction_sc.frame, SpacecraftFrame):
+            raise ValueError("Local PsiChi Coordinates need to be in SC frame")
+        
+        if not isinstance(scattered_direction_gal.frame, "Galactic"):
+            raise ValueError("Galactic PsiChi Coordinates need to be in Galactic frame")
+
+        
+        scattered_direction_sc = scattered_direction_sc.represent_as(UnitSphericalRepresentation)
+        scattered_direction_gal = scattered_direction_gal.represent_as(UnitSphericalRepresentation)
+
+        scatt_lat_sc = scattered_direction_sc.lat.rad
+        scatt_lon_sc = scattered_direction_sc.lon.rad
+        scatt_lat_gal = scattered_direction_gal.lat.deg
+        scatt_lon_gal = scattered_direction_gal.lon.deg
+
+        if event_id is not None:
+            event_id = np.asarray(event_id)
+
+        return cls(energy, scatt_lon_rad, scatt_lat_rad, scatt_lon_gal, scatt_lat_gal, scatt_angle, event_id, selection)
+
+
+    def __getitem__(self, i: int) -> EmCDSEventInSCAndGalFrameInterface:
+        return EmCDSEventInSCAndGalFrame(self._energy[i], self._scatt_angle[i], self._scatt_lon_sc[i], self._scatt_lat_sc[i],
+                                          self._scatt_lon_gal[i], self._scatt_lat_gal[i], self._id[i])
+
+    @property
+    def nevents(self) -> int:
+        return self._nevents
+
+    def __iter__(self) -> Iterator[EmCDSEventInSCAndGalFrameInterface]:
+        for id, energy, scatt_angle, scatt_lat_sc, scatt_lon_sc, scatt_lat_gal, scatt_lon_gal in zip(self._id, self._energy, self._scatt_angle, self._scatt_lat_sc, self._scatt_lon_sc, self._scatt_lat_gal, self._scatt_lon_gal):
+            yield EmCDSEventInSCAndGalFrame(energy, scatt_angle, scatt_lon_sc, scatt_lat_sc, scatt_lon_gal, scatt_lat_gal, id)
+
+    @property
+    def frame(self) -> str:
+        return self._frame
+
+    @property
+    def ids(self) -> Iterable[int]:
+        return self._id
+
+    @property
+    def energy_keV(self) -> Iterable[float]:
+        return self._energy
+
+    @property
+    def scattering_angle_rad(self) -> Iterable[float]:
+        return self._scatt_angle
+
+    @property
+    def scattered_lon_rad_sc(self) -> Iterable[float]:
+        return self._scatt_lon_sc
+
+    @property
+    def scattered_lat_rad_sc(self) -> Iterable[float]:
+        return self._scatt_lat_sc
+
+    @property
+    def scattered_lon_deg_gal(self) -> Iterable[float]:
+        return self._scatt_lon_gal
+
+    @property
+    def scattered_lat_deg_gal(self) -> Iterable[float]:
+        return self._scatt_lat_gal
+        
 class TimeTagEmCDSEventDataInSCFrameFromArrays(EmCDSEventDataInSCFrameFromArrays, TimeTagEmCDSEventDataInSCFrameInterface):
 
     event_type = TimeTagEmCDSEventInSCFrameInterface
@@ -236,24 +462,19 @@ class TimeTagEmCDSEventDataInSCFrameFromArrays(EmCDSEventDataInSCFrameFromArrays
                    scatt_angle_rad: np.ndarray[float],
                    event_id: Optional[np.ndarray[int]] = None,
                    selection: Optional[EventSelectorInterface] = None):
-        """Initialize from bare numpy arrays. The user is responsible from
-        getting the right units, coordinates and formats
+        """
+        Initialize from bare numpy arrays. The user is responsible from getting the right units, coordinates and formats
 
         Parameters
         ----------
-        jd1: Julian days. Internal astropy Time representation using
-          two values for full precision.
-        jd2: Julian days. Internal astropy Time representation using
-          two values for full precision.
+        jd1: Julian days. Internal astropy Time representation using two values for full precision.
+        jd2: Julian days. Internal astropy Time representation using two values for full precision.
         energy_keV: energy [keV]
-        scattered_lon_rad_sc: Longitude of the direction of the
-          scattered photon in spacecraft coordinates [radian]
-        scattered_lat_rad_sc: Latitude of the direction of the
-          scattered photon in spacecraft coordinates [radian]
+        scattered_lon_rad_sc: Longitude of the direction of the scattered photon in spacecraft coordinates [radian]
+        scattered_lat_rad_sc:  Latitude of the direction of the scattered photon in spacecraft coordinates [radian]
         scatt_angle_rad: Compton scattering angle [radians]
         event_id: Event ID. Optional. Sequential is not provided
         selection: Optional. Apply an event selection.
-
         """
 
         # Check size
@@ -281,15 +502,14 @@ class TimeTagEmCDSEventDataInSCFrameFromArrays(EmCDSEventDataInSCFrameFromArrays
 
     @classmethod
     def from_astropy(cls,
-                     time:Time,
-                     energy:Quantity,
-                     scattering_angle:Angle,
-                     scattered_direction:SkyCoord,
-                     event_id:Optional[Iterable[int]] = None,
-                    selection:Optional[EventSelectorInterface] = None):
+                 time:Time,
+                 energy:Quantity,
+                 scattering_angle:Angle,
+                 scattered_direction:SkyCoord,
+                 event_id:Optional[Iterable[int]] = None,
+                 selection:Optional[EventSelectorInterface] = None):
         """
-        Initialize from astropy objects, taking into account the units and
-        formats
+        Initialize from astropy objects, taking into account the units and formats
 
         Parameters
         ----------
@@ -299,7 +519,6 @@ class TimeTagEmCDSEventDataInSCFrameFromArrays(EmCDSEventDataInSCFrameFromArrays
         scattered_direction
         event_id
         selection
-
         """
 
         jd1 = time.jd1
@@ -337,6 +556,129 @@ class TimeTagEmCDSEventDataInSCFrameFromArrays(EmCDSEventDataInSCFrameFromArrays
     def jd2(self) -> Iterable[float]:
         return self._jd2
 
+class TimeTagEmCDSEventDataInSCAndGalFrameFromArrays(EmCDSEventDataInSCAndGalFrameFromArrays, TimeTagEmCDSEventDataInSCAndGalFrameInterface):
+
+    event_type = TimeTagEmCDSEventInSCAndGalFrameInterface
+
+    def __init__(self,
+                   jd1: np.ndarray[float],
+                   jd2: np.ndarray[float],
+                   energy_keV: np.ndarray[float],
+                   scattered_lon_rad_sc:  np.ndarray[float],
+                   scattered_lat_rad_sc: np.ndarray[float],
+                   scattered_lon_deg_gal:  np.ndarray[float],
+                   scattered_lat_deg_gal: np.ndarray[float],
+                   scatt_angle_rad: np.ndarray[float],
+                   event_id: Optional[np.ndarray[int]] = None,
+                   selection: Optional[EventSelectorInterface] = None):
+        """
+        Initialize from bare numpy arrays. The user is responsible from getting the right units, coordinates and formats
+
+        Parameters
+        ----------
+        jd1: Julian days. Internal astropy Time representation using two values for full precision.
+        jd2: Julian days. Internal astropy Time representation using two values for full precision.
+        energy_keV: energy [keV]
+        scattered_lon_rad_sc: Longitude of the direction of the scattered photon in spacecraft coordinates [radian]
+        scattered_lat_rad_sc:  Latitude of the direction of the scattered photon in spacecraft coordinates [radian]
+        scattered_lon_deg_gal: Longitude of the direction of the scattered photon in galactic coordinates [deg]
+        scattered_lat_deg_gal:  Latitude of the direction of the scattered photon in galactic coordinates [deg]
+        scatt_angle_rad: Compton scattering angle [radians]
+        event_id: Event ID. Optional. Sequential is not provided
+        selection: Optional. Apply an event selection.
+        """
+
+        # Check size
+        self._jd1, self._jd2, energy, scatt_angle, scatt_lon_sc, scatt_lat_sc, scatt_lon_gal, scatt_lat_gal = np.broadcast_arrays(
+            jd1, jd2, energy_keV, scatt_angle_rad, scattered_lon_rad_sc, scattered_lat_rad_sc, scattered_lon_deg_gal, scattered_lat_deg_gal)
+
+        super().__init__(energy, scatt_lon_sc, scatt_lat_sc, scatt_lon_gal, scatt_lat_gal, scatt_angle, event_id)
+
+        if selection is not None:
+            mask = asarray(selection.select(self), dtype=bool)
+
+            if mask.size < self._nevents:
+                # The rest of the events are False implicitly
+                mask = np.append(mask, np.full(self._nevents - mask.size, False))
+
+            self._id = self._id[mask]
+            self._jd1 = self._jd1[mask]
+            self._jd2 = self._jd2[mask]
+            self._energy = self._energy[mask]
+            self._scatt_angle = self._scatt_angle[mask]
+            self._scatt_lat_sc = self._scatt_lat_sc[mask]
+            self._scatt_lon_sc = self._scatt_lon_sc[mask]
+            self._scatt_lat_gal = self._scatt_lat_gal[mask]
+            self._scatt_lon_gal = self._scatt_lon_gal[mask]
+            
+            self._nevents = self._id.size
+
+    @classmethod
+    def from_astropy(cls,
+                 time:Time,
+                 energy:Quantity,
+                 scattering_angle:Angle,
+                 scattered_direction_sc:SkyCoord,
+                 scattered_direction_gal:SkyCoord,
+                 event_id:Optional[Iterable[int]] = None,
+                 selection:Optional[EventSelectorInterface] = None):
+        """
+        Initialize from astropy objects, taking into account the units and formats
+
+        Parameters
+        ----------
+        time
+        energy
+        scattering_angle
+        scattered_direction_sc
+        scattered_direction_gal
+        event_id
+        selection
+        """
+
+        jd1 = time.jd1
+        jd2 = time.jd2
+        energy = energy.to_value(u.keV)
+        scatt_angle = scattering_angle.to_value(u.rad)
+
+        if not isinstance(scattered_direction_sc.frame, SpacecraftFrame):
+            raise ValueError("Local PsiChi Coordinates need to be in SC frame")
+        
+        if not isinstance(scattered_direction_gal.frame, "Galactic"):
+            raise ValueError("Galactic PsiChi Coordinates need to be in Galactic frame")
+
+        scattered_direction_sc = scattered_direction_sc.represent_as(UnitSphericalRepresentation)
+        scattered_direction_gal = scattered_direction_gal.represent_as(UnitSphericalRepresentation)
+
+        scatt_lat_sc = scattered_direction_sc.lat.rad
+        scatt_lon_sc = scattered_direction_sc.lon.rad
+        scatt_lat_gal = scattered_direction_gal.lat.deg
+        scatt_lon_gal = scattered_direction_gal.lon.deg
+
+        if event_id is not None:
+            event_id = np.asarray(event_id)
+
+        return cls(jd1, jd2, energy, scatt_lon_sc, scatt_lat_sc, scatt_lon_gal, scatt_lat_gal, scatt_angle, event_id, selection)
+
+
+    def __getitem__(self, i: int) -> TimeTagEmCDSEventInSCAndGalFrameInterface:
+        return TimeTagEmCDSEventInSCAndGalFrame(self._jd1[i], self._jd2[i], self._energy[i], self._scatt_angle[i], self._scatt_lon_sc[i], self._scatt_lat_sc[i], self._scatt_lon_gal[i], self._scatt_lat_gal[i],
+                                          self._id[i])
+
+    def __iter__(self) -> Iterator[TimeTagEmCDSEventInSCAndGalFrameInterface]:
+        for id, jd1, jd2, energy, scatt_angle, scatt_lat_sc, scatt_lon_sc, scatt_lat_gal, scatt_lon_gal in zip(self._id, self._jd1, self._jd2, self._energy, self._scatt_angle, self._scatt_lat_sc, self._scatt_lon_sc, self._scatt_lat_gal, self._scatt_lon_gal):
+            yield TimeTagEmCDSEventInSCAndGalFrame(jd1, jd2, energy, scatt_angle, scatt_lon_sc, scatt_lat_sc, scatt_lon_gal, scatt_lat_gal, id)
+
+    @property
+    def jd1(self) -> Iterable[float]:
+        return self._jd1
+
+    @property
+    def jd2(self) -> Iterable[float]:
+        return self._jd2
+
+
+        
 class TimeTagEmCDSEventDataInSCFrameFromDC3Fits(TimeTagEmCDSEventDataInSCFrameFromArrays):
 
     def __init__(self, data_path: Union[Path, List[Path]],
@@ -374,3 +716,51 @@ class TimeTagEmCDSEventDataInSCFrameFromDC3Fits(TimeTagEmCDSEventDataInSCFrameFr
 
         # Psi is colatitude (latitude complementary angle)
         super().__init__(time.jd1, time.jd2, energy, chi, np.pi / 2 - psi, phi, selection = selection)
+
+
+
+class TimeTagEmCDSEventDataInSCAndGalFrameFromDC3Fits(TimeTagEmCDSEventDataInSCAndGalFrameFromArrays):
+
+    def __init__(self, data_path: Union[Path, List[Path]],
+                 selection:EventSelectorInterface = None):
+
+        time = np.empty(0)
+        energy = np.empty(0)
+        phi = np.empty(0)
+        psi_local = np.empty(0)
+        chi_local = np.empty(0)
+        psi_gal = np.empty(0)
+        chi_gal = np.empty(0)
+
+        if isinstance(data_path, (str, Path)):
+            data_path = [Path(data_path)]
+
+        for file in data_path:
+            # get_dict_from_fits is really a static method, no config file needed
+            data_dict = UnBinnedData.get_dict_from_fits(None, str(file))
+
+            time = np.append(time, data_dict['TimeTags'])
+            energy = np.append(energy, data_dict['Energies'])
+            phi = np.append(phi, data_dict['Phi'])
+            psi_local = np.append(psi_local, data_dict['Psi local'])
+            chi_local = np.append(chi_local, data_dict['Chi local'])
+            psi_gal = np.append(psi_gal, data_dict['Psi galactic'])
+            chi_gal = np.append(chi_gal, data_dict['Chi galactic'])
+            
+        # Time sort
+        tsort = np.argsort(time)
+
+        time = time[tsort]
+        energy = energy[tsort]
+        phi = phi[tsort]
+        psi_local = psi_local[tsort]
+        chi_local = chi_local[tsort]
+        psi_gal = psi_gal[tsort]
+        chi_gal = chi_gal[tsort]
+        
+        time = Time(time, format='unix')
+
+        # Psi is colatitude (latitude complementary angle)
+        super().__init__(time.jd1, time.jd2, energy, chi_local, np.pi / 2 - psi_local, psi_gal, chi_gal, phi, selection = selection)
+
+

--- a/cosipy/data_io/EmCDSUnbinnedData.py
+++ b/cosipy/data_io/EmCDSUnbinnedData.py
@@ -91,8 +91,8 @@ class EmCDSEventInSCAndGalFrame(EmCDSEventInSCAndGalFrameInterface):
         scatt_angle: scattering angle radians
         scatt_lon_sc: scattering longitude radians (SC frame)
         scatt_lat_sc: scattering latitude radians (SC frame)
-        scatt_lon_gal: scattering longitude radians (Gal frame)
-        scatt_lat_gal: scattering latitude radians (Gal frame)
+        scatt_lon_gal: scattering longitude deg (Gal frame)
+        scatt_lat_gal: scattering latitude deg (Gal frame)
         """
         self._id = event_id
         self._energy = energy

--- a/cosipy/data_io/UnBinnedData.py
+++ b/cosipy/data_io/UnBinnedData.py
@@ -10,7 +10,7 @@ import numpy as np
 from scipy import interpolate
 
 import astropy.units as u
-from astropy.coordinates import SkyCoord, cartesian_to_spherical
+from astropy.coordinates import SkyCoord, cartesian_to_spherical, Galactic, GCRS,CartesianRepresentation
 from astropy.table import Table
 from astropy.io import fits
 
@@ -921,3 +921,200 @@ class UnBinnedData(DataIO):
         if output_name is not None:
             logger.info("Saving file...")
             self.write_unbinned_output(output_name)
+			
+	def cut_EarthHorizon(self ,cutvalue ,unbinned_data=None, output_name=None, returnEHcut = False):
+
+        """Applies Earth horizon cuts [cutvalue,1] to unbinnned data dictionary
+
+        Parameters
+        ----------
+        cutvalue : float
+            value of the Earth Horizon cut
+        unbinned_data : str, optional
+            Name of unbinned dictionary file.
+        output_name : str, optional
+            Prefix of output file (default is None, in which case no
+            file is saved).
+        returnEHcut : bool, optional.
+            return the fsky distribution (default is False).
+        """
+        
+        # Option to read in unbinned data file
+        if unbinned_data:
+            self.cosi_dataset = self.get_dict(unbinned_data)
+
+        costheta, theta_max = self.Angle_PsiChi_Ez()
+        fsky = self.calculate_sky_fraction(costheta, self.cosi_dataset["Phi"], theta_max)
+
+        EHcut = ( fsky >= cutvalue)
+        
+        # Apply cuts to dictionary
+        for key in self.cosi_dataset:
+            self.cosi_dataset[key] = self.cosi_dataset[key][EHcut]
+
+        # Write unbinned data to file (either fits or hdf5)
+        if output_name is not None:
+            logger.info("Saving file...")
+            self.write_unbinned_output(output_name)
+
+        if returnEHcut:
+            return fsky
+    
+    def Angle_PsiChi_Ez(self):
+        """
+        Calculates the angle between PsiChi and the Earth zenith for each event.
+    
+        Parameters:
+        -----------
+        unbinned_data : str, optional
+            Name of unbinned dictionary file.
+        Returns:
+        --------
+        costheta : array-like
+            Angle in rad.
+        thetamax : array-like
+            Max angle between Earth zenith and Earth horizon
+        """
+
+        #Get orientation info
+        ori = SpacecraftHistory.open(self.ori_file)
+        ori.cache_earth_occ = True
+    
+        #compute once the Earth occ for a random source in order to cache min_angle_cos and ez_cart
+        randomsource = SkyCoord(0*u.deg, 0*u.deg, frame ="galactic")
+        ori.get_earth_occ(randomsource)
+    
+    
+        # Ensure the events time is sorted and convert it to a NumPy array
+        ori_times = ori.obstime.value
+        event_times = np.sort(np.array(self.cosi_dataset["TimeTags"]))
+    
+        # Find the closest index ahead of each event time
+        idx = np.searchsorted(ori_times, event_times, side='left')
+        idx = np.clip(idx, 1, len(ori_times) - 1)
+        left_idx = idx - 1
+        right_idx = idx
+    
+        # Choose whichever side is closer in time
+        closer_than_right = np.abs(event_times - ori_times[left_idx]) < np.abs(event_times - ori_times[right_idx])
+        nearest_idx = np.where(closer_than_right, left_idx, right_idx)
+    
+        # Get the Earth zenith and max angle for each event
+        # ori._ez_cart has a shape of (3, N). Slicing the columns via [:, nearest_idx] 
+        # and transposing (.T) instantly yields a clean (N, 3) vector array.
+        earth_zenith_vector = ori._ez_cart[:, nearest_idx].T 
+        max_ang = ori._min_angle_cos[nearest_idx]
+    
+        # Standard spherical to cartesian unit vectors (Galactic Frame)
+        x_gal = np.cos(np.radians(self.cosi_dataset["Psi galactic"])) * np.cos(np.radians(self.cosi_dataset["Chi galactic"]))
+        y_gal = np.cos(np.radians(self.cosi_dataset["Psi galactic"])) * np.sin(np.radians(self.cosi_dataset["Chi galactic"]))
+        z_gal = np.sin(np.radians(self.cosi_dataset["Psi galactic"]))
+        source_vector_gal = np.vstack([x_gal, y_gal, z_gal]).T 
+    
+        # Compute the 3x3 rotation matrix from Galactic to GCRS (ICRS/Equatorial aligned)
+        # This is a trick to not use directly astropy.transform_to for every event
+        # because this would be very slow for millions of events
+        cart_axes = CartesianRepresentation(x=[1, 0, 0], y=[0, 1, 0], z=[0, 0, 1])
+        dummy_gal = Galactic(cart_axes)
+        axes_gcrs = dummy_gal.transform_to(GCRS(obstime="J2000"))
+    
+        R = np.vstack([
+            axes_gcrs.cartesian.x.value,
+            axes_gcrs.cartesian.y.value,
+            axes_gcrs.cartesian.z.value
+            ])
+    
+        # Rotate Galactic vectors to GCRS unit vectors
+        source_vector_gcrs = np.dot(source_vector_gal, R.T) 
+    
+        # Einstein Summation: Dot product of two unit vectors in GCRS frame
+        costheta = np.einsum('ij,ij->i', source_vector_gcrs, earth_zenith_vector)
+    
+        # Safety clip for floating-point precision edge cases
+        costheta = np.clip(costheta, -1.0, 1.0)
+        theta_max = np.clip(max_ang, -1.0, 1.0)
+
+    
+        return np.arccos(costheta), np.arccos(theta_max)
+
+
+
+    def calculate_sky_fraction(self, theta_psichi, theta_phi, theta_max):
+        """
+        Calculates the fraction of the Compton cone that is above the Earth horizon
+        using the Spherical Law of Cosines.
+
+        Mathematical Logic:
+        ------------------
+        1. Define a spherical triangle on the sky with vertices at:
+           - Z: Earth Zenith
+           - C: Center of the Compton scattering circle (cone axis)
+           - I: Intersection point where the Compton circle crosses the horizon boundary
+
+        2. Define the angular lengths of the sides of this spherical triangle:
+           - Side connecting Z and I = theta_max (Max angle from Zenith to horizon)
+           - Side connecting Z and C = theta_psichi (Angle between cone axis and Zenith)
+           - Side connecting C and I = theta_phi (Compton scattering cone half-angle)
+
+        3. Solve for the interior angle at vertex C (alpha_cut) using the Spherical 
+           Law of Cosines for sides:
+       
+           cos(theta_max) = cos(theta_psichi)*cos(theta_phi) + sin(theta_psichi)*sin(theta_phi)*cos(alpha_cut)
+
+        4. Isolate alpha_cut, which represents the half-angle of the Compton circle arc
+           that resides safely in the unoccluded sky (above the horizon):
+       
+           cos_alpha_cut = (cos(theta_max) - cos(theta_psichi)*cos(theta_phi)) / (sin(theta_psichi)*sin(theta_phi))
+           alpha_cut = arccos(cos_alpha_cut)
+
+        5. Convert the unoccluded half-angle into the total sky fraction (f_sky):
+           - The total unoccluded arc fraction of the circle is (2 * alpha_cut) / (2 * pi)
+           - f_sky = alpha_cut / pi
+
+        Boundary Conditions & Clipping:
+        -------------------------------
+        - If the cone is completely above the horizon: cos_alpha_cut scales below -1.0. 
+          Clipping to -1.0 yields alpha_cut = pi, meaning f_sky = 1.0 (100% sky exposure).
+        - If the cone is completely below the horizon: cos_alpha_cut scales above 1.0. 
+          Clipping to 1.0 yields alpha_cut = 0.0, meaning f_sky = 0.0 (100% occulted).
+    
+        Parameters:
+        -----------
+        theta_psichi : float or array-like
+            Angle between the scattered direction (cone axis) and Earth zenith (radians).
+        theta_phi : float or array-like
+            Compton scattering angle / cone half-opening angle (radians).
+        theta_max : float
+            Maximum angle from Earth zenith to the horizon boundary (radians).
+        
+        Returns:
+        --------
+        f_sky : float or array-like
+            Fraction of the cone in the sky [0.0, 1.0].
+        """
+        # Avoid division by zero for perfectly on-axis events
+        sin_term = np.sin(theta_psichi) * np.sin(theta_phi)
+    
+        # Handle the edge case where sin_term is 0 (e.g., theta_psichi=0 or theta_phi=0)
+        # If sin_term is 0, the cone is either entirely in the sky or entirely in the mud.
+        safe_sin_term = np.where(sin_term == 0, 1e-9, sin_term)
+    
+        # Calculate cos(alpha_cut) using the spherical law of cosines
+        cos_alpha_cut = (np.cos(theta_max) - np.cos(theta_psichi) * np.cos(theta_phi)) / safe_sin_term
+    
+        # Clip values to handle cases where the cone is entirely above or below the horizon
+        cos_alpha_cut = np.clip(cos_alpha_cut, -1.0, 1.0)
+    
+        # Calculate the angle and the resulting sky fraction
+        alpha_cut = np.arccos(cos_alpha_cut)
+        f_sky = alpha_cut / np.pi
+    
+        # Clean up the perfectly on-axis edge cases manually if needed
+        # (If centered on zenith and within horizon, f_sky should be 1.0)
+        if np.isscalar(theta_psichi):
+            if sin_term == 0:
+                f_sky = 1.0 if (theta_psichi + theta_phi) <= theta_max else 0.0
+        else:
+            f_sky = np.where(sin_term == 0, np.where((theta_psichi + theta_phi) <= theta_max, 1.0, 0.0), f_sky)
+        
+        return f_sky

--- a/cosipy/data_io/UnBinnedData.py
+++ b/cosipy/data_io/UnBinnedData.py
@@ -922,7 +922,7 @@ class UnBinnedData(DataIO):
             logger.info("Saving file...")
             self.write_unbinned_output(output_name)
 			
-	def cut_EarthHorizon(self ,cutvalue ,unbinned_data=None, output_name=None, returnEHcut = False):
+    def cut_EarthHorizon(self ,cutvalue ,unbinned_data=None, output_name=None, returnEHcut = False):
 
         """Applies Earth horizon cuts [cutvalue,1] to unbinnned data dictionary
 

--- a/cosipy/event_selection/earth_horizon_selection.py
+++ b/cosipy/event_selection/earth_horizon_selection.py
@@ -1,0 +1,242 @@
+import logging
+logger = logging.getLogger(__name__)
+
+import itertools
+from typing import Union, Iterable
+
+import numpy as np
+from astropy.coordinates import SkyCoord, Galactic, GCRS, CartesianRepresentation
+
+from cosipy.interfaces import TimeTagEmCDSEventInSCFrameInterface
+from cosipy.interfaces.event_selection import EventSelectorInterface
+from cosipy.util.iterables import itertools_batched, asarray
+from cosipy.spacecraftfile import SpacecraftHistory
+
+class EHSelector(EventSelectorInterface):
+    def __init__(self, ori:SpacecraftHistory, cutvalue:float = None, batch_size:int = None):
+        """
+        Assumes events are time-ordered
+        
+        Selects events based on Earth Horizon cut
+        
+        Parameters
+        ----------
+        ori: SpacecraftHistory
+            SpacecraftHistory object
+        cutvalue: float
+            Value of the earth horizon cut to apply [0,1].
+        batch_size: int, default None
+            Number of events to process at once
+            If None, all values are processed in a single batch.
+            This parameter only affects iteration when the expectation density
+            is provided as an iterator that is not a numpy array. If it is already
+            an array batching is not applied.
+        """
+        if cutvalue is None:
+            logger.error("You must give a value for the EH cut.")
+            raise ValueError
+
+        if cutvalue > 1 or cutvalue < 0 :
+            logger.error("The cut value must be between 0 and 1.")
+            raise ValueError
+    
+    def _select(self, events:TimeTagEmCDSEventInSCFrameInterface, early_stop:bool = True) -> Iterable[bool]:
+        
+        def process_chunk(jd1: np.ndarray, phi: np.ndarray):
+
+            costheta, theta_max = self.Angle_PsiChi_Ez(jd1)
+            fsky = self.calculate_sky_fraction(costheta, phi, theta_max)
+
+            result = ( fsky >= self.cutvalue)
+
+            # Stop further loading of event
+            stop = early_stop
+
+            return result, stop
+
+        def process_in_chunks(events):
+
+            for chunk in itertools_batched(events, self._batch_size):
+
+                jd1 = []
+                phi = []
+
+                for event in chunk:
+                    jd1.append(event.jd1)
+                    phi.append(event.events.scattering_angle_rad)
+
+                # Cache in memory
+                jd1 = asarray(jd1, dtype=np.float64, force_dtype=False)
+                phi = asarray(phi, dtype=np.float64, force_dtype=False)
+
+                result, stop = process_chunk(jd1, phi)
+
+                yield from result
+
+                if stop:
+                    return
+
+        if (self._batch_size is None) or (isinstance(events.jd1, np.ndarray) and isinstance(events.scattering_angle_rad, np.ndarray)):
+            results, _ = process_chunk(events.jd1, events.scattering_angle_rad)
+            return results
+        else:
+            return process_in_chunks(events)
+
+       
+    def Angle_PsiChi_Ez(self, jd1):
+        """
+        Calculates the angle between PsiChi and the Earth zenith for each event.
+    
+        Parameters:
+        -----------
+        events : TimeTagEventDataInterface
+        
+        Returns:
+        --------
+        costheta : array-like
+            Angle in rad.
+        thetamax : array-like
+            Max angle between Earth zenith and Earth horizon
+        """
+
+        #Get orientation info
+        self.ori.cache_earth_occ = True
+    
+        #compute once the Earth occ for a random source in order to cache min_angle_cos and ez_cart
+        randomsource = SkyCoord(0*u.deg, 0*u.deg, frame ="galactic")
+        self.ori.get_earth_occ(randomsource)
+    
+    
+        # Ensure the events time is sorted and convert it to a NumPy array
+        ori_times = self.ori.obstime.value
+        event_times = jd1
+    
+        # Find the closest index ahead of each event time
+        idx = np.searchsorted(ori_times, event_times, side='left')
+        idx = np.clip(idx, 1, len(ori_times) - 1)
+        left_idx = idx - 1
+        right_idx = idx
+    
+        # Choose whichever side is closer in time
+        closer_than_right = np.abs(event_times - ori_times[left_idx]) < np.abs(event_times - ori_times[right_idx])
+        nearest_idx = np.where(closer_than_right, left_idx, right_idx)
+    
+        # Get the Earth zenith and max angle for each event
+        # ori._ez_cart has a shape of (3, N). Slicing the columns via [:, nearest_idx] 
+        # and transposing (.T) instantly yields a clean (N, 3) vector array.
+        earth_zenith_vector = self.ori._ez_cart[:, nearest_idx].T 
+        max_ang = self.ori._min_angle_cos[nearest_idx]
+    
+        # Standard spherical to cartesian unit vectors (Galactic Frame)
+        x_gal = np.cos(np.radians(self.cosi_dataset["Psi galactic"])) * np.cos(np.radians(self.cosi_dataset["Chi galactic"]))
+        y_gal = np.cos(np.radians(self.cosi_dataset["Psi galactic"])) * np.sin(np.radians(self.cosi_dataset["Chi galactic"]))
+        z_gal = np.sin(np.radians(self.cosi_dataset["Psi galactic"]))
+        source_vector_gal = np.vstack([x_gal, y_gal, z_gal]).T 
+    
+        # Compute the 3x3 rotation matrix from Galactic to GCRS (ICRS/Equatorial aligned)
+        # This is a trick to not use directly astropy.transform_to for every event
+        # because this would be very slow for millions of events
+        cart_axes = CartesianRepresentation(x=[1, 0, 0], y=[0, 1, 0], z=[0, 0, 1])
+        dummy_gal = Galactic(cart_axes)
+        axes_gcrs = dummy_gal.transform_to(GCRS(obstime="J2000"))
+    
+        R = np.vstack([
+            axes_gcrs.cartesian.x.value,
+            axes_gcrs.cartesian.y.value,
+            axes_gcrs.cartesian.z.value
+            ])
+    
+        # Rotate Galactic vectors to GCRS unit vectors
+        source_vector_gcrs = np.dot(source_vector_gal, R.T) 
+    
+        # Einstein Summation: Dot product of two unit vectors in GCRS frame
+        costheta = np.einsum('ij,ij->i', source_vector_gcrs, earth_zenith_vector)
+    
+        # Safety clip for floating-point precision edge cases
+        costheta = np.clip(costheta, -1.0, 1.0)
+        theta_max = np.clip(max_ang, -1.0, 1.0)
+
+    
+        return np.arccos(costheta), np.arccos(theta_max)
+
+
+    @classmethod
+    def calculate_sky_fraction(theta_psichi, theta_phi, theta_max):
+        """
+        Calculates the fraction of the Compton cone that is above the Earth horizon
+        using the Spherical Law of Cosines.
+
+        Mathematical Logic:
+        ------------------
+        1. Define a spherical triangle on the sky with vertices at:
+           - Z: Earth Zenith
+           - C: Center of the Compton scattering circle (cone axis)
+           - I: Intersection point where the Compton circle crosses the horizon boundary
+
+        2. Define the angular lengths of the sides of this spherical triangle:
+           - Side connecting Z and I = theta_max (Max angle from Zenith to horizon)
+           - Side connecting Z and C = theta_psichi (Angle between cone axis and Zenith)
+           - Side connecting C and I = theta_phi (Compton scattering cone half-angle)
+
+        3. Solve for the interior angle at vertex C (alpha_cut) using the Spherical 
+           Law of Cosines for sides:
+       
+           cos(theta_max) = cos(theta_psichi)*cos(theta_phi) + sin(theta_psichi)*sin(theta_phi)*cos(alpha_cut)
+
+        4. Isolate alpha_cut, which represents the half-angle of the Compton circle arc
+           that resides safely in the unoccluded sky (above the horizon):
+       
+           cos_alpha_cut = (cos(theta_max) - cos(theta_psichi)*cos(theta_phi)) / (sin(theta_psichi)*sin(theta_phi))
+           alpha_cut = arccos(cos_alpha_cut)
+
+        5. Convert the unoccluded half-angle into the total sky fraction (f_sky):
+           - The total unoccluded arc fraction of the circle is (2 * alpha_cut) / (2 * pi)
+           - f_sky = alpha_cut / pi
+
+        Boundary Conditions & Clipping:
+        -------------------------------
+        - If the cone is completely above the horizon: cos_alpha_cut scales below -1.0. 
+          Clipping to -1.0 yields alpha_cut = pi, meaning f_sky = 1.0 (100% sky exposure).
+        - If the cone is completely below the horizon: cos_alpha_cut scales above 1.0. 
+          Clipping to 1.0 yields alpha_cut = 0.0, meaning f_sky = 0.0 (100% occulted).
+    
+        Parameters:
+        -----------
+        theta_psichi : float or array-like
+            Angle between the scattered direction (cone axis) and Earth zenith (radians).
+        theta_phi : float or array-like
+            Compton scattering angle / cone half-opening angle (radians).
+        theta_max : float
+            Maximum angle from Earth zenith to the horizon boundary (radians).
+        
+        Returns:
+        --------
+        f_sky : float or array-like
+            Fraction of the cone in the sky [0.0, 1.0].
+        """
+        # Avoid division by zero for perfectly on-axis events
+        sin_term = np.sin(theta_psichi) * np.sin(theta_phi)
+    
+        # Handle the edge case where sin_term is 0 (e.g., theta_psichi=0 or theta_phi=0)
+        # If sin_term is 0, the cone is either entirely in the sky or entirely in the mud.
+        safe_sin_term = np.where(sin_term == 0, 1e-9, sin_term)
+    
+        # Calculate cos(alpha_cut) using the spherical law of cosines
+        cos_alpha_cut = (np.cos(theta_max) - np.cos(theta_psichi) * np.cos(theta_phi)) / safe_sin_term
+    
+        # Clip values to handle cases where the cone is entirely above or below the horizon
+        cos_alpha_cut = np.clip(cos_alpha_cut, -1.0, 1.0)
+    
+        # Calculate the angle and the resulting sky fraction
+        alpha_cut = np.arccos(cos_alpha_cut)
+        f_sky = alpha_cut / np.pi
+    
+        # Clean up the perfectly on-axis edge cases manually if needed
+        # (If centered on zenith and within horizon, f_sky should be 1.0)
+        if np.isscalar(theta_psichi):
+            if sin_term == 0:
+                f_sky = 1.0 if (theta_psichi + theta_phi) <= theta_max else 0.0
+        else:
+            f_sky = np.where(sin_term == 0, np.where((theta_psichi + theta_phi) <= theta_max, 1.0, 0.0), f_sky)
+        
+        return f_sky

--- a/cosipy/event_selection/earth_horizon_selection.py
+++ b/cosipy/event_selection/earth_horizon_selection.py
@@ -6,14 +6,18 @@ from typing import Union, Iterable
 
 import numpy as np
 from astropy.coordinates import SkyCoord, Galactic, GCRS, CartesianRepresentation
+import astropy.units as u
+from astropy.time import Time
 
 from cosipy.interfaces import TimeTagEmCDSEventInSCFrameInterface
 from cosipy.interfaces.event_selection import EventSelectorInterface
 from cosipy.util.iterables import itertools_batched, asarray
 from cosipy.spacecraftfile import SpacecraftHistory
 
+import matplotlib.pyplot as plt
+
 class EHSelector(EventSelectorInterface):
-    def __init__(self, ori:SpacecraftHistory, cutvalue:float = None, batch_size:int = None):
+    def __init__(self, ori:SpacecraftHistory, cutvalue:float = None, batch_size:int = None, plotfsky:bool = False):
         """
         Assumes events are time-ordered
         
@@ -31,6 +35,8 @@ class EHSelector(EventSelectorInterface):
             This parameter only affects iteration when the expectation density
             is provided as an iterator that is not a numpy array. If it is already
             an array batching is not applied.
+        plotfsky: bool , default False
+            If you want to plot the Earth Horizon cut distribution
         """
         if cutvalue is None:
             logger.error("You must give a value for the EH cut.")
@@ -39,6 +45,11 @@ class EHSelector(EventSelectorInterface):
         if cutvalue > 1 or cutvalue < 0 :
             logger.error("The cut value must be between 0 and 1.")
             raise ValueError
+
+        self._batch_size = batch_size
+        self._ori = ori
+        self._cutvalue = cutvalue
+        self._plotfsky = plotfsky
     
     def _select(self, events:TimeTagEmCDSEventInSCFrameInterface, early_stop:bool = True) -> Iterable[bool]:
         
@@ -47,8 +58,18 @@ class EHSelector(EventSelectorInterface):
             costheta, theta_max = self.Angle_PsiChi_Ez(jd1)
             fsky = self.calculate_sky_fraction(costheta, phi, theta_max)
 
-            result = ( fsky >= self.cutvalue)
+            result = ( fsky >= self._cutvalue)
 
+            if self._plotfsky:
+                bins = np.arange(0,1,0.01)
+                fig,ax = plt.subplots()
+                count,_,_ = ax.hist(fsky,histtype="step",label="test",bins=bins,density=True)
+                ax.set_xlabel("Fraction of the cone above the Earth Horizon")
+                ax.set_ylabel("a.u")
+                ax.set_yscale("log")
+                plt.show()
+                #print(list(count))
+                
             # Stop further loading of event
             stop = early_stop
 
@@ -60,14 +81,15 @@ class EHSelector(EventSelectorInterface):
 
                 jd1 = []
                 phi = []
-
+                
                 for event in chunk:
-                    jd1.append(event.jd1)
-                    phi.append(event.events.scattering_angle_rad)
-
+                    jd1.append(events.jd1)
+                    phi.append(events.scattering_angle_rad)
+                    
                 # Cache in memory
                 jd1 = asarray(jd1, dtype=np.float64, force_dtype=False)
                 phi = asarray(phi, dtype=np.float64, force_dtype=False)
+                
 
                 result, stop = process_chunk(jd1, phi)
 
@@ -89,28 +111,29 @@ class EHSelector(EventSelectorInterface):
     
         Parameters:
         -----------
-        events : TimeTagEventDataInterface
+        jd1 : array-like
+            obstime of the events
         
         Returns:
         --------
         costheta : array-like
-            Angle in rad.
-        thetamax : array-like
-            Max angle between Earth zenith and Earth horizon
+            cos(angle) in rad.
+        costheta_max : array-like
+            Max cos(angle) between Earth zenith and Earth horizon
         """
 
         #Get orientation info
-        self.ori.cache_earth_occ = True
+        self._ori.cache_earth_occ = True
     
         #compute once the Earth occ for a random source in order to cache min_angle_cos and ez_cart
         randomsource = SkyCoord(0*u.deg, 0*u.deg, frame ="galactic")
-        self.ori.get_earth_occ(randomsource)
+        self._ori.get_earth_occ(randomsource)
     
     
         # Ensure the events time is sorted and convert it to a NumPy array
-        ori_times = self.ori.obstime.value
+        ori_times = Time(self._ori.obstime.value, format='unix').jd #convert unix time into jd
         event_times = jd1
-    
+        
         # Find the closest index ahead of each event time
         idx = np.searchsorted(ori_times, event_times, side='left')
         idx = np.clip(idx, 1, len(ori_times) - 1)
@@ -121,17 +144,12 @@ class EHSelector(EventSelectorInterface):
         closer_than_right = np.abs(event_times - ori_times[left_idx]) < np.abs(event_times - ori_times[right_idx])
         nearest_idx = np.where(closer_than_right, left_idx, right_idx)
     
-        # Get the Earth zenith and max angle for each event
+        # Get the Earth zenith, gal z pointing and max angle for each event
         # ori._ez_cart has a shape of (3, N). Slicing the columns via [:, nearest_idx] 
         # and transposing (.T) instantly yields a clean (N, 3) vector array.
-        earth_zenith_vector = self.ori._ez_cart[:, nearest_idx].T 
-        max_ang = self.ori._min_angle_cos[nearest_idx]
-    
-        # Standard spherical to cartesian unit vectors (Galactic Frame)
-        x_gal = np.cos(np.radians(self.cosi_dataset["Psi galactic"])) * np.cos(np.radians(self.cosi_dataset["Chi galactic"]))
-        y_gal = np.cos(np.radians(self.cosi_dataset["Psi galactic"])) * np.sin(np.radians(self.cosi_dataset["Chi galactic"]))
-        z_gal = np.sin(np.radians(self.cosi_dataset["Psi galactic"]))
-        source_vector_gal = np.vstack([x_gal, y_gal, z_gal]).T 
+        earth_zenith_vector = self._ori._ez_cart[:, nearest_idx].T
+        source_vector_gal = self._ori._attitude.rot.as_matrix()[nearest_idx,2] #only get gal z-pointing
+        max_ang = self._ori._min_angle_cos[nearest_idx] 
     
         # Compute the 3x3 rotation matrix from Galactic to GCRS (ICRS/Equatorial aligned)
         # This is a trick to not use directly astropy.transform_to for every event
@@ -154,14 +172,14 @@ class EHSelector(EventSelectorInterface):
     
         # Safety clip for floating-point precision edge cases
         costheta = np.clip(costheta, -1.0, 1.0)
-        theta_max = np.clip(max_ang, -1.0, 1.0)
+        costheta_max = np.clip(max_ang, -1.0, 1.0)
 
     
-        return np.arccos(costheta), np.arccos(theta_max)
+        return costheta, costheta_max
 
 
-    @classmethod
-    def calculate_sky_fraction(theta_psichi, theta_phi, theta_max):
+    @staticmethod
+    def calculate_sky_fraction(costheta_psichi, theta_phi, costheta_max):
         """
         Calculates the fraction of the Compton cone that is above the Earth horizon
         using the Spherical Law of Cosines.
@@ -202,12 +220,12 @@ class EHSelector(EventSelectorInterface):
     
         Parameters:
         -----------
-        theta_psichi : float or array-like
-            Angle between the scattered direction (cone axis) and Earth zenith (radians).
+        costheta_psichi : float or array-like
+            cos(Angle) between the scattered direction (cone axis) and Earth zenith (radians).
         theta_phi : float or array-like
             Compton scattering angle / cone half-opening angle (radians).
-        theta_max : float
-            Maximum angle from Earth zenith to the horizon boundary (radians).
+        costheta_max : float
+            Maximum cos(angle) from Earth zenith to the horizon boundary (radians).
         
         Returns:
         --------
@@ -215,14 +233,16 @@ class EHSelector(EventSelectorInterface):
             Fraction of the cone in the sky [0.0, 1.0].
         """
         # Avoid division by zero for perfectly on-axis events
-        sin_term = np.sin(theta_psichi) * np.sin(theta_phi)
+        # since we pass cos(theta_psichi) we use cos/sin relation 
+        # to get sin(theta_psichi)
+        sin_term = (np.sqrt(1-(costheta_psichi)**2)) * np.sin(theta_phi)
     
         # Handle the edge case where sin_term is 0 (e.g., theta_psichi=0 or theta_phi=0)
         # If sin_term is 0, the cone is either entirely in the sky or entirely in the mud.
         safe_sin_term = np.where(sin_term == 0, 1e-9, sin_term)
     
         # Calculate cos(alpha_cut) using the spherical law of cosines
-        cos_alpha_cut = (np.cos(theta_max) - np.cos(theta_psichi) * np.cos(theta_phi)) / safe_sin_term
+        cos_alpha_cut = (costheta_max - costheta_psichi * np.cos(theta_phi)) / safe_sin_term
     
         # Clip values to handle cases where the cone is entirely above or below the horizon
         cos_alpha_cut = np.clip(cos_alpha_cut, -1.0, 1.0)
@@ -233,10 +253,10 @@ class EHSelector(EventSelectorInterface):
     
         # Clean up the perfectly on-axis edge cases manually if needed
         # (If centered on zenith and within horizon, f_sky should be 1.0)
-        if np.isscalar(theta_psichi):
+        if np.isscalar(costheta_psichi):
             if sin_term == 0:
-                f_sky = 1.0 if (theta_psichi + theta_phi) <= theta_max else 0.0
+                f_sky = 1.0 if (costheta_psichi + np.cos(theta_phi)) <= costheta_max else 0.0
         else:
-            f_sky = np.where(sin_term == 0, np.where((theta_psichi + theta_phi) <= theta_max, 1.0, 0.0), f_sky)
+            f_sky = np.where(sin_term == 0, np.where((costheta_psichi + np.cos(theta_phi)) <= costheta_max, 1.0, 0.0), f_sky)
         
         return f_sky

--- a/cosipy/event_selection/earth_horizon_selection.py
+++ b/cosipy/event_selection/earth_horizon_selection.py
@@ -9,7 +9,7 @@ from astropy.coordinates import SkyCoord, Galactic, GCRS, CartesianRepresentatio
 import astropy.units as u
 from astropy.time import Time
 
-from cosipy.interfaces import TimeTagEmCDSEventInSCFrameInterface
+from cosipy.interfaces import TimeTagEmCDSEventInSCAndGalFrameInterface
 from cosipy.interfaces.event_selection import EventSelectorInterface
 from cosipy.util.iterables import itertools_batched, asarray
 from cosipy.spacecraftfile import SpacecraftHistory
@@ -51,11 +51,11 @@ class EHSelector(EventSelectorInterface):
         self._cutvalue = cutvalue
         self._plotfsky = plotfsky
     
-    def _select(self, events:TimeTagEmCDSEventInSCFrameInterface, early_stop:bool = True) -> Iterable[bool]:
+    def _select(self, events:TimeTagEmCDSEventInSCAndGalFrameInterface, early_stop:bool = True) -> Iterable[bool]:
         
-        def process_chunk(jd1: np.ndarray, phi: np.ndarray):
+        def process_chunk(jd1: np.ndarray, phi: np.ndarray, psi_gal: np.ndarray, chi_gal: np.ndarray):
 
-            costheta, theta_max = self.Angle_PsiChi_Ez(jd1)
+            costheta, theta_max = self.Angle_PsiChi_Ez(jd1, psi_gal, chi_gal)
             fsky = self.calculate_sky_fraction(costheta, phi, theta_max)
 
             result = ( fsky >= self._cutvalue)
@@ -68,7 +68,7 @@ class EHSelector(EventSelectorInterface):
                 ax.set_ylabel("a.u")
                 ax.set_yscale("log")
                 plt.show()
-                #print(list(count))
+                print(list(count))
                 
             # Stop further loading of event
             stop = early_stop
@@ -81,31 +81,38 @@ class EHSelector(EventSelectorInterface):
 
                 jd1 = []
                 phi = []
+                psi_gal = []
+                chi_gal = []
                 
                 for event in chunk:
                     jd1.append(events.jd1)
                     phi.append(events.scattering_angle_rad)
-                    
+                    psi_gal.append(events.scattered_lon_deg_gal)
+                    chi_gal.append(events.scattered_lat_deg_gal)
+
                 # Cache in memory
                 jd1 = asarray(jd1, dtype=np.float64, force_dtype=False)
                 phi = asarray(phi, dtype=np.float64, force_dtype=False)
-                
+                psi_gal = asarray(psi_gal, dtype=np.float64, force_dtype=False)
+                chi_gal = asarray(chi_gal, dtype=np.float64, force_dtype=False)
 
-                result, stop = process_chunk(jd1, phi)
+
+                result, stop = process_chunk(jd1, phi, psi_gal, chi_gal)
 
                 yield from result
 
                 if stop:
                     return
 
-        if (self._batch_size is None) or (isinstance(events.jd1, np.ndarray) and isinstance(events.scattering_angle_rad, np.ndarray)):
-            results, _ = process_chunk(events.jd1, events.scattering_angle_rad)
+        if (self._batch_size is None) or (isinstance(events.jd1, np.ndarray) and isinstance(events.scattering_angle_rad, np.ndarray)
+                and isinstance(events.scattered_lon_deg_gal, np.ndarray) and isinstance(events.scattered_lat_deg_gal, np.ndarray) ):
+            results, _ = process_chunk(events.jd1, events.scattering_angle_rad, events.scattered_lon_deg_gal, events.scattered_lat_deg_gal)
             return results
         else:
             return process_in_chunks(events)
 
        
-    def Angle_PsiChi_Ez(self, jd1):
+    def Angle_PsiChi_Ez(self, jd1, psi_gal, chi_gal):
         """
         Calculates the angle between PsiChi and the Earth zenith for each event.
     
@@ -113,7 +120,10 @@ class EHSelector(EventSelectorInterface):
         -----------
         jd1 : array-like
             obstime of the events
-        
+        psi_gal : array-like
+            scattered direction of the events in galactic frame (lon)
+        chi_gal : array-like
+            scattered direction of the events in galactic frame (lat)
         Returns:
         --------
         costheta : array-like
@@ -144,13 +154,18 @@ class EHSelector(EventSelectorInterface):
         closer_than_right = np.abs(event_times - ori_times[left_idx]) < np.abs(event_times - ori_times[right_idx])
         nearest_idx = np.where(closer_than_right, left_idx, right_idx)
     
-        # Get the Earth zenith, gal z pointing and max angle for each event
+        # Get the Earth zenith and max angle for each event
         # ori._ez_cart has a shape of (3, N). Slicing the columns via [:, nearest_idx] 
         # and transposing (.T) instantly yields a clean (N, 3) vector array.
         earth_zenith_vector = self._ori._ez_cart[:, nearest_idx].T
-        source_vector_gal = self._ori._attitude.rot.as_matrix()[nearest_idx,2] #only get gal z-pointing
         max_ang = self._ori._min_angle_cos[nearest_idx] 
-    
+
+        # Standard spherical to cartesian unit vectors (Galactic Frame)
+        x_gal = np.cos(np.radians(psi_gal)) * np.cos(np.radians(chi_gal))
+        y_gal = np.cos(np.radians(psi_gal)) * np.sin(np.radians(chi_gal))
+        z_gal = np.sin(np.radians(psi_gal))
+        source_vector_gal = np.vstack([x_gal, y_gal, z_gal]).T 
+       
         # Compute the 3x3 rotation matrix from Galactic to GCRS (ICRS/Equatorial aligned)
         # This is a trick to not use directly astropy.transform_to for every event
         # because this would be very slow for millions of events

--- a/cosipy/interfaces/data_interface.py
+++ b/cosipy/interfaces/data_interface.py
@@ -1,26 +1,26 @@
 import itertools
-from typing import Protocol, runtime_checkable, Iterator, Union, Iterable
+from typing import Protocol, runtime_checkable, Dict, Type, Any, Tuple, Iterator, Union, Sequence, Iterable, ClassVar
 
-from astropy.coordinates import Angle, SkyCoord
-from astropy.units import  Quantity
+import numpy as np
+from astropy.coordinates import BaseCoordinateFrame, Angle, SkyCoord
+from astropy.units import Unit, Quantity
 import astropy.units as u
-
 from scoords import SpacecraftFrame
 
 from . import EventWithEnergyInterface
-
-from .event import (
-    EventInterface,
-    TimeTagEventInterface,
-    ComptonDataSpaceInSCFrameEventInterface,
-    EmCDSEventInSCFrameInterface,
-    TimeTagEmCDSEventInSCFrameInterface,
-    EventWithScatteringAngleInterface,
-)
-
+from .event import EventInterface, TimeTagEventInterface, \
+    ComptonDataSpaceInSCFrameEventInterface, ComptonDataSpaceInGalFrameEventInterface,TimeTagEmCDSEventInSCFrameInterface, EventWithScatteringAngleInterface, \
+    EmCDSEventInSCFrameInterface, EmCDSEventInSCAndGalFrameInterface, TimeTagEmCDSEventInSCAndGalFrameInterface
 from histpy import Histogram, Axes
 
 from astropy.time import Time
+
+# Guard to prevent circular import
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .event_selection import EventSelectorInterface
+
+import histpy
 
 __all__ = ["DataInterface",
            "EventDataInterface",
@@ -77,17 +77,14 @@ class EventDataInterface(DataInterface, Protocol):
 
         For convenience. Specific implementation can do better job.
 
-        It is not safe to call this method from an interface
-        implementation that does not explicitly overload
-        fromiter(). Call it from an interface instead.
+        It is not safe to call this method from an interface implementation that
+        does not explicitly overload fromiter(). Call it from an interface instead.
 
-        If you know it, specifying the length of the iterable can help
-        optimize the code.
-
+        If you know it, specifying the length of the iterable can help optimize the code.
         """
 
         if not getattr(cls, "_is_protocol", False):
-            raise RuntimeError("It is not safe to call fromiter() from an interface implementation that"
+            raise RuntimeError("It is not safe to call fromiter() from an interface implementation that"                        
                                "does not explicitly overload fromiter(). Call it from an interface instead.")
 
         class EventDataIterableWrapper(cls):
@@ -116,13 +113,11 @@ class EventDataInterface(DataInterface, Protocol):
         Parameters
         ----------
         event:
-        repeat: Number of time to repeat photon. If None, it will
-        repeat indefinitely (use with care)
+        repeat: Number of time to repeat photon. Is None, it will repeat indefinitely (use with care)
 
         Returns
         -------
         tuple:  is_single? (bool), event_data
-
         """
 
         if not getattr(cls, "_is_protocol", False):
@@ -153,9 +148,8 @@ class EventDataInterface(DataInterface, Protocol):
         """
         Total number of events yielded by __iter__
 
-        Convenience method. Pretty slow in general. It's suggested
-        that the implementations override it
-
+        Convenience method. Pretty slow in general. It's suggested that
+        the implementations override it
         """
         return sum(1 for _ in iter(self))
 
@@ -165,9 +159,8 @@ class EventDataInterface(DataInterface, Protocol):
 
 
 def is_single_event(photon: Union[EventInterface, 'EventDataInterface']) -> bool:
-    # Since these protocols are runtime checkable, it's not enough to
-    # check the input is EventInterface, since the EventDataInterface
-    # also returns True.
+    # Since these protocols are runtime checkable, it's not enough to check the input is
+    # EventInterface, since the EventDataInterface also returns True.
     if isinstance(photon, EventDataInterface):
         return False
     else:
@@ -262,6 +255,32 @@ class ComptonDataSpaceInSCFrameEventDataInterface(EventDataWithScatteringAngleIn
                         frame = SpacecraftFrame())
 
 @runtime_checkable
+class ComptonDataSpaceInGalFrameEventDataInterface(EventDataWithScatteringAngleInterface, Protocol):
+
+    event_type = ComptonDataSpaceInGalFrameEventInterface
+
+    def __iter__(self) -> Iterator[ComptonDataSpaceInGalFrameEventInterface]:...
+
+    @property
+    def scattered_lon_deg_gal(self) -> Iterable[float]:
+        return [e.scattered_lon_deg_gal for e in self]
+
+    @property
+    def scattered_lat_deg_gal(self) -> Iterable[float]:
+        return [e.scattered_lat_deg_gal for e in self]
+
+    @property
+    def scattered_direction_gal(self) -> SkyCoord:
+        """
+        Add fancy energy quantity
+        """
+        return SkyCoord(self.scattered_lon_deg_gal,
+                        self.scattered_lat_deg_gal,
+                        unit = u.deg,
+                        frame = "Galactic")
+
+    
+@runtime_checkable
 class EmCDSEventDataInSCFrameInterface(EventDataWithEnergyInterface, ComptonDataSpaceInSCFrameEventDataInterface, Protocol):
 
     event_type = EmCDSEventInSCFrameInterface
@@ -276,3 +295,22 @@ class TimeTagEmCDSEventDataInSCFrameInterface(TimeTagEventDataInterface,
     event_type = TimeTagEmCDSEventInSCFrameInterface
 
     def __iter__(self) -> Iterator[TimeTagEmCDSEventInSCFrameInterface]:...
+
+
+@runtime_checkable
+class EmCDSEventDataInSCAndGalFrameInterface(EventDataWithEnergyInterface, 
+                                             ComptonDataSpaceInSCFrameEventDataInterface,
+                                             ComptonDataSpaceInGalFrameEventDataInterface, Protocol):
+
+    event_type = EmCDSEventInSCAndGalFrameInterface
+
+    def __iter__(self) -> Iterator[EmCDSEventInSCAndGalFrameInterface]: ...
+
+@runtime_checkable
+class TimeTagEmCDSEventDataInSCAndGalFrameInterface(TimeTagEventDataInterface,
+                                              EmCDSEventDataInSCAndGalFrameInterface,
+                                              Protocol):
+
+    event_type = TimeTagEmCDSEventInSCAndGalFrameInterface
+
+    def __iter__(self) -> Iterator[TimeTagEmCDSEventInSCAndGalFrameInterface]:...

--- a/cosipy/interfaces/event.py
+++ b/cosipy/interfaces/event.py
@@ -12,6 +12,10 @@ __all__ = [
     "EventInterface",
     "TimeTagEventInterface",
     "EventWithEnergyInterface",
+    "EventWithScatteringAngleInterface",
+    "ComptonDataSpaceInSCFrameEventInterface",
+    "EmCDSEventInSCFrameInterface",
+    "TimeTagEmCDSEventInSCFrameInterface"
 ]
 
 @runtime_checkable

--- a/cosipy/interfaces/event.py
+++ b/cosipy/interfaces/event.py
@@ -1,8 +1,11 @@
-from typing import Union, Protocol, ClassVar
-from typing_extensions import runtime_checkable
+from abc import ABC, abstractmethod
+from symtable import Class
+from typing import Sequence, Union, Protocol, ClassVar
 
-from astropy.coordinates import Angle, SkyCoord
+import numpy as np
+from astropy.coordinates import Angle, SkyCoord, BaseCoordinateFrame
 from scoords import SpacecraftFrame
+from typing_extensions import runtime_checkable
 
 from astropy.time import Time
 from astropy.units import Quantity, Unit
@@ -14,8 +17,11 @@ __all__ = [
     "EventWithEnergyInterface",
     "EventWithScatteringAngleInterface",
     "ComptonDataSpaceInSCFrameEventInterface",
+    "ComptonDataSpaceInGalFrameEventInterface",
     "EmCDSEventInSCFrameInterface",
-    "TimeTagEmCDSEventInSCFrameInterface"
+    "TimeTagEmCDSEventInSCFrameInterface",
+    "EmCDSEventInSCAndGalFrameInterface",
+    "TimeTagEmCDSEventInSCAndGalFrameInterface"
 ]
 
 @runtime_checkable
@@ -25,7 +31,7 @@ class EventInterface(Protocol):
     """
 
     # This makes sure that all PDFs have the same units
-    data_space_units = ClassVar[Union[Unit, None]]
+    data_space_units = ClassVar[Union[u.Unit, None]]
 
     @property
     def id(self) -> int:
@@ -106,6 +112,28 @@ class ComptonDataSpaceInSCFrameEventInterface(EventWithScatteringAngleInterface,
                         unit=u.rad,
                         frame=SpacecraftFrame())
 
+
+@runtime_checkable
+class ComptonDataSpaceInGalFrameEventInterface(EventWithScatteringAngleInterface, Protocol):
+
+    data_space_units = EventWithScatteringAngleInterface.data_space_units * u.deg
+
+    @property
+    def scattered_lon_deg_gal(self) -> float: ...
+
+    @property
+    def scattered_lat_deg_gal(self) -> float: ...
+
+    @property
+    def scattered_direction_gal(self) -> SkyCoord:
+        """
+        Add fancy energy quantity
+        """
+        return SkyCoord(self.scattered_lon_deg_gal,
+                        self.scattered_lat_deg_gal,
+                        unit=u.deg,
+                        frame="Galactic")
+
 @runtime_checkable
 class EmCDSEventInSCFrameInterface(EventWithEnergyInterface,
                                    ComptonDataSpaceInSCFrameEventInterface,
@@ -117,3 +145,21 @@ class TimeTagEmCDSEventInSCFrameInterface(TimeTagEventInterface,
                                           EmCDSEventInSCFrameInterface,
                                           Protocol):
     data_space_units = EmCDSEventInSCFrameInterface.data_space_units * TimeTagEventInterface.data_space_units
+
+@runtime_checkable
+class EmCDSEventInSCAndGalFrameInterface(EventWithEnergyInterface,
+                                   ComptonDataSpaceInSCFrameEventInterface,
+                                   ComptonDataSpaceInGalFrameEventInterface,      
+                                   Protocol):
+    data_space_units = ComptonDataSpaceInSCFrameEventInterface.data_space_units * EventWithEnergyInterface.data_space_units * \
+                       ComptonDataSpaceInGalFrameEventInterface.data_space_units
+
+@runtime_checkable
+class TimeTagEmCDSEventInSCAndGalFrameInterface(TimeTagEventInterface,
+                                          EmCDSEventInSCAndGalFrameInterface,
+                                          Protocol):
+    data_space_units = EmCDSEventInSCAndGalFrameInterface.data_space_units * TimeTagEventInterface.data_space_units
+
+
+
+

--- a/tests/dataIO/test_unbinned_data_all.py
+++ b/tests/dataIO/test_unbinned_data_all.py
@@ -108,6 +108,9 @@ def test_unbinned_data_all(tmp_path):
     # Test SAA cut:
     analysis.cut_SAA_events(unbinned_data=tmp_path/"test_h5.hdf5")
 
+    # Test Earth Horizon cut
+    analysis.cut_EarthHorizon(0.4,unbinned_data=tmp_path/"test_h5.hdf5")
+
     return
 
 def test_unbinned_data_nopointings(tmp_path):

--- a/tests/event_selection/test_EH_selector.py
+++ b/tests/event_selection/test_EH_selector.py
@@ -1,5 +1,5 @@
 from cosipy.event_selection.earth_horizon_selection import EHSelector
-from cosipy.data_io.EmCDSUnbinnedData import TimeTagEmCDSEventDataInSCFrameFromDC3Fits
+from cosipy.data_io.EmCDSUnbinnedData import TimeTagEmCDSEventDataInSCAndGalFrameFromDC3Fits
 from cosipy import test_data
 from cosipy.spacecraftfile import SpacecraftHistory
 
@@ -8,4 +8,4 @@ def test_EHevent_selector():
     data_file = test_data.path / "unbinned_data_MEGAlib_calc.hdf5"
     ori = SpacecraftHistory.open(test_data.path / "20280301_first_10sec.fits")
     EH_selector = EHSelector(ori,cutvalue=0.4,plotfsky=True)
-    data = TimeTagEmCDSEventDataInSCFrameFromDC3Fits(data_file, selection=EH_selector)
+    data = TimeTagEmCDSEventDataInSCAndGalFrameFromDC3Fits(data_file, selection=EH_selector)

--- a/tests/event_selection/test_EH_selector.py
+++ b/tests/event_selection/test_EH_selector.py
@@ -5,7 +5,7 @@ from cosipy.spacecraftfile import SpacecraftHistory
 
 
 def test_EHevent_selector():
-    data_file = test_data.path+"unbinned_data_MEGAlib_calc.hdf5"
-    ori = SpacecraftHistory.open(test_data.path+"20280301_first_10sec.fits")
+    data_file = test_data.path / "unbinned_data_MEGAlib_calc.hdf5"
+    ori = SpacecraftHistory.open(test_data.path / "20280301_first_10sec.fits")
     EH_selector = EHSelector(ori,cutvalue=0.4,plotfsky=True)
     data = TimeTagEmCDSEventDataInSCFrameFromDC3Fits(data_file, selection=EH_selector)

--- a/tests/event_selection/test_EH_selector.py
+++ b/tests/event_selection/test_EH_selector.py
@@ -1,0 +1,11 @@
+from cosipy.event_selection.earth_horizon_selection import EHSelector
+from cosipy.data_io.EmCDSUnbinnedData import TimeTagEmCDSEventDataInSCFrameFromDC3Fits
+from cosipy import test_data
+from cosipy.spacecraftfile import SpacecraftHistory
+
+
+def test_EHevent_selector():
+    data_file = test_data.path+"unbinned_data_MEGAlib_calc.hdf5"
+    ori = SpacecraftHistory.open(test_data.path+"20280301_first_10sec.fits")
+    EH_selector = EHSelector(ori,cutvalue=0.4,plotfsky=True)
+    data = TimeTagEmCDSEventDataInSCFrameFromDC3Fits(data_file, selection=EH_selector)


### PR DESCRIPTION
This pull request add the Earth Horizon cut feature. This is done by 2 steps :

1.  Match the `_ez_cart` and `_min_angle_cos` computed by `get_earth_occ` for each event. Then compute the angle between PsiChi  and `_ez_cart` .
2. Compute the fraction of the Compton cone that is above the Earth Horizon (0 completely below, 1 completely above)
 
The user can then set a cut value based on this distribution with `cut_EarthHorizon()`.
By using only numpy, this function is pretty fast ( ~3,4 min for 118 M events of the Cosmic photons bg component). 

<img width="288" height="363" alt="image" src="https://github.com/user-attachments/assets/b056008a-f836-447a-8f91-11c1353b4354" />

Here an example on how this distribution differs between the Albedo Photons (coming from below the satellite) and the Cosmic Photons (coming from above). 

<img width="572" height="428" alt="image" src="https://github.com/user-attachments/assets/ae0f6144-5e10-492e-be13-384f7164f49e" />

The power of discrimination is not that great but that's not a surprise. This can be of course improve by asking nb of interaction > 2 and applying some cut in Phi, if the signal is a point source , ect...

<img width="562" height="429" alt="image" src="https://github.com/user-attachments/assets/20b53bdb-d929-480f-a402-58046bd12926" />

