### PR TITLE
Add Cutoff PowerLaw torch version 

### DIFF
--- a/cosipy/threeml/ml/function_torch.py
+++ b/cosipy/threeml/ml/function_torch.py
@@ -62,7 +62,7 @@ class FastPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
         # The normalization has the same units as the y
 
         self.K.unit = y_unit
-        
+        self._y_unit = y_unit
     
     def evaluate(self, x, K, piv, index):
         
@@ -74,7 +74,7 @@ class FastPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
 
         if isinstance(K, astropy_units.Quantity):
             K_, piv_, index_ = K.value, piv.value, index.value
-            unit_ = self.K.unit
+            unit_ = self.y_unit
         else:
             K_, piv_, index_ = K, piv, index
             unit_ = 1.0
@@ -218,7 +218,7 @@ class FastCutoffPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
         # The normalization has the same units as the y
 
         self.K.unit = y_unit
-        
+        self._y_unit = y_unit
         
     # noinspectionq PyPep8Naming
     def evaluate(self, x, K, piv, index, xc):
@@ -230,7 +230,7 @@ class FastCutoffPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
             xc_ = xc.value
             x_ = x.value
 
-            unit_ = self.K.unit
+            unit_ = self.y_unit
 
         else:
             unit_ = 1.0

--- a/cosipy/threeml/ml/function_torch.py
+++ b/cosipy/threeml/ml/function_torch.py
@@ -62,7 +62,7 @@ class FastPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
         # The normalization has the same units as the y
 
         self.K.unit = y_unit
-        self.y_unit = y_unit
+        
     
     def evaluate(self, x, K, piv, index):
         
@@ -74,7 +74,7 @@ class FastPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
 
         if isinstance(K, astropy_units.Quantity):
             K_, piv_, index_ = K.value, piv.value, index.value
-            unit_ = self.y_unit
+            unit_ = self.K.unit
         else:
             K_, piv_, index_ = K, piv, index
             unit_ = 1.0
@@ -218,7 +218,7 @@ class FastCutoffPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
         # The normalization has the same units as the y
 
         self.K.unit = y_unit
-        self.y_unit = y_unit
+        
         
     # noinspectionq PyPep8Naming
     def evaluate(self, x, K, piv, index, xc):
@@ -230,7 +230,7 @@ class FastCutoffPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
             xc_ = xc.value
             x_ = x.value
 
-            unit_ = self.y_unit
+            unit_ = self.K.unit
 
         else:
             unit_ = 1.0

--- a/cosipy/threeml/ml/function_torch.py
+++ b/cosipy/threeml/ml/function_torch.py
@@ -62,7 +62,7 @@ class FastPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
         # The normalization has the same units as the y
 
         self.K.unit = y_unit
-        self._y_unit = y_unit
+        
     
     def evaluate(self, x, K, piv, index):
         
@@ -218,7 +218,7 @@ class FastCutoffPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
         # The normalization has the same units as the y
 
         self.K.unit = y_unit
-        self._y_unit = y_unit
+        
         
     # noinspectionq PyPep8Naming
     def evaluate(self, x, K, piv, index, xc):

--- a/cosipy/threeml/ml/function_torch.py
+++ b/cosipy/threeml/ml/function_torch.py
@@ -156,3 +156,94 @@ class FastGaussianPyTorch(Function1D, metaclass=FunctionMeta):
         result = F * norm * torch.exp(-torch.pow(x - mu, 2.0) / (2 * torch.pow(sigma, 2.0)))
         
         return result.cpu().numpy()
