### PR TITLE
Remove earth_occ from get_scatt_map

### DIFF
--- a/cosipy/response/FullDetectorResponse.py
+++ b/cosipy/response/FullDetectorResponse.py
@@ -834,8 +834,7 @@ class FullDetectorResponse(HealpixBase):
         coord = hpbase.pix2skycoord(ipix)
 
         scatt_map = orientation.get_scatt_map(nside = nside_scatt_map,
-                                              target_coord = coord,
-                                              earth_occ = earth_occ)
+                                              target_coord = coord if earth_occ else None)
 
         psr = self.get_point_source_response(coord = coord,
                                              scatt_map = scatt_map)

--- a/cosipy/response/threeml_point_source_response.py
+++ b/cosipy/response/threeml_point_source_response.py
@@ -192,8 +192,7 @@ class BinnedThreeMLPointSourceResponse(BinnedThreeMLSourceResponseInterface):
                 # Inertial, e.g., galactic
 
                 scatt_map = self._sc_ori.get_scatt_map(nside=self._nside,
-                                                       target_coord=coord,
-                                                       earth_occ=True)
+                                                       target_coord=coord)
 
                 self._psr = PointSourceResponse.from_scatt_map(coord,
                                                                self._data,

--- a/cosipy/source_injector/source_injector.py
+++ b/cosipy/source_injector/source_injector.py
@@ -142,8 +142,7 @@ class SourceInjector():
             with response as response:
 
                 scatt_map = orientation.get_scatt_map(response.nside * 2,
-                                                      target_coord=coordinate,
-                                                      earth_occ=earth_occ)
+                                                      target_coord=coordinate if earth_occ else None)
 
                 psr = response.get_point_source_response(coord=coordinate,
                                                          scatt_map=scatt_map)

