### PR TITLE
Warning for MDP > 100%

### DIFF
--- a/cosipy/polarization_fitting/polarization_asad.py
+++ b/cosipy/polarization_fitting/polarization_asad.py
@@ -117,6 +117,10 @@ class PolarizationASAD():
                                        asads['background_scaled'],
                                        self._mu_100['mu'])
 
+        if self._mdp > 1.:
+            logger.warning("The minimum detectable polarization (MDP) exceeds 100%, " 
+                            "so it is not possible to measure the polarization.")
+
         if show_plots:
 
             self.plot_asad(asads['source'],


### PR DESCRIPTION
This adds a warning when PolarizationASAD is initialized if the MDP of the source exceeds 100%