+
+
+
+
+class FastCutoffPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
+    r"""
+    description :
+
+        A power law multiplied by an exponential cutoff
+
+    latex : $ K~\left(\frac{x}{piv}\right)^{index}~\exp{-x/xc} $
+
+    parameters :
+
+        K :
+
+            desc : Normalization (differential flux at the pivot value)
+            initial value : 1.0
+            is_normalization : True
+            transformation : log10
+            min : 1e-30
+            max : 1e3
+            delta : 0.1
+
+        piv :
+
+            desc : Pivot value
+            initial value : 1
+            fix : yes
+
+        index :
+
+            desc : Photon index
+            initial value : -2
+            min : -10
+            max : 10
+
+        xc :
+
+            desc : Cutoff energy
+            initial value : 10.0
+            transformation : log10
+            min: 1.0
+    
+    properties:
+        devices:
+            desc: devices used by torch
+            initial value: cpu
+    """
+
+    def _set_units(self, x_unit, y_unit):
+        # The index is always dimensionless
+        self.index.unit = astropy_units.dimensionless_unscaled
+
+        # The pivot energy has always the same dimension as the x variable
+        self.piv.unit = x_unit
+
+        self.xc.unit = x_unit
+
+        # The normalization has the same units as the y
+
+        self.K.unit = y_unit
+
+    # noinspectionq PyPep8Naming
+    def evaluate(self, x, K, piv, index, xc):
+
+        if isinstance(x, astropy_units.Quantity):
+            index_ = index.value
+            K_ = K.value
+            piv_ = piv.value
+            xc_ = xc.value
+            x_ = x.value
+
+            unit_ = self.y_unit
+
+        else:
+            unit_ = 1.0
+            K_, piv_, x_, index_, xc_ = K, piv, x, index, xc
+
+        x_t = torch.as_tensor(x_, dtype=torch.float64, device=self.devices.value)
+        x_t = x_t.view(-1, 1)
+        K_, piv_, index_, xc_ = [torch.as_tensor(t, dtype=torch.float64, device=self.devices.value) for t in (K_, piv_, index_, xc_)]
+        res = torch.div(x_t, piv_)
+        res.pow_(index_)
+        res.mul_(K_)
+        res.mul_(torch.exp_(-x_t/xc_))        
+
+        if unit_ == 1.0:
+            return res.cpu().numpy()
+        else:
+            return res.cpu().numpy() * unit_

--- a/cosipy/threeml/ml/function_torch.py
+++ b/cosipy/threeml/ml/function_torch.py
@@ -62,7 +62,7 @@ class FastPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
         # The normalization has the same units as the y
 
         self.K.unit = y_unit
-
+        self.y_unit = y_unit
     
     def evaluate(self, x, K, piv, index):
         
@@ -218,7 +218,8 @@ class FastCutoffPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
         # The normalization has the same units as the y
 
         self.K.unit = y_unit
-
+        self.y_unit = y_unit
+        
     # noinspectionq PyPep8Naming
     def evaluate(self, x, K, piv, index, xc):
 

--- a/tests/threeml/test_threeml_function_withtorch.py
+++ b/tests/threeml/test_threeml_function_withtorch.py
@@ -30,7 +30,7 @@ def test_powerlaw_basic_numeric():
     np.testing.assert_allclose(result.flatten(), expected, rtol=1e-6)
 
 
-def test_powerlaw_with_u():
+def test_powerlaw_with_astropy_units():
     """Test Powerlaw when parameters and inputs are passed as Astropy Quantities."""
     model = FastPowerlawPyTorch()
     

--- a/tests/threeml/test_threeml_function_withtorch.py
+++ b/tests/threeml/test_threeml_function_withtorch.py
@@ -224,6 +224,10 @@ def test_evaluate_no_units_applied_when_plain_input():
  
 def test_evaluate_with_quantity_input_returns_quantity():
     f = make_function(K=1.0, piv=1.0, index=-2.0, xc=10.0)