--- a/cosipy/spacecraftfile/spacecraft_file.py
+++ b/cosipy/spacecraftfile/spacecraft_file.py
@@ -1267,7 +1267,6 @@ class SpacecraftHistory:
     def get_scatt_map(self,
                       nside:int,
                       target_coord:Optional[SkyCoord] = None,
-                      earth_occ:Optional[bool] = True,
                       angle_nbins:Optional[int] = None) -> SpacecraftAttitudeMap:
 
         """
@@ -1278,20 +1277,17 @@ class SpacecraftHistory:
         grid that discretizes the rotvec's direction, while a multiple
         of nside defines the number of bins to discretize its angle.
 
-        If a target coordinate is provided and earth_occ is True,
-        attitudes for which the view of the target is occluded by
-        the earth are excluded.
+        If a target coordinate is provided, attitudes for which the
+        view of the target is occluded by the earth are excluded.
 
         Parameters
         ----------
         nside : int
             The nside of the scatt map.
         target_coord : astropy.coordinates.SkyCoord, optional
-            The coordinates of the target object.
-        earth_occ : bool, optional
-            Option to include Earth occultation in scatt map calculation.
-            Default is True.
-        angle_nbins : int, ptional
+            The coordinates of the target object. If not specified,
+            Earth occultation is not applied.
+        angle_nbins : int, optional
             Number of bins used for the rotvec's angle. If none
             specified, default is 8*nside
 
@@ -1305,7 +1301,7 @@ class SpacecraftHistory:
         source = target_coord
 
         # compute time that the source is visible per time bin
-        duration = self.get_source_visibility(source if earth_occ else None)
+        duration = self.get_source_visibility(source)
 
         # Convert attitudes from points to time bins.  We use the
         # attitude at the start of the bin as the representative value
@@ -1363,7 +1359,7 @@ class SpacecraftHistory:
                                  frame = self._attitude.frame)
 
         return SpacecraftAttitudeMap(binned_attitudes, duration,
-                                     source = source if earth_occ else None)
+                                     source = source)
 
     @staticmethod
     def _sparse_sum_duplicates(indices:np.ndarray,

--- a/docs/tutorials/response/DetectorResponse.ipynb
+++ b/docs/tutorials/response/DetectorResponse.ipynb
@@ -679,7 +679,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scatt_map = ori.get_scatt_map(nside = 16, earth_occ = False)"
+    "scatt_map = ori.get_scatt_map(nside = 16)"
    ]
   },
   {

--- a/docs/tutorials/response/PSR_with_Earth_occultation_example.ipynb
+++ b/docs/tutorials/response/PSR_with_Earth_occultation_example.ipynb
@@ -88,7 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scatt_map = ori.get_scatt_map(coord, nside = 16)"
+    "scatt_map = ori.get_scatt_map(nside = 16, target_coord = coord)"
    ]
   },
   {
@@ -154,7 +154,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scatt_map = ori.get_scatt_map(coord, nside = 16)"
+    "scatt_map = ori.get_scatt_map(nside = 16, target_coord = coord)"
    ]
   },
   {

--- a/tests/spacecraftfile/test_spacecraftfile.py
+++ b/tests/spacecraftfile/test_spacecraftfile.py
@@ -1,3 +1,5 @@
+from inspect import signature
+
 import numpy as np
 
 import astropy.units as u
@@ -227,8 +229,16 @@ def test_get_dwell_map():
 
 def test_get_scatt_map():
 
+    assert "earth_occ" not in signature(
+        SpacecraftHistory.get_scatt_map).parameters
+
     ori_path = test_data.path / "20280301_first_10sec.fits"
     ori = SpacecraftHistory.open(ori_path)
+
+    scatt_map = ori.get_scatt_map(nside=16)
+    assert scatt_map.source is None
+    assert np.isclose(np.sum(scatt_map.weights),
+                      ori.cumulative_livetime())
 
     # Crab
     target_coord = SkyCoord(l=184.5551, b = -05.7877,
@@ -237,14 +247,16 @@ def test_get_scatt_map():
     # With this orientation file, Crab is entirely occluded, so
     # scatt map is empty!  But the code should still work.
     scatt_map = ori.get_scatt_map(target_coord=target_coord,
-                                  nside=16, earth_occ=True)
+                                  nside=16)
+    assert scatt_map.source is target_coord
+    assert scatt_map.weights.size == 0
     ax_map = scatt_map.get_axes_map(nside=16)
 
     # This orientation file does not occlude the Crab.
     ori_path = test_data.path / "DC3-3mo-arbitrary-10s.fits"
     ori = SpacecraftHistory.open(ori_path)
     scatt_map = ori.get_scatt_map(target_coord=target_coord,
-                                  nside=16, earth_occ=True)
+                                  nside=16)
     ax_map = scatt_map.get_axes_map(nside=16)
 
     # Test caching behavior for earth occultation
@@ -252,7 +264,7 @@ def test_get_scatt_map():
     assert ori.cache_earth_occ
 
     scatt_map2 = ori.get_scatt_map(target_coord=target_coord,
-                                   nside=16, earth_occ=True)
+                                   nside=16)
     assert np.all(scatt_map2.attitudes.as_quat() == \
                   scatt_map.attitudes.as_quat()) and \
             np.all(scatt_map2.weights == scatt_map.weights)
@@ -261,7 +273,7 @@ def test_get_scatt_map():
     assert not ori.cache_earth_occ
 
     scatt_map3 = ori.get_scatt_map(target_coord=target_coord,
-                                   nside=16, earth_occ=True)
+                                   nside=16)
     assert np.all(scatt_map3.attitudes.as_quat() == \
                   scatt_map.attitudes.as_quat()) and \
             np.all(scatt_map3.weights == scatt_map.weights)


### PR DESCRIPTION
> Autonomous contribution disclosure: this pull request was prepared and submitted by OpenAI Codex operating as `LunaMeerkats`. No human pre-submission review was performed or is claimed.

Closes #326.

## Summary

- remove the redundant `earth_occ` argument from `SpacecraftHistory.get_scatt_map`
- make `target_coord` presence the sole Earth-occultation switch
- preserve higher-level `earth_occ=False` behavior by forwarding `target_coord=None`
- migrate direct Python and tutorial callers and cover both target/no-target paths

## Evidence

Before the production change, the focused regression failed because `earth_occ` remained in the public signature. On the exact committed diff:

- focused regression: 1 passed
- spacecraft module from Git-blob LF contents: 14 passed
- full suite from the same clean LF copy: 165 passed, 11 skipped, 73 warnings
- affected response/source-injector/spectral tests: 17 passed total
- all modified Python parsed; all 34 notebooks parsed as JSON
- repository call-site inventory found no remaining `get_scatt_map(..., earth_occ=...)`
- `git diff --check` passed

The ordinary Windows checkout converted two existing `.ori` fixtures to CRLF, producing two unrelated failures; both pass from Git's authoritative LF blobs. Optional ML tests were skipped. The Sphinx build was not run because `pandoc` is unavailable, so tutorial changes were validated structurally and by call-site inspection.

## Compatibility

This intentionally removes a public argument. Keyword callers must stop passing `earth_occ`; higher-level repository APIs retain their existing toggle. Existing two-positional-argument calls remain valid. A former third positional Boolean can bind to `angle_nbins`, so external positional callers must migrate as part of this API change.