### PR TITLE
Add super cutoff pl torch version 

### DIFF
--- a/cosipy/threeml/ml/function_torch.py
+++ b/cosipy/threeml/ml/function_torch.py
@@ -149,11 +149,12 @@ class FastGaussianPyTorch(Function1D, metaclass=FunctionMeta):
         
         
         norm = self.__norm_const / sigma
-        x = torch.as_tensor(x, dtype=torch.float64, device=self.devices.value)
+        x_t = torch.as_tensor(x, dtype=torch.float64, device=self.devices.value)
+        x_t = x_t.view(-1, 1)
         mu = torch.as_tensor(mu, dtype=torch.float64, device=self.devices.value)
         sigma = torch.as_tensor(sigma, dtype=torch.float64, device=self.devices.value)
 
-        result = F * norm * torch.exp(-torch.pow(x - mu, 2.0) / (2 * torch.pow(sigma, 2.0)))
+        result = F * norm * torch.exp(-torch.pow(x_t - mu, 2.0) / (2 * torch.pow(sigma, 2.0)))
         
         return result.cpu().numpy()
 
@@ -335,9 +336,8 @@ class FastSuperCutoffPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
         x_t = torch.as_tensor(x_, dtype=torch.float64, device=self.devices.value)
         x_t = x_t.view(-1, 1)
         K_, piv_, index_, xc_, gamma_ = [torch.as_tensor(t, dtype=torch.float64, device=self.devices.value) for t in (K_, piv_, index_, xc_, gamma_)]
-        res = torch.div(x_t, piv_)
-        res.pow_(index_)
+        
+        res = torch.exp( index_ * torch.log(x_t / piv_) - torch.pow(x_t / xc_, gamma_) )
         res.mul_(K_)
-        res.mul_( torch.pow( torch.exp_(-x_t/xc_), gamma_ ) ) 
         
         return res.cpu().numpy() * unit_

--- a/cosipy/threeml/ml/function_torch.py
+++ b/cosipy/threeml/ml/function_torch.py
@@ -248,3 +248,96 @@ class FastCutoffPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
             return res.cpu().numpy()
         else:
             return res.cpu().numpy() * unit_
+            
+class FastSuperCutoffPowerlawPyTorch(Function1D, metaclass=FunctionMeta):
+    r"""
+    description :
+
+        A power law with a super-exponential cutoff
+
+    latex : $ K~\left(\frac{x}{piv}\right)^{index}~\exp{(-x/xc)^{\gamma}} $
+
+    parameters :
+
+        K :
+
+            desc : Normalization (differential flux at the pivot value)
+            initial value : 1.0
+            min : 1e-50
+            is_normalization : True
+            transformation : log10
+
+        piv :
+
+            desc : Pivot value
+            initial value : 1
+            fix : yes
+
+        index :
+
+            desc : Photon index
+            initial value : -2
+            min : -10
+            max : 10
+
+        xc :
+
+            desc : Cutoff energy
+            initial value : 10.0
+            min : 1.0
+            transformation : log10
+
+        gamma :
+
+            desc : Index of the super-exponential cutoff
+            initial value : 1.0
+            min : 0.1
+            max : 10.0
+    
+    properties:
+        devices:
+            desc: devices used by torch
+            initial value: cpu
+    """
+
+    def _set_units(self, x_unit, y_unit):
+        # The index is always dimensionless
+        self.index.unit = astropy_units.dimensionless_unscaled
+        self.gamma.unit = astropy_units.dimensionless_unscaled
+
+        # The pivot energy has always the same dimension as the x variable
+        self.piv.unit = x_unit
+
+        # The cutoff has the same dimensions as x
+        self.xc.unit = x_unit
+
+        # The normalization has the same units as the y
+
+        self.K.unit = y_unit
+
+    # noinspection PyPep8Naming
+    def evaluate(self, x, K, piv, index, xc, gamma):
+
+        if isinstance(x, astropy_units.Quantity):
+            index_ = index.value
+            K_ = K.value
+            piv_ = piv.value
+            xc_ = xc.value
+            gamma_ = gamma.value
+            x_ = x.value
+
+            unit_ = self.y_unit
+
+        else:
+            unit_ = 1.0
+            K_, piv_, x_, index_, xc_, gamma_ = K, piv, x, index, xc, gamma
+
+        x_t = torch.as_tensor(x_, dtype=torch.float64, device=self.devices.value)
+        x_t = x_t.view(-1, 1)
+        K_, piv_, index_, xc_, gamma_ = [torch.as_tensor(t, dtype=torch.float64, device=self.devices.value) for t in (K_, piv_, index_, xc_, gamma_)]
+        res = torch.div(x_t, piv_)
+        res.pow_(index_)
+        res.mul_(K_)
+        res.mul_( torch.pow( torch.exp_(-x_t/xc_), gamma_ ) ) 
+        
+        return res.cpu().numpy() * unit_