+    f.set_units(
+        u.keV,
+        1 / (u.keV * u.cm ** 2 * u.s),
+    )
     f._set_units(
         u.keV,
         1 / (u.keV * u.cm ** 2 * u.s),

--- a/tests/threeml/test_threeml_function_withtorch.py
+++ b/tests/threeml/test_threeml_function_withtorch.py
@@ -159,12 +159,6 @@ def test_parameter_bounds():
     assert f.xc.min_value == pytest.approx(1.0)
  
  
-def test_K_and_xc_use_log10_transform():
-    f = FastCutoffPowerlawPyTorch()
-    assert f.K.transformation.name == "log10"
-    assert f.xc.transformation.name == "log10"
- 
- 
 def test_devices_property_defaults_to_cpu():
     f = FastCutoffPowerlawPyTorch()
     assert f.devices.value == "cpu"
@@ -313,6 +307,4 @@ def test_output_length_matches_input_length():
     result = f.evaluate(x, K=1.0, piv=1.0, index=-2.0, xc=10.0)
     assert result.shape[0] == len(x)
     
-    
-    np.testing.assert_allclose(result.flatten(), expected, rtol=1e-6)
-    
+        

--- a/tests/threeml/test_threeml_function_withtorch.py
+++ b/tests/threeml/test_threeml_function_withtorch.py
@@ -4,7 +4,7 @@ import cosipy
 if not cosipy.with_ml:
     pytest.skip(reason="Optional [ml] dependencies not installed", allow_module_level=True) 
 
-from cosipy.threeml.ml.function_torch import FastPowerlawPyTorch, FastGaussianPyTorch
+from cosipy.threeml.ml.function_torch import FastPowerlawPyTorch, FastGaussianPyTorch, FastCutoffPowerlawPyTorch
 import astropy.units as u
 import numpy as np
 import torch 
@@ -30,7 +30,7 @@ def test_powerlaw_basic_numeric():
     np.testing.assert_allclose(result.flatten(), expected, rtol=1e-6)
 
 
-def test_powerlaw_with_astropy_units():
+def test_powerlaw_with_u():
     """Test Powerlaw when parameters and inputs are passed as Astropy Quantities."""
     model = FastPowerlawPyTorch()
     
@@ -102,6 +102,217 @@ def test_gaussian_array_input():
     # Calculate pure numpy alternative to verify values
     norm = (1.0 / np.sqrt(2 * np.pi)) / sigma
     expected = F * norm * np.exp(-((x - mu) ** 2) / (2 * sigma**2))
+
+
+# ==========================================
+# Tests for FastCutoffPowerlawPyTorch
+# ==========================================
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+ 
+def make_function(K=1.0, piv=1.0, index=-2.0, xc=10.0):
+    f = FastCutoffPowerlawPyTorch()
+    f.K = K
+    f.piv = piv
+    f.index = index
+    f.xc = xc
+    return f
+ 
+ 
+def analytic_cutoff_powerlaw(x, K, piv, index, xc):
+    return K * np.power(np.asarray(x, dtype=float) / piv, index) * np.exp(
+        -np.asarray(x, dtype=float) / xc
+    )
+ 
+ 
+# ---------------------------------------------------------------------------
+# Parameter defaults / metadata (from the docstring YAML block)
+# ---------------------------------------------------------------------------
+ 
+def test_default_parameter_values():
+    f = FastCutoffPowerlawPyTorch()
+    assert pytest.approx(f.K.value) == 1.0
+    assert pytest.approx(f.piv.value) == 1.0
+    assert pytest.approx(f.index.value) == -2.0
+    assert pytest.approx(f.xc.value) == 10.0
+ 
+ 
+def test_piv_is_fixed_by_default():
+    f = FastCutoffPowerlawPyTorch()
+    assert f.piv.free is False
+ 
+ 
+def test_K_is_normalization():
+    f = FastCutoffPowerlawPyTorch()
+    assert f.K.is_normalization is True
+ 
+ 
+def test_parameter_bounds():
+    f = FastCutoffPowerlawPyTorch()
+    assert f.K.min_value == pytest.approx(1e-30)
+    assert f.K.max_value == pytest.approx(1e3)
+    assert f.index.min_value == pytest.approx(-10)
+    assert f.index.max_value == pytest.approx(10)
+    assert f.xc.min_value == pytest.approx(1.0)
+ 
+ 
+def test_K_and_xc_use_log10_transform():
+    f = FastCutoffPowerlawPyTorch()
+    assert f.K.transformation.name == "log10"
+    assert f.xc.transformation.name == "log10"
+ 
+ 
+def test_devices_property_defaults_to_cpu():
+    f = FastCutoffPowerlawPyTorch()
+    assert f.devices.value == "cpu"
+ 
+ 
+# ---------------------------------------------------------------------------
+# _set_units
+# ---------------------------------------------------------------------------
+ 
+def test_set_units_assigns_expected_units():
+    f = FastCutoffPowerlawPyTorch()
+    x_unit = u.keV
+    y_unit = 1 / (u.keV * u.cm ** 2 * u.s)
+ 
+    f._set_units(x_unit, y_unit)
+ 
+    assert f.index.unit == u.dimensionless_unscaled
+    assert f.piv.unit == x_unit
+    assert f.xc.unit == x_unit
+    assert f.K.unit == y_unit
+ 
+ 
+# ---------------------------------------------------------------------------
+# evaluate: plain (non-Quantity) input
+# ---------------------------------------------------------------------------
+ 
+def test_evaluate_matches_analytic_formula():
+    f = make_function(K=2.0, piv=1.0, index=-2.0, xc=10.0)
+    x = np.array([1.0, 2.0, 5.0, 10.0])
+ 
+    result = f.evaluate(x, K=2.0, piv=1.0, index=-2.0, xc=10.0)
+    expected = analytic_cutoff_powerlaw(x, K=2.0, piv=1.0, index=-2.0, xc=10.0)
+ 
+    # NOTE: evaluate() currently returns shape (N, 1) due to `.view(-1, 1)`
+    assert result.shape == (len(x), 1)
+    np.testing.assert_allclose(result.ravel(), expected, rtol=1e-6)
+ 
+ 
+def test_evaluate_scalar_input():
+    f = make_function()
+    result = f.evaluate(5.0, K=1.0, piv=1.0, index=-2.0, xc=10.0)
+    expected = analytic_cutoff_powerlaw(5.0, K=1.0, piv=1.0, index=-2.0, xc=10.0)
+    np.testing.assert_allclose(np.ravel(result), np.ravel(expected), rtol=1e-6)
+ 
+ 
+def test_evaluate_returns_numpy_array():
+    f = make_function()
+    result = f.evaluate(np.array([1.0, 2.0]), K=1.0, piv=1.0, index=-2.0, xc=10.0)
+    assert isinstance(result, np.ndarray)
+ 
+ 
+def test_evaluate_no_units_applied_when_plain_input():
+    # When x is not an astropy Quantity, the result should be a bare
+    # array (unit_ == 1.0 branch), not multiplied by any astropy unit.
+    f = make_function()
+    result = f.evaluate(np.array([1.0, 2.0]), K=1.0, piv=1.0, index=-2.0, xc=10.0)
+    assert not hasattr(result, "unit")
+ 
+ 
+# ---------------------------------------------------------------------------
+# evaluate: Quantity input
+# ---------------------------------------------------------------------------
+ 
+def test_evaluate_with_quantity_input_returns_quantity():
+    f = make_function(K=1.0, piv=1.0, index=-2.0, xc=10.0)
+    f._set_units(
+        u.keV,
+        1 / (u.keV * u.cm ** 2 * u.s),
+    )
+ 
+    x = np.array([1.0, 2.0, 5.0]) * u.keV
+    result = f.evaluate(
+        x,
+        K=f.K.as_quantity,
+        piv=f.piv.as_quantity,
+        index=f.index.as_quantity,
+        xc=f.xc.as_quantity,
+    )
+ 
+    assert hasattr(result, "unit")
+    assert result.unit == f.y_unit
+ 
+ 
+def test_evaluate_quantity_matches_plain_evaluation_numerically():
+    f = make_function(K=3.0, piv=2.0, index=-1.5, xc=7.0)
+    f._set_units(
+        u.keV,
+        1 / (u.keV * u.cm ** 2 * u.s),
+    )
+ 
+    x_val = np.array([1.0, 3.0, 6.0])
+    x_q = x_val * u.keV
+ 
+    plain_result = f.evaluate(x_val, K=3.0, piv=2.0, index=-1.5, xc=7.0)
+    quantity_result = f.evaluate(
+        x_q,
+        K=f.K.as_quantity,
+        piv=f.piv.as_quantity,
+        index=f.index.as_quantity,
+        xc=f.xc.as_quantity,
+    )
+ 
+    np.testing.assert_allclose(
+        plain_result.ravel(), quantity_result.value.ravel(), rtol=1e-6
+    )
+ 
+ 
+# ---------------------------------------------------------------------------
+# Physical / shape behavior
+# ---------------------------------------------------------------------------
+ 
+def test_value_at_pivot_equals_K_times_cutoff_term():
+    f = make_function(K=5.0, piv=2.0, index=-2.0, xc=10.0)
+    result = f.evaluate(np.array([2.0]), K=5.0, piv=2.0, index=-2.0, xc=10.0)
+    expected = 5.0 * np.exp(-2.0 / 10.0)
+    np.testing.assert_allclose(result.ravel()[0], expected, rtol=1e-6)
+ 
+ 
+def test_decreasing_with_negative_index_before_cutoff_dominates():
+    # For a steep negative index and a cutoff far away, flux should
+    # decrease as x increases (power-law term dominates).
+    f = make_function(K=1.0, piv=1.0, index=-2.0, xc=1e6)
+    x = np.array([1.0, 2.0, 4.0])
+    result = f.evaluate(x, K=1.0, piv=1.0, index=-2.0, xc=1e6).ravel()
+    assert result[0] > result[1] > result[2]
+ 
+ 
+def test_cutoff_suppresses_flux_well_above_xc():
+    f = make_function(K=1.0, piv=1.0, index=0.0, xc=1.0)
+    x = np.array([0.1, 1.0, 10.0, 50.0])
+    result = f.evaluate(x, K=1.0, piv=1.0, index=0.0, xc=1.0).ravel()
+    # Well beyond the cutoff energy, flux should be strongly suppressed
+    assert result[-1] < result[0] * 1e-10
+ 
+ 
+def test_result_is_non_negative():
+    f = make_function(K=1.0, piv=1.0, index=-2.0, xc=10.0)
+    x = np.linspace(0.5, 20, 10)
+    result = f.evaluate(x, K=1.0, piv=1.0, index=-2.0, xc=10.0)
+    assert np.all(result >= 0)
+ 
+ 
+def test_output_length_matches_input_length():
+    f = make_function()
+    x = np.linspace(1, 100, 25)
+    result = f.evaluate(x, K=1.0, piv=1.0, index=-2.0, xc=10.0)
+    assert result.shape[0] == len(x)
+    
     
     np.testing.assert_allclose(result.flatten(), expected, rtol=1e-6)
     

--- a/tests/threeml/test_threeml_function_withtorch.py
+++ b/tests/threeml/test_threeml_function_withtorch.py
@@ -244,6 +244,10 @@ def test_evaluate_with_quantity_input_returns_quantity():
  
 def test_evaluate_quantity_matches_plain_evaluation_numerically():
     f = make_function(K=3.0, piv=2.0, index=-1.5, xc=7.0)
+    f.set_units(
+        u.keV,
+        1 / (u.keV * u.cm ** 2 * u.s),
+    )
     f._set_units(
         u.keV,
         1 / (u.keV * u.cm ** 2 * u.s),

--- a/tests/threeml/test_threeml_function_withtorch.py
+++ b/tests/threeml/test_threeml_function_withtorch.py
@@ -174,7 +174,7 @@ def test_set_units_assigns_expected_units():
     x_unit = u.keV
     y_unit = 1 / (u.keV * u.cm ** 2 * u.s)
  
-    f._set_units(x_unit, y_unit)
+    f.set_units(x_unit, y_unit)
  
     assert f.index.unit == u.dimensionless_unscaled
     assert f.piv.unit == x_unit

--- a/tests/threeml/test_threeml_function_withtorch.py
+++ b/tests/threeml/test_threeml_function_withtorch.py
@@ -34,12 +34,13 @@ def test_powerlaw_with_astropy_units():
     """Test Powerlaw when parameters and inputs are passed as Astropy Quantities."""
     model = FastPowerlawPyTorch()
     
-    # Manually mimic what astromodels sets up behind the scenes for units
-    model._y_unit = u.erg / (u.cm**2 * u.s * u.keV)
-    model._x_unit = u.keV
+    model.set_units(
+        u.keV,
+        1 / (u.keV * u.cm ** 2 * u.s),
+    )
     
     x = np.array([10.0, 20.0]) * u.keV
-    K = 3.0 * model._y_unit
+    K = 3.0 * model.y_unit
     piv = 10.0 * u.keV
     index = -2.0 * u.dimensionless_unscaled
     
@@ -50,7 +51,7 @@ def test_powerlaw_with_astropy_units():
     
     assert isinstance(result, u.Quantity)
     np.testing.assert_allclose(result.flatten().value, expected_values, rtol=1e-6)
-    assert result.unit == model._y_unit
+    assert result.unit == model.y_unit
 
 
 # ==========================================

--- a/tests/threeml/test_threeml_function_withtorch.py
+++ b/tests/threeml/test_threeml_function_withtorch.py
@@ -228,11 +228,7 @@ def test_evaluate_with_quantity_input_returns_quantity():
         u.keV,
         1 / (u.keV * u.cm ** 2 * u.s),
     )
-    f._set_units(
-        u.keV,
-        1 / (u.keV * u.cm ** 2 * u.s),
-    )
- 
+
     x = np.array([1.0, 2.0, 5.0]) * u.keV
     result = f.evaluate(
         x,
@@ -252,10 +248,7 @@ def test_evaluate_quantity_matches_plain_evaluation_numerically():
         u.keV,
         1 / (u.keV * u.cm ** 2 * u.s),
     )
-    f._set_units(
-        u.keV,
-        1 / (u.keV * u.cm ** 2 * u.s),
-    )
+    
  
     x_val = np.array([1.0, 3.0, 6.0])
     x_q = x_val * u.keV


### PR DESCRIPTION
Similarly to the pr #628 , this one add an exponential cutoff power law using torch. 

Much faster for evaluation, to be used for unbinned analysis. 