### PR TITLE
General binned sed -- Fix typos in example notebook

### DIFF
--- a/docs/tutorials/spectral_fits/sed_model/sed_spectral_model_tutorial.ipynb
+++ b/docs/tutorials/spectral_fits/sed_model/sed_spectral_model_tutorial.ipynb
@@ -13,7 +13,7 @@
     "$$\\frac{dN}{dE} = K_i \\left(\\frac{E}{E_{\\mathrm{piv},i}}\\right)^{\\alpha},$$\n",
     "\n",
     "\n",
-    "where ($K_i$) is the fitted normalization for bin $i$, $E_{\\mathrm{piv},i}$ is the geometric-center energy of the bin, and $\\alpha$ is a fixed local power-law index shared across the bins. This approach reconstructs the spectrum bin by bin without imposing a single global spectral shape.\n",
+    "where $K_i$ is the fitted normalization for bin $i$, $E_{\\mathrm{piv},i}$ is the geometric-center energy of the bin, and $\\alpha$ is a fixed local power-law index shared across the bins. This approach reconstructs the spectrum bin by bin without imposing a single global spectral shape.\n",
     "\n",
     "The example shows how to construct the generalized `BinnedSED` model directly from the COSI response, perform the likelihood fit, identify bins whose fitted normalizations are dominated by the lower boundary at zero, refit after freezing those bins, and calculate profile-likelihood upper limits where appropriate. The resulting flux points and upper limits can then be used to construct the reconstructed true-energy SED.\n"
    ]

--- a/docs/tutorials/spectral_fits/sed_model/sed_spectral_model_tutorial.ipynb
+++ b/docs/tutorials/spectral_fits/sed_model/sed_spectral_model_tutorial.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# SED Spectral Model\n",
     "\n",
-    "This notebook demonstrates how to perform a binned spectral energy distribution (SED) fit with COSIPy. The SED is modeled with independent flux normalizations in each selected true-energy bin, allowing the spectrum to be reconstructed without assuming a global spectral shape. The example also shows how to identify poorly constrained bins, refit after freezing boundary-dominated parameters, and calculate profile-likelihood upper limits where appropriate.This notebook demonstrates how to perform a binned spectral energy distribution (SED) fit with COSIPy. The SED is modeled as a piecewise power law in true energy, with an independent differential flux normalization in each selected energy bin. Within each bin, the spectrum is defined as\n",
+    "This notebook demonstrates how to perform a binned spectral energy distribution (SED) fit with COSIPy. The SED is modeled as a piecewise power law in true energy, with an independent differential flux normalization in each selected energy bin. Within each bin, the spectrum is defined as\n",
     "\n",
     "\n",
     "$$\\frac{dN}{dE} = K_i \\left(\\frac{E}{E_{\\mathrm{piv},i}}\\right)^{\\alpha},$$\n",

--- a/docs/tutorials/spectral_fits/sed_model/sed_spectral_model_tutorial.ipynb
+++ b/docs/tutorials/spectral_fits/sed_model/sed_spectral_model_tutorial.ipynb
@@ -13,7 +13,7 @@
     "$$\\frac{dN}{dE} = K_i \\left(\\frac{E}{E_{\\mathrm{piv},i}}\\right)^{\\alpha},$$\n",
     "\n",
     "\n",
-    "where (K_i) is the fitted normalization for bin (i), (E_{\\mathrm{piv},i}) is the geometric-center energy of the bin, and (\\alpha) is a fixed local power-law index shared across the bins. This approach reconstructs the spectrum bin by bin without imposing a single global spectral shape.\n",
+    "where ($K_i$) is the fitted normalization for bin (i), (E_{\\mathrm{piv},i}) is the geometric-center energy of the bin, and (\\alpha) is a fixed local power-law index shared across the bins. This approach reconstructs the spectrum bin by bin without imposing a single global spectral shape.\n",
     "\n",
     "The example shows how to construct the generalized `BinnedSED` model directly from the COSI response, perform the likelihood fit, identify bins whose fitted normalizations are dominated by the lower boundary at zero, refit after freezing those bins, and calculate profile-likelihood upper limits where appropriate. The resulting flux points and upper limits can then be used to construct the reconstructed true-energy SED.\n"
    ]

--- a/docs/tutorials/spectral_fits/sed_model/sed_spectral_model_tutorial.ipynb
+++ b/docs/tutorials/spectral_fits/sed_model/sed_spectral_model_tutorial.ipynb
@@ -13,7 +13,7 @@
     "$$\\frac{dN}{dE} = K_i \\left(\\frac{E}{E_{\\mathrm{piv},i}}\\right)^{\\alpha},$$\n",
     "\n",
     "\n",
-    "where ($K_i$) is the fitted normalization for bin (i), (E_{\\mathrm{piv},i}) is the geometric-center energy of the bin, and (\\alpha) is a fixed local power-law index shared across the bins. This approach reconstructs the spectrum bin by bin without imposing a single global spectral shape.\n",
+    "where ($K_i$) is the fitted normalization for bin ($i$), ($E_{\\mathrm{piv},i}$) is the geometric-center energy of the bin, and ($\\alpha$) is a fixed local power-law index shared across the bins. This approach reconstructs the spectrum bin by bin without imposing a single global spectral shape.\n",
     "\n",
     "The example shows how to construct the generalized `BinnedSED` model directly from the COSI response, perform the likelihood fit, identify bins whose fitted normalizations are dominated by the lower boundary at zero, refit after freezing those bins, and calculate profile-likelihood upper limits where appropriate. The resulting flux points and upper limits can then be used to construct the reconstructed true-energy SED.\n"
    ]

--- a/docs/tutorials/spectral_fits/sed_model/sed_spectral_model_tutorial.ipynb
+++ b/docs/tutorials/spectral_fits/sed_model/sed_spectral_model_tutorial.ipynb
@@ -13,7 +13,7 @@
     "$$\\frac{dN}{dE} = K_i \\left(\\frac{E}{E_{\\mathrm{piv},i}}\\right)^{\\alpha},$$\n",
     "\n",
     "\n",
-    "where ($K_i$) is the fitted normalization for bin ($i$), ($E_{\\mathrm{piv},i}$) is the geometric-center energy of the bin, and ($\\alpha$) is a fixed local power-law index shared across the bins. This approach reconstructs the spectrum bin by bin without imposing a single global spectral shape.\n",
+    "where ($K_i$) is the fitted normalization for bin $i$, $E_{\\mathrm{piv},i}$ is the geometric-center energy of the bin, and $\\alpha$ is a fixed local power-law index shared across the bins. This approach reconstructs the spectrum bin by bin without imposing a single global spectral shape.\n",
     "\n",
     "The example shows how to construct the generalized `BinnedSED` model directly from the COSI response, perform the likelihood fit, identify bins whose fitted normalizations are dominated by the lower boundary at zero, refit after freezing those bins, and calculate profile-likelihood upper limits where appropriate. The resulting flux points and upper limits can then be used to construct the reconstructed true-energy SED.\n"
    ]


### PR DESCRIPTION
I noticed some typos in the example notebook, which I fixed. Nothing else changed. 