--- a/cosipy/threeml/ml/function_torch.py
+++ b/cosipy/threeml/ml/function_torch.py
@@ -149,12 +149,11 @@ class FastGaussianPyTorch(Function1D, metaclass=FunctionMeta):
         
         
         norm = self.__norm_const / sigma
-        x_t = torch.as_tensor(x, dtype=torch.float64, device=self.devices.value)
-        x_t = x_t.view(-1, 1)
+        x = torch.as_tensor(x, dtype=torch.float64, device=self.devices.value)
         mu = torch.as_tensor(mu, dtype=torch.float64, device=self.devices.value)
         sigma = torch.as_tensor(sigma, dtype=torch.float64, device=self.devices.value)
 
-        result = F * norm * torch.exp(-torch.pow(x_t - mu, 2.0) / (2 * torch.pow(sigma, 2.0)))
+        result = F * norm * torch.exp(-torch.pow(x - mu, 2.0) / (2 * torch.pow(sigma, 2.0)))
         
         return result.cpu().numpy()
 

--- a/tests/threeml/test_threeml_function_withtorch.py
+++ b/tests/threeml/test_threeml_function_withtorch.py
@@ -364,7 +364,7 @@ def test_parameter_bounds():
     assert f.index.max_value == pytest.approx(10)
     assert f.xc.min_value == pytest.approx(1.0)
     assert f.gamma.min_value == pytest.approx(0.1)
-    assert f.gamma.min_value == pytest.approx(10.0)
+    assert f.gamma.max_value == pytest.approx(10.0)
 
 def test_devices_property_defaults_to_cpu():
     f = FastSuperCutoffPowerlawPyTorch()

--- a/tests/threeml/test_threeml_function_withtorch.py
+++ b/tests/threeml/test_threeml_function_withtorch.py
@@ -330,10 +330,8 @@ def make_function(K=1.0, piv=1.0, index=-2.0, xc=10.0, gamma=2.0):
  
  
 def analytic_cutoff_powerlaw(x, K, piv, index, xc, gamma):
-    return K * np.power(np.asarray(x, dtype=float) / piv, index) * np.power(np.exp(
-        -np.asarray(x, dtype=float) / xc
-    ), gamma)
- 
+    return K * np.exp( index * np.log(x / piv) - np.pow(x / xc, gamma) )
+
  
 # ---------------------------------------------------------------------------
 # Parameter defaults / metadata (from the docstring YAML block)

--- a/tests/threeml/test_threeml_function_withtorch.py
+++ b/tests/threeml/test_threeml_function_withtorch.py
@@ -310,3 +310,209 @@ def test_output_length_matches_input_length():
     assert result.shape[0] == len(x)
     
         
+# ==========================================
+# Tests for FastSuperCutoffPowerlawPyTorch
+# ==========================================
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+ 
+def make_function(K=1.0, piv=1.0, index=-2.0, xc=10.0, gamma=2.0):
+    f = FastSuperCutoffPowerlawPyTorch()
+    f.K = K
+    f.piv = piv
+    f.index = index
+    f.xc = xc
+    f.gamma = gamma
+    return f
+ 
+ 
+def analytic_cutoff_powerlaw(x, K, piv, index, xc, gamma):
+    return K * np.power(np.asarray(x, dtype=float) / piv, index) * np.power(np.exp(
+        -np.asarray(x, dtype=float) / xc
+    ), gamma)
+ 
+ 
+# ---------------------------------------------------------------------------
+# Parameter defaults / metadata (from the docstring YAML block)
+# ---------------------------------------------------------------------------
+ 
+def test_default_parameter_values():
+    f = FastSuperCutoffPowerlawPyTorch()
+    assert pytest.approx(f.K.value) == 1.0
+    assert pytest.approx(f.piv.value) == 1.0
+    assert pytest.approx(f.index.value) == -2.0
+    assert pytest.approx(f.xc.value) == 10.0
+    assert pytest.approx(f.gamma.value) == 2.0
+ 
+def test_piv_is_fixed_by_default():
+    f = FastSuperCutoffPowerlawPyTorch()
+    assert f.piv.free is False
+ 
+ 
+def test_K_is_normalization():
+    f = FastSuperCutoffPowerlawPyTorch()
+    assert f.K.is_normalization is True
+ 
+ 
+def test_parameter_bounds():
+    f = FastSuperCutoffPowerlawPyTorch()
+    assert f.K.min_value == pytest.approx(1e-30)
+    assert f.K.max_value == pytest.approx(1e3)
+    assert f.index.min_value == pytest.approx(-10)
+    assert f.index.max_value == pytest.approx(10)
+    assert f.xc.min_value == pytest.approx(1.0)
+    assert f.gamma.min_value == pytest.approx(0.1)
+ 
+def test_devices_property_defaults_to_cpu():
+    f = FastSuperCutoffPowerlawPyTorch()
+    assert f.devices.value == "cpu"
+ 
+ 
+# ---------------------------------------------------------------------------
+# _set_units
+# ---------------------------------------------------------------------------
+ 
+def test_set_units_assigns_expected_units():
+    f = FastSuperCutoffPowerlawPyTorch()
+    x_unit = u.keV
+    y_unit = 1 / (u.keV * u.cm ** 2 * u.s)
+ 
+    f.set_units(x_unit, y_unit)
+ 
+    assert f.index.unit == u.dimensionless_unscaled
+    assert f.piv.unit == x_unit
+    assert f.xc.unit == x_unit
+    assert f.K.unit == y_unit
+    assert f.gamma.unit == u.dimensionless_unscaled
+ 
+# ---------------------------------------------------------------------------
+# evaluate: plain (non-Quantity) input
+# ---------------------------------------------------------------------------
+ 
+def test_evaluate_matches_analytic_formula():
+    f = make_function(K=2.0, piv=1.0, index=-2.0, xc=10.0, gamma=2.0)
+    x = np.array([1.0, 2.0, 5.0, 10.0])
+ 
+    result = f.evaluate(x, K=2.0, piv=1.0, index=-2.0, xc=10.0, gamma=2.0)
+    expected = analytic_cutoff_powerlaw(x, K=2.0, piv=1.0, index=-2.0, xc=10.0, gamma=2.0)
+ 
+    # NOTE: evaluate() currently returns shape (N, 1) due to `.view(-1, 1)`
+    assert result.shape == (len(x), 1)
+    np.testing.assert_allclose(result.ravel(), expected, rtol=1e-6)
+ 
+ 
+def test_evaluate_scalar_input():
+    f = make_function()
+    result = f.evaluate(5.0, K=1.0, piv=1.0, index=-2.0, xc=10.0, gamma=2.0)
+    expected = analytic_cutoff_powerlaw(5.0, K=1.0, piv=1.0, index=-2.0, xc=10.0, gamma=2.0)
+    np.testing.assert_allclose(np.ravel(result), np.ravel(expected), rtol=1e-6)
+ 
+ 
+def test_evaluate_returns_numpy_array():
+    f = make_function()
+    result = f.evaluate(np.array([1.0, 2.0]), K=1.0, piv=1.0, index=-2.0, xc=10.0, gamma=2.0)
+    assert isinstance(result, np.ndarray)
+ 
+ 
+def test_evaluate_no_units_applied_when_plain_input():
+    # When x is not an astropy Quantity, the result should be a bare
+    # array (unit_ == 1.0 branch), not multiplied by any astropy unit.
+    f = make_function()
+    result = f.evaluate(np.array([1.0, 2.0]), K=1.0, piv=1.0, index=-2.0, xc=10.0, gamma=2.0)
+    assert not hasattr(result, "unit")
+ 
+ 
+# ---------------------------------------------------------------------------
+# evaluate: Quantity input
+# ---------------------------------------------------------------------------
+ 
+def test_evaluate_with_quantity_input_returns_quantity():
+    f = make_function(K=1.0, piv=1.0, index=-2.0, xc=10.0, gamma=2.0)
+    f.set_units(
+        u.keV,
+        1 / (u.keV * u.cm ** 2 * u.s),
+    )
+
+    x = np.array([1.0, 2.0, 5.0]) * u.keV
+    result = f.evaluate(
+        x,
+        K=f.K.as_quantity,
+        piv=f.piv.as_quantity,
+        index=f.index.as_quantity,
+        xc=f.xc.as_quantity,
+        gamma=f.gamma.as_quantity
+    )
+ 
+    assert hasattr(result, "unit")
+    assert result.unit == f.y_unit
+ 
+ 
+def test_evaluate_quantity_matches_plain_evaluation_numerically():
+    f = make_function(K=3.0, piv=2.0, index=-1.5, xc=7.0, gamma=2.0)
+    f.set_units(
+        u.keV,
+        1 / (u.keV * u.cm ** 2 * u.s),
+    )
+    
+ 
+    x_val = np.array([1.0, 3.0, 6.0])
+    x_q = x_val * u.keV
+ 
+    plain_result = f.evaluate(x_val, K=3.0, piv=2.0, index=-1.5, xc=7.0, gamma=2.0)
+    quantity_result = f.evaluate(
+        x_q,
+        K=f.K.as_quantity,
+        piv=f.piv.as_quantity,
+        index=f.index.as_quantity,
+        xc=f.xc.as_quantity,
+        gammac=f.gamma.as_quantity
+    )
+ 
+    np.testing.assert_allclose(
+        plain_result.ravel(), quantity_result.value.ravel(), rtol=1e-6
+    )
+ 
+ 
+# ---------------------------------------------------------------------------
+# Physical / shape behavior
+# ---------------------------------------------------------------------------
+ 
+def test_value_at_pivot_equals_K_times_cutoff_term():
+    f = make_function(K=5.0, piv=2.0, index=-2.0, xc=10.0, gamma=2.0)
+    result = f.evaluate(np.array([2.0]), K=5.0, piv=2.0, index=-2.0, xc=10.0, gamma=2.0)
+    expected = 5.0 * np.power(np.exp(-2.0 / 10.0), 2.0)
+    np.testing.assert_allclose(result.ravel()[0], expected, rtol=1e-6)
+ 
+ 
+def test_decreasing_with_negative_index_before_cutoff_dominates():
+    # For a steep negative index and a cutoff far away, flux should
+    # decrease as x increases (power-law term dominates).
+    f = make_function(K=1.0, piv=1.0, index=-2.0, xc=1e6, gamma=2.0)
+    x = np.array([1.0, 2.0, 4.0])
+    result = f.evaluate(x, K=1.0, piv=1.0, index=-2.0, xc=1e6, gamma=2.0).ravel()
+    assert result[0] > result[1] > result[2]
+ 
+ 
+def test_cutoff_suppresses_flux_well_above_xc():
+    f = make_function(K=1.0, piv=1.0, index=0.0, xc=1.0, gamma=2.0)
+    x = np.array([0.1, 1.0, 10.0, 50.0])
+    result = f.evaluate(x, K=1.0, piv=1.0, index=0.0, xc=1.0, gamma=2.0).ravel()
+    # Well beyond the cutoff energy, flux should be strongly suppressed
+    assert result[-1] < result[0] * 1e-10
+ 
+ 
+def test_result_is_non_negative():
+    f = make_function(K=1.0, piv=1.0, index=-2.0, xc=10.0, gamma=2.0)
+    x = np.linspace(0.5, 20, 10)
+    result = f.evaluate(x, K=1.0, piv=1.0, index=-2.0, xc=10.0, gamma=2.0)
+    assert np.all(result >= 0)
+ 
+ 
+def test_output_length_matches_input_length():
+    f = make_function()
+    x = np.linspace(1, 100, 25)
+    result = f.evaluate(x, K=1.0, piv=1.0, index=-2.0, xc=10.0, gamma=2.0)
+    assert result.shape[0] == len(x)

--- a/tests/threeml/test_threeml_function_withtorch.py
+++ b/tests/threeml/test_threeml_function_withtorch.py
@@ -481,7 +481,7 @@ def test_evaluate_quantity_matches_plain_evaluation_numerically():
 def test_value_at_pivot_equals_K_times_cutoff_term():
     f = make_function(K=5.0, piv=2.0, index=-2.0, xc=10.0, gamma=2.0)
     result = f.evaluate(np.array([2.0]), K=5.0, piv=2.0, index=-2.0, xc=10.0, gamma=2.0)
-    expected = 5.0 * np.power(np.exp(-2.0 / 10.0), 2.0)
+    expected = analytic_cutoff_powerlaw(np.array([2.0]), K=5.0, piv=2.0, index=-2.0, xc=10.0, gamma=2.0)
     np.testing.assert_allclose(result.ravel()[0], expected, rtol=1e-6)
  
  

--- a/tests/threeml/test_threeml_function_withtorch.py
+++ b/tests/threeml/test_threeml_function_withtorch.py
@@ -345,7 +345,7 @@ def test_default_parameter_values():
     assert pytest.approx(f.piv.value) == 1.0
     assert pytest.approx(f.index.value) == -2.0
     assert pytest.approx(f.xc.value) == 10.0
-    assert pytest.approx(f.gamma.value) == 2.0
+    assert pytest.approx(f.gamma.value) == 1.0
  
 def test_piv_is_fixed_by_default():
     f = FastSuperCutoffPowerlawPyTorch()
@@ -359,13 +359,13 @@ def test_K_is_normalization():
  
 def test_parameter_bounds():
     f = FastSuperCutoffPowerlawPyTorch()
-    assert f.K.min_value == pytest.approx(1e-30)
-    assert f.K.max_value == pytest.approx(1e3)
+    assert f.K.min_value == pytest.approx(1e-50)
     assert f.index.min_value == pytest.approx(-10)
     assert f.index.max_value == pytest.approx(10)
     assert f.xc.min_value == pytest.approx(1.0)
     assert f.gamma.min_value == pytest.approx(0.1)
- 
+    assert f.gamma.min_value == pytest.approx(10.0)
+
 def test_devices_property_defaults_to_cpu():
     f = FastSuperCutoffPowerlawPyTorch()
     assert f.devices.value == "cpu"
@@ -468,7 +468,7 @@ def test_evaluate_quantity_matches_plain_evaluation_numerically():
         piv=f.piv.as_quantity,
         index=f.index.as_quantity,
         xc=f.xc.as_quantity,
-        gammac=f.gamma.as_quantity
+        gamma=f.gamma.as_quantity
     )
  
     np.testing.assert_allclose(

--- a/tests/threeml/test_threeml_function_withtorch.py
+++ b/tests/threeml/test_threeml_function_withtorch.py
@@ -4,7 +4,7 @@ import cosipy
 if not cosipy.with_ml:
     pytest.skip(reason="Optional [ml] dependencies not installed", allow_module_level=True) 
 
-from cosipy.threeml.ml.function_torch import FastPowerlawPyTorch, FastGaussianPyTorch, FastCutoffPowerlawPyTorch
+from cosipy.threeml.ml.function_torch import FastPowerlawPyTorch, FastGaussianPyTorch, FastCutoffPowerlawPyTorch, FastSuperCutoffPowerlawPyTorch
 import astropy.units as u
 import numpy as np
 import torch 


### PR DESCRIPTION
Similar to previous pull requests, this one add a version of the threeml super cutoff power law using torch for faster evaluation